### PR TITLE
Make project build

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -85,13 +85,6 @@
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
         <module name="BitbucketWhitespaceAround">
-            <!-- removed these from default: GENERIC_START  GENERIC_END, WILDCARD_TYPE -->
-            <!-- TMP TODO remove RCURLY becauuse of annotations like
-             @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-            -->
-            <!-- Tom Davies: removed LCURLY to allow empty interfaces, e.g.
-                interface Binder extends UiBinder<Widget, ChangesetDiscussionPanel> {}
-            -->
             <property name="tokens"
                       value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
             <property name="ignoredParents" value="ANNOTATION_MEMBER_VALUE_PAIR"/>
@@ -128,17 +121,7 @@
             <property name="annotation" value="EventListener"/>
             <property name="incompatibleAnnotations" value="Transactional,PreAuthorize"/>
         </module>
-        <!-- prevents AO from creating additional indexes on unique or PK columns (which will fail under Oracle) -->
-        <module name="AllowedAnnotations">
-            <property name="annotation" value="Indexed"/>
-            <property name="incompatibleAnnotations" value="PrimaryKey,Unique"/>
-        </module>
-        <!-- PK keys are unique -->
-        <module name="AllowedAnnotations">
-            <property name="annotation" value="PrimaryKey"/>
-            <property name="incompatibleAnnotations" value="Unique"/>
-        </module>
-        <module name="XMLParserConstructionUse"/>
+
         <module name="GetClassTestContextUse"/>
         <module name="MissingDeprecated">
             <property name="skipNoJavadoc" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-osgi</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!--to mock Bitbucket Server-->
@@ -176,6 +180,7 @@
                     <encoding>UTF-8</encoding>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -266,5 +271,18 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/atlassian-bitbucket-server-integration-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin</url>
     </scm>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -298,22 +298,23 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
         Request.Builder requestBuilder = new Request.Builder().url(url);
         addCredentials(requestBuilder);
 
-        try (Response response = okHttpClient.newCall(requestBuilder.build()).execute()) {
+        try {
+            Response response = okHttpClient.newCall(requestBuilder.build()).execute();
             int responseCode = response.code();
 
-            ResponseBody body = response.body();
-            if (response.isSuccessful()) {
-                if (body == null) {
-                    log.debug("Bitbucket - No content in response");
-                    throw new NoContentException(
-                            "Remote side did not send a response body", responseCode);
+            try (ResponseBody body = response.body()) {
+                if (response.isSuccessful()) {
+                    if (body == null) {
+                        log.debug("Bitbucket - No content in response");
+                        throw new NoContentException(
+                                "Remote side did not send a response body", responseCode);
+                    }
+                    log.trace("Bitbucket - call successful");
+                    return new BitbucketResponse<>(
+                            response.headers().toMultimap(), reader.readObject(body.byteStream()));
                 }
-                log.trace("Bitbucket - call successful");
-                return new BitbucketResponse<>(
-                        response.headers().toMultimap(), reader.readObject(body.byteStream()));
+                handleError(responseCode, body == null ? null : body.string());
             }
-            handleError(responseCode, body == null ? null : body.string());
-
         } catch (ConnectException | SocketTimeoutException e) {
             log.debug("Bitbucket - Connection failed", e);
             throw new ConnectionFailureException(e);


### PR DESCRIPTION
Fix resource leak where responses were not closed properly.
Fix checkstyle to be buildable using only publicly available dependencies, as well as tidy up ruleset a bit.
Add exclusion for an OSGi package that is not available under java 11, that we do not use anyway.