### PR TITLE
Move BitbucketRepositorySearchClient to use Bitbucket project filter endpoint

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -34,10 +34,10 @@ public interface BitbucketClientFactory {
     /**
      * Return a repository search client
      *
-     * @param projectKey The project key to scope the repository search
+     * @param projectName The project key to scope the repository search
      * @return a client that it ready to use
      */
-    BitbucketRepositorySearchClient getRepositorySearchClient(String projectKey);
+    BitbucketRepositorySearchClient getRepositorySearchClient(String projectName);
 
     /**
      * Return a client that can return the username for the credentials used.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -34,7 +34,7 @@ public interface BitbucketClientFactory {
     /**
      * Return a repository search client
      *
-     * @param projectName The project key to scope the repository search
+     * @param projectName The project name to scope the repository search
      * @return a client that it ready to use
      */
     BitbucketRepositorySearchClient getRepositorySearchClient(String projectName);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -122,13 +122,13 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     }
 
     @Override
-    public BitbucketRepositorySearchClient getRepositorySearchClient(String projectKey) {
-        requireNonNull(projectKey, "projectKey");
+    public BitbucketRepositorySearchClient getRepositorySearchClient(String projectName) {
+        requireNonNull(projectName, "projectName");
         return new BitbucketRepositorySearchClient() {
 
             @Override
             public BitbucketPage<BitbucketRepository> get(String filter) {
-                return get(singletonMap("filter", filter));
+                return get(singletonMap("name", filter));
             }
 
             @Override
@@ -140,11 +140,10 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
                 HttpUrl.Builder urlBuilder = baseUrl.newBuilder();
                 urlBuilder
                         .addPathSegment("rest")
-                        .addPathSegment("search")
+                        .addPathSegment("api")
                         .addPathSegment("1.0")
-                        .addPathSegment("projects")
-                        .addPathSegment(projectKey)
-                        .addPathSegment("repos");
+                        .addPathSegment("repos")
+                        .addQueryParameter("projectname", projectName);
                 queryParams.forEach(urlBuilder::addQueryParameter);
                 return makeGetRequest(
                         urlBuilder.build(),

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpoint.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpoint.java
@@ -34,7 +34,7 @@ import static org.kohsuke.stapler.HttpResponses.error;
 @Extension
 public class BitbucketSearchEndpoint implements RootAction {
 
-    public static final String BITBUCKET_SERVER_SEARCH_URL = "bitbucket-server-search";
+    static final String BITBUCKET_SERVER_SEARCH_URL = "bitbucket-server-search";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BitbucketSearchEndpoint.class);
 
@@ -66,16 +66,16 @@ public class BitbucketSearchEndpoint implements RootAction {
     public HttpResponse doFindRepositories(
             @Nullable @QueryParameter("serverId") String serverId,
             @Nullable @QueryParameter("credentialsId") String credentialsId,
-            @Nullable @QueryParameter("projectKey") String projectKey,
+            @Nullable @QueryParameter("projectName") String projectName,
             @Nullable @QueryParameter("filter") String filter) {
         Jenkins.get().checkPermission(CONFIGURE);
-        if (StringUtils.isBlank(projectKey)) {
-            throw error(HTTP_BAD_REQUEST, "The projectKey must be present");
+        if (StringUtils.isBlank(projectName)) {
+            throw error(HTTP_BAD_REQUEST, "The projectName must be present");
         }
         BitbucketRepositorySearchClient searchClient =
                 bitbucketClientFactoryProvider
                         .getClient(getServer(serverId), getCredentials(credentialsId))
-                        .getRepositorySearchClient(projectKey);
+                        .getRepositorySearchClient(projectName);
         try {
             BitbucketPage<BitbucketRepository> repositories =
                     searchClient.get(StringUtils.stripToEmpty(filter));

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointIT.java
@@ -207,9 +207,10 @@ public class BitbucketSearchEndpointIT {
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
-        assertThat(repo.getCloneUrls().get(0).getName(), equalTo("http"));
-        assertThat(repo.getCloneUrls().get(0).getHref(),
-                equalTo(bitbucketJenkinsRule.getBitbucketServer().getBaseUrl() + "/scm/project_1/rep_1.git"));
+        BitbucketNamedLink httpCloneUrl = repo.getCloneUrls().stream().filter(url -> "http".equals(url.getName()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("There should be an http clone url"));
+        assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
         BitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
@@ -290,12 +291,10 @@ public class BitbucketSearchEndpointIT {
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
-        assertThat(repo.getCloneUrls().get(0).getName(), equalTo("http"));
-        assertThat(
-                repo.getCloneUrls().get(0).getHref(),
-                equalTo(
-                        bitbucketJenkinsRule.getBitbucketServer().getBaseUrl()
-                        + "/scm/project_1/rep_1.git"));
+        BitbucketNamedLink httpCloneUrl = repo.getCloneUrls().stream().filter(url -> "http".equals(url.getName()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("There should be an http clone url"));
+        assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
         BitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
@@ -341,12 +340,10 @@ public class BitbucketSearchEndpointIT {
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
-        assertThat(repo.getCloneUrls().get(0).getName(), equalTo("http"));
-        assertThat(
-                repo.getCloneUrls().get(0).getHref(),
-                equalTo(
-                        bitbucketJenkinsRule.getBitbucketServer().getBaseUrl()
-                        + "/scm/project_1/rep_1.git"));
+        BitbucketNamedLink httpCloneUrl = repo.getCloneUrls().stream().filter(url -> "http".equals(url.getName()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("There should be an http clone url"));
+        assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
         BitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
@@ -391,12 +388,10 @@ public class BitbucketSearchEndpointIT {
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
-        assertThat(repo.getCloneUrls().get(0).getName(), equalTo("http"));
-        assertThat(
-                repo.getCloneUrls().get(0).getHref(),
-                equalTo(
-                        bitbucketJenkinsRule.getBitbucketServer().getBaseUrl()
-                        + "/scm/project_1/rep_1.git"));
+        BitbucketNamedLink httpCloneUrl = repo.getCloneUrls().stream().filter(url -> "http".equals(url.getName()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("There should be an http clone url"));
+        assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
         BitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
@@ -59,12 +59,12 @@ public class BitbucketSCMIT {
                 new BitbucketSCM(
                         "",
                         ImmutableList.of(new BranchSpec(branchSpec)),
-                        bbJenkinsRule.getCredentialsId(),
+                        bbJenkinsRule.getBitbucketServer().getAdminCredentialsId(),
                         emptyList(),
                         "",
                         PROJECT_KEY,
                         REPO_SLUG,
-                        bbJenkinsRule.getServerId());
+                        bbJenkinsRule.getBitbucketServer().getId());
         bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider());
         bitbucketSCM.createGitSCM();
         return bitbucketSCM;

--- a/src/test/resources/repo-filter-response.json
+++ b/src/test/resources/repo-filter-response.json
@@ -5,7 +5,7 @@
   "values": [
     {
       "slug": "rep_1",
-      "id": 402,
+      "id": 1,
       "name": "rep_1",
       "scmId": "git",
       "state": "AVAILABLE",
@@ -13,12 +13,11 @@
       "forkable": true,
       "project": {
         "key": "PROJECT_1",
-        "id": 382,
-        "name": "PROJECT_1",
+        "id": 1,
+        "name": "Project 1",
         "description": "PROJECT_1",
         "public": false,
         "type": "NORMAL",
-        "avatarUrl": "/bitbucket/projects/PROJECT_1/avatar.png?s=48&v=1562569947918",
         "links": {
           "self": [
             {
@@ -27,7 +26,7 @@
           ]
         }
       },
-      "public": true,
+      "public": false,
       "links": {
         "clone": [
           {


### PR DESCRIPTION
Move BitbucketRepositorySearchClient to use `<bitbucket-url>/rest/api/1.0/repos?projectName=<projectName>&name=<query>` because the other endpoint does not return the clone URL in older Bitbucket versions.
Also removes @Ignore from BitbucketSearchEndpointIT and ensures they all pass