### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl.java
@@ -42,25 +42,25 @@ public class BitbucketTokenCredentialsImpl extends BaseStandardCredentials
             IconSet.icons.addIcon(
                     new Icon(
                             "icon-bitbucket-credentials icon-sm",
-                            "atlassian-bitbucket-server-scm/images/16x16/credentials.png",
+                            "atlassian-bitbucket-server-integration/images/16x16/credentials.png",
                             Icon.ICON_SMALL_STYLE,
                             IconType.PLUGIN));
             IconSet.icons.addIcon(
                     new Icon(
                             "icon-bitbucket-credentials icon-md",
-                            "atlassian-bitbucket-server-scm/images/24x24/credentials.png",
+                            "atlassian-bitbucket-server-integration/images/24x24/credentials.png",
                             Icon.ICON_MEDIUM_STYLE,
                             IconType.PLUGIN));
             IconSet.icons.addIcon(
                     new Icon(
                             "icon-bitbucket-credentials icon-lg",
-                            "atlassian-bitbucket-server-scm/images/32x32/credentials.png",
+                            "atlassian-bitbucket-server-integration/images/32x32/credentials.png",
                             Icon.ICON_LARGE_STYLE,
                             IconType.PLUGIN));
             IconSet.icons.addIcon(
                     new Icon(
                             "icon-bitbucket-credentials icon-xlg",
-                            "atlassian-bitbucket-server-scm/images/48x48/credentials.png",
+                            "atlassian-bitbucket-server-integration/images/48x48/credentials.png",
                             Icon.ICON_XLARGE_STYLE,
                             IconType.PLUGIN));
         }

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl/config.groovy
@@ -3,7 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredential
 def f = namespace(lib.FormTagLib)
 
 f.entry(title: _("bitbucket.admin.token"), field: "secret") {
-    f.password(value: instance?.encryptedPassword)
+    f.password(value: instance?.secret)
 }
 
 f.entry(title: _("bitbucket.admin.token.description"), field: "description") {


### PR DESCRIPTION
Icons were broken due to the plugin being renamed but the icon reference was not.
The credentials had an invalid field that meant it broke when trying to edit. Updated the groovy file to use the correct field name