### PR TITLE
Support for fetching supported webhook event type

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -35,6 +35,7 @@ public interface BitbucketClientFactory {
      * Return a repository search client
      *
      * @param projectKey The project key to scope the repository search
+     *
      * @return a client that it ready to use
      */
     BitbucketRepositorySearchClient getRepositorySearchClient(String projectKey);
@@ -48,6 +49,7 @@ public interface BitbucketClientFactory {
 
     /**
      * Returns a client that can return the supported web hook events
+     *
      * @return a client that can fetch supported event type.
      */
     BitbucketWebhookSupportedEventsClient getWebhookCapabilities();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -45,4 +45,10 @@ public interface BitbucketClientFactory {
      * @return a client that is ready to use
      */
     BitbucketUsernameClient getUsernameClient();
+
+    /**
+     * Returns a client that can return the supported web hook events
+     * @return a client that can fetch supported event type.
+     */
+    BitbucketWebhookSupportedEventsClient getWebhookCapabilities();
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -39,8 +39,8 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     private static final Logger log = Logger.getLogger(BitbucketClientFactoryImpl.class);
     private final HttpUrl baseUrl;
     private final Credentials credentials;
-    private final ObjectMapper objectMapper;
     private final Call.Factory httpCallFactory;
+    private final ObjectMapper objectMapper;
 
     BitbucketClientFactoryImpl(
             String serverUrl,
@@ -180,7 +180,15 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
         return () -> {
             AtlassianServerCapabilities capabilities = getCapabilityClient().get();
             String urlStr = capabilities.getCapabilities().get(WEBHOOK_CAPABILITY_KEY);
+            if(urlStr == null) {
+                throw new WebhookNotSupportedException("Remote Bitbucket Server does not support Web hooks. Make sure " +
+                                                       "Bitbucket server supports web hooks or correct version of it is installed.");
+            }
             HttpUrl url = parse(urlStr);
+            if(url == null) {
+                throw new IllegalStateException(
+                        "URL to fetch supported web hook supported event is wrong. URL: " + urlStr);
+            }
             return makeGetRequest(url, BitbucketWebhookSupportedEvents.class).getBody();
         };
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketWebhookSupportedEventsClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketWebhookSupportedEventsClient.java
@@ -1,0 +1,5 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
+
+public interface BitbucketWebhookSupportedEventsClient extends BitbucketClient<BitbucketWebhookSupportedEvents> {}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/exception/WebhookNotSupportedException.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/exception/WebhookNotSupportedException.java
@@ -1,0 +1,8 @@
+package com.atlassian.bitbucket.jenkins.internal.client.exception;
+
+public class WebhookNotSupportedException extends RuntimeException {
+
+    public WebhookNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
@@ -1,8 +1,12 @@
 package com.atlassian.bitbucket.jenkins.internal.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Capabilities as advertised by Atlassian products.
@@ -10,7 +14,17 @@ import javax.annotation.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AtlassianServerCapabilities {
 
-    private String application;
+    public static final String WEBHOOK_CAPABILITY_KEY = "webhooks";
+
+    private final String application;
+    private final Map<String, String> capabilities;
+
+    @JsonCreator
+    public AtlassianServerCapabilities(@JsonProperty(value = "application") String application,
+                                       @JsonProperty(value = "capabilities") Map<String, String> capabilities) {
+        this.application = application;
+        this.capabilities = capabilities;
+    }
 
     /**
      * Return the application type as provided by the remote side.
@@ -28,5 +42,9 @@ public class AtlassianServerCapabilities {
      */
     public boolean isBitbucketServer() {
         return "stash".equals(application);
+    }
+
+    public Map<String, String> getCapabilities() {
+        return capabilities;
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -23,7 +23,7 @@ public class AtlassianServerCapabilities {
     public AtlassianServerCapabilities(@JsonProperty(value = "application") String application,
                                        @JsonProperty(value = "capabilities") Map<String, String> capabilities) {
         this.application = application;
-        this.capabilities = capabilities;
+        this.capabilities = Collections.unmodifiableMap(capabilities);
     }
 
     /**

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketWebhookSupportedEvents.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketWebhookSupportedEvents.java
@@ -6,14 +6,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketWebhookSupportedEvents {
 
-    private Set<String> applicationWebHooks;
+    private final Set<String> applicationWebHooks;
 
     @JsonCreator
     public BitbucketWebhookSupportedEvents(@JsonProperty(value = "application-webhooks") Set<String> applicationWebHooks) {
-        this.applicationWebHooks = applicationWebHooks;
+        this.applicationWebHooks = requireNonNull(applicationWebHooks, "Application hooks events unavailable");
     }
 
     public Set<String> getApplicationWebHooks() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketWebhookSupportedEvents.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketWebhookSupportedEvents.java
@@ -1,0 +1,22 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketWebhookSupportedEvents {
+
+    private Set<String> applicationWebHooks;
+
+    @JsonCreator
+    public BitbucketWebhookSupportedEvents(@JsonProperty(value = "application-webhooks") Set<String> applicationWebHooks) {
+        this.applicationWebHooks = applicationWebHooks;
+    }
+
+    public Set<String> getApplicationWebHooks() {
+        return applicationWebHooks;
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
@@ -12,11 +12,10 @@ import okhttp3.*;
 import okio.BufferedSource;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.annotation.Nullable;
@@ -25,13 +24,20 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import static com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookEndpoint.REFS_CHANGED_EVENT;
 import static java.net.HttpURLConnection.*;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static okhttp3.HttpUrl.parse;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -40,13 +46,9 @@ import static org.mockito.Mockito.*;
 public class BitbucketClientFactoryImplTest {
 
     private static final String BASE_URL = "http://localhost:7990/bitbucket";
+
     private BitbucketClientFactoryImpl anonymousClientFactory;
-    @Mock
-    private ResponseBody mockBody;
-    @Mock
-    private Call mockCall;
-    @Mock
-    private OkHttpClient mockClient;
+    private MockRemoteHttpServer mockRemoteHttpServer = new MockRemoteHttpServer();
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
@@ -54,89 +56,79 @@ public class BitbucketClientFactoryImplTest {
         anonymousClientFactory = getClientFactory(BASE_URL, null);
     }
 
+    @After
+    public void teardown() {
+        mockRemoteHttpServer.ensureResponseBodyClosed();
+    }
+
     @Test
-    public void testAccessTokenAuthCall() throws IOException {
+    public void testAccessTokenAuthCall() {
         Secret secret = SecretFactory.getSecret("MDU2NzY4Nzc0Njk5OgYPksHP4qAul5j5bCPoINDWmYio");
         StringCredentials cred = mock(StringCredentials.class);
         when(cred.getSecret()).thenReturn(secret);
 
         AtlassianServerCapabilities response =
                 makeCall(
+                        BASE_URL,
                         cred,
                         HTTP_OK,
                         readCapabilitiesResponseFromFile(),
                         AtlassianServerCapabilities.class);
-        ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
-        verify(mockClient).newCall(request.capture());
         assertTrue("Expected Bitbucket server", response.isBitbucketServer());
-        String authHeader = request.getValue().header("Authorization");
+        String authHeader = mockRemoteHttpServer.getCapturedRequest(BASE_URL).header("Authorization");
         assertNotNull(
                 "Should have added Authorization headers when credentials are provided",
                 authHeader);
         assertEquals(String.format("Bearer %s", secret.getPlainText()), authHeader);
-        verify(mockBody).close();
     }
 
     @Test
-    public void testAdminCall() throws IOException {
+    public void testAdminCall() {
         Secret secret = SecretFactory.getSecret("adminUtiSecretoMaiestatisSignum");
         BitbucketTokenCredentials admin = mock(BitbucketTokenCredentials.class);
         when(admin.getSecret()).thenReturn(secret);
 
         AtlassianServerCapabilities response =
                 makeCall(
+                        BASE_URL,
                         admin,
                         HTTP_OK,
                         readCapabilitiesResponseFromFile(),
                         AtlassianServerCapabilities.class);
-        ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
-        verify(mockClient).newCall(request.capture());
         assertTrue("Expected Bitbucket server", response.isBitbucketServer());
-        String authHeader = request.getValue().header("Authorization");
+        String authHeader = mockRemoteHttpServer.getCapturedRequest(BASE_URL).header("Authorization");
         assertNotNull(
                 "Should have added Authorization headers when credentials are provided",
                 authHeader);
         assertEquals("Bearer adminUtiSecretoMaiestatisSignum", authHeader);
-        verify(mockBody).close();
     }
 
     @Test
-    public void testAnonymousCall() throws IOException {
+    public void testAnonymousCall() {
         AtlassianServerCapabilities response =
                 makeCall(
                         null,
                         HTTP_OK,
                         readCapabilitiesResponseFromFile(),
                         AtlassianServerCapabilities.class);
-        ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
-        verify(mockClient).newCall(request.capture());
         assertTrue("Expected Bitbucket server", response.isBitbucketServer());
         assertNull(
                 "Should not have added any headers for anonymous call",
-                request.getValue().header("Authorization"));
-        verify(mockBody).close();
+                mockRemoteHttpServer.getCapturedRequest(BASE_URL).header("Authorization"));
     }
 
     @Test(expected = ServerErrorException.class)
-    public void testBadGateway() throws IOException {
-        try {
-            makeCall(HTTP_BAD_GATEWAY);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testBadGateway() {
+        makeCall(HTTP_BAD_GATEWAY);
     }
 
     @Test(expected = BadRequestException.class)
-    public void testBadRequest() throws IOException {
-        try {
-            makeCall(HTTP_BAD_REQUEST);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testBadRequest() {
+        makeCall(HTTP_BAD_REQUEST);
     }
 
     @Test
-    public void testBasicAuthCall() throws IOException {
+    public void testBasicAuthCall() {
         Secret secret = SecretFactory.getSecret("password");
         String username = "username";
 
@@ -146,44 +138,51 @@ public class BitbucketClientFactoryImplTest {
 
         AtlassianServerCapabilities response =
                 makeCall(
+                        BASE_URL,
                         cred,
                         HTTP_OK,
                         readCapabilitiesResponseFromFile(),
                         AtlassianServerCapabilities.class);
-        ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
-        verify(mockClient).newCall(request.capture());
         assertTrue("Expected Bitbucket server", response.isBitbucketServer());
-        String authHeader = request.getValue().header("Authorization");
+        String authHeader = mockRemoteHttpServer.getCapturedRequest(BASE_URL).header("Authorization");
         assertNotNull(
                 "Should have added Authorization headers when credentials are provided",
                 authHeader);
         assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", authHeader);
-        verify(mockBody).close();
     }
 
     @Test(expected = AuthorizationException.class)
-    public void testForbidden() throws IOException {
-        try {
-            makeCall(HTTP_FORBIDDEN);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testForbidden() {
+        makeCall(HTTP_FORBIDDEN);
     }
 
     @Test
-    public void testGetCapabilties() throws IOException {
-        mockBasicResponseWithBody(
-                BASE_URL + "/rest/capabilities", 200, readCapabilitiesResponseFromFile());
+    public void testGetCapabilties() {
+        mockRemoteHttpServer.mapUrlToResult(
+                BASE_URL + "/rest/capabilities",readCapabilitiesResponseFromFile());
         AtlassianServerCapabilities response = anonymousClientFactory.getCapabilityClient().get();
         assertTrue(response.isBitbucketServer());
         assertEquals("stash", response.getApplication());
+        assertThat(response.getCapabilities(), hasKey("webhooks"));
     }
 
     @Test
-    public void testGetFullRepository() throws IOException {
-        mockBasicResponseWithBody(
+    public void testGetWebHookCapabilities() {
+        mockRemoteHttpServer.mapUrlToResult(
+                BASE_URL + "/rest/webhooks/latest/capabilities", readWebhookCapabilitiesResponseFromFile());
+        mockRemoteHttpServer.mapUrlToResult(
+                BASE_URL + "/rest/capabilities", readCapabilitiesResponseFromFile());
+
+        BitbucketWebhookSupportedEvents hookSupportedEvents =
+                anonymousClientFactory.getWebhookCapabilities().get();
+        assertThat(hookSupportedEvents.getApplicationWebHooks(), hasItem(REFS_CHANGED_EVENT));
+
+    }
+
+    @Test
+    public void testGetFullRepository() {
+        mockRemoteHttpServer.mapUrlToResult(
                 BASE_URL + "/rest/api/1.0/projects/QA/repos/qa-resources",
-                200,
                 readFullRepositoryFromFile());
 
         BitbucketRepository repository =
@@ -215,10 +214,9 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetNoSShRepository() throws IOException {
-        mockBasicResponseWithBody(
+    public void testGetNoSShRepository() {
+        mockRemoteHttpServer.mapUrlToResult(
                 BASE_URL + "/rest/api/1.0/projects/QA/repos/qa-resources",
-                200,
                 readNoSshRepositoryFromFile());
 
         BitbucketRepository repository =
@@ -248,20 +246,20 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetProject() throws IOException {
-        mockBasicResponseWithBody(
-                BASE_URL + "/rest/api/1.0/projects/QA", 200, readProjectFromFile());
+    public void testGetProject() {
+        mockRemoteHttpServer.mapUrlToResult(
+                BASE_URL + "/rest/api/1.0/projects/QA", readProjectFromFile());
         BitbucketProject project = anonymousClientFactory.getProjectClient("QA").get();
 
         assertEquals("QA", project.getKey());
     }
 
     @Test
-    public void testGetProjectPage() throws IOException {
+    public void testGetProjectPage() {
         String url = BASE_URL + "/rest/api/1.0/projects";
 
         String projectPage = readFileToString("/project-page-all-response.json");
-        mockBasicResponseWithBody(url, 200, projectPage);
+        mockRemoteHttpServer.mapUrlToResult(url, projectPage);
 
         BitbucketPage<BitbucketProject> projects =
                 anonymousClientFactory.getProjectSearchClient().get();
@@ -273,11 +271,11 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetProjectPageFiltered() throws IOException {
+    public void testGetProjectPageFiltered() {
         String url = BASE_URL + "/rest/api/1.0/projects?name=myFilter";
 
         String projectPage = readFileToString("/project-page-filtered-response.json");
-        mockBasicResponseWithBody(url, 200, projectPage);
+        mockRemoteHttpServer.mapUrlToResult(url, projectPage);
 
         BitbucketPage<BitbucketProject> projects =
                 anonymousClientFactory.getProjectSearchClient().get("myFilter");
@@ -290,11 +288,11 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetRepoPage() throws IOException {
+    public void testGetRepoPage() {
         String url = BASE_URL + "/rest/search/1.0/projects/PROJ/repos";
 
         String projectPage = readFileToString("/repo-filter-response.json");
-        mockBasicResponseWithBody(url, 200, projectPage);
+        mockRemoteHttpServer.mapUrlToResult(url, projectPage);
 
         BitbucketPage<BitbucketRepository> repositories =
                 anonymousClientFactory.getRepositorySearchClient("PROJ").get();
@@ -306,11 +304,11 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetRepoPageFiltered() throws IOException {
+    public void testGetRepoPageFiltered() {
         String url = BASE_URL + "/rest/search/1.0/projects/PROJ/repos?filter=rep";
 
         String projectPage = readFileToString("/repo-filter-response.json");
-        mockBasicResponseWithBody(url, 200, projectPage);
+        mockRemoteHttpServer.mapUrlToResult(url, projectPage);
 
         BitbucketPage<BitbucketRepository> repositories =
                 anonymousClientFactory.getRepositorySearchClient("PROJ").get("rep");
@@ -323,12 +321,10 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test
-    public void testGetUsername() throws IOException {
+    public void testGetUsername() {
         String url = BASE_URL + "/rest/capabilities";
         String username = "CoolBananas";
-        mockBasicResponseWithBody(
-                url,
-                200,
+        mockRemoteHttpServer.mapUrlToResultWithHeaders(url,
                 readCapabilitiesResponseFromFile(),
                 singletonMap("X-AUSERNAME", username));
 
@@ -336,90 +332,62 @@ public class BitbucketClientFactoryImplTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void testMethodNotAllowed() throws IOException {
-        try {
-            makeCall(HTTP_BAD_METHOD);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testMethodNotAllowed() {
+        makeCall(HTTP_BAD_METHOD);
     }
 
     @Test(expected = NoContentException.class)
-    public void testNoBody() throws IOException {
+    public void testNoBody() {
         // test that all the handling logic does not fail if there is no body available, this just
         // checks that no exceptions are thrown.
-        Response response =
-                new Response.Builder()
-                        .code(HTTP_OK)
-                        .request(new Request.Builder().url(BASE_URL).build())
-                        .protocol(Protocol.HTTP_1_1)
-                        .message("Hello handsome!")
-                        .build();
-        when(mockClient.newCall(any())).thenReturn(mockCall);
-        when(mockCall.execute()).thenReturn(response);
+        mockRemoteHttpServer.mapUrlToResult(BASE_URL, null);
 
-        anonymousClientFactory.makeGetRequest(HttpUrl.parse(BASE_URL), String.class);
+        anonymousClientFactory.makeGetRequest(parse(BASE_URL), String.class);
     }
 
     @Test(expected = AuthorizationException.class)
-    public void testNotAuthorized() throws IOException {
-        try {
-            makeCall(HTTP_UNAUTHORIZED);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testNotAuthorized() {
+        makeCall(HTTP_UNAUTHORIZED);
     }
 
     @Test(expected = NotFoundException.class)
-    public void testNotFound() throws IOException {
-        try {
-            makeCall(HTTP_NOT_FOUND);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testNotFound() {
+        makeCall(HTTP_NOT_FOUND);
     }
 
     @Test(expected = UnhandledErrorException.class)
-    public void testRedirect() throws IOException {
+    public void testRedirect() {
         // by default the client will follow re-directs, this test just makes sure that if that is
         // disabled the client will throw an exception
-        try {
-            makeCall(HTTP_MOVED_PERM);
-        } finally {
-            verify(mockBody).close();
-        }
+        makeCall(HTTP_MOVED_PERM);
     }
 
     @Test(expected = ServerErrorException.class)
-    public void testServerError() throws IOException {
-        try {
-            makeCall(HTTP_INTERNAL_ERROR);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testServerError() {
+        makeCall(HTTP_INTERNAL_ERROR);
     }
 
     @Test(expected = ConnectionFailureException.class)
-    public void testThrowsConnectException() throws IOException {
+    public void testThrowsConnectException() {
         ConnectException exception = new ConnectException();
         makeCallThatThrows(exception);
     }
 
     @Test(expected = BitbucketClientException.class)
-    public void testThrowsIoException() throws IOException {
+    public void testThrowsIoException() {
         IOException exception = new IOException();
 
         makeCallThatThrows(exception);
     }
 
     @Test(expected = ConnectionFailureException.class)
-    public void testThrowsSocketException() throws IOException {
+    public void testThrowsSocketException() {
         SocketTimeoutException exception = new SocketTimeoutException();
         makeCallThatThrows(exception);
     }
 
     @Test
-    public void testTokenCall() throws IOException {
+    public void testTokenCall() {
         Secret secret = SecretFactory.getSecret("adminUtiSecretoMaiestatisSignumLepus");
 
         StringCredentials cred = mock(StringCredentials.class);
@@ -427,49 +395,33 @@ public class BitbucketClientFactoryImplTest {
 
         AtlassianServerCapabilities response =
                 makeCall(
+                        BASE_URL,
                         cred,
                         HTTP_OK,
                         readCapabilitiesResponseFromFile(),
                         AtlassianServerCapabilities.class);
-        ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
-        verify(mockClient).newCall(request.capture());
         assertTrue("Expected Bitbucket server", response.isBitbucketServer());
-        String authHeader = request.getValue().header("Authorization");
+        String authHeader = mockRemoteHttpServer.getCapturedRequest(BASE_URL).header("Authorization");
         assertNotNull(
                 "Should have added Authorization headers when credentials are provided",
                 authHeader);
         assertEquals("Bearer adminUtiSecretoMaiestatisSignumLepus", authHeader);
-        verify(mockBody).close();
     }
 
     @Test(expected = ServerErrorException.class)
-    public void testUnavailable() throws IOException {
-        try {
-            makeCall(HTTP_UNAVAILABLE);
-        } finally {
-            verify(mockBody).close();
-        }
+    public void testUnavailable() {
+        makeCall(HTTP_UNAVAILABLE);
     }
 
     private BitbucketClientFactoryImpl getClientFactory(
             String url, @Nullable Credentials credentials) {
-        return new BitbucketClientFactoryImpl(url, credentials, objectMapper, mockClient);
-    }
-
-    private Response getResponse(String url, int responseCode, Map<String, String> headers) {
-        return new Response.Builder()
-                .code(responseCode)
-                .request(new Request.Builder().url(url).build())
-                .protocol(Protocol.HTTP_1_1)
-                .message("Hello handsome!")
-                .body(mockBody)
-                .headers(Headers.of(headers))
-                .build();
+        return new BitbucketClientFactoryImpl(url, credentials, objectMapper, mockRemoteHttpServer);
     }
 
     private AtlassianServerCapabilities makeCall(int responseCode)
-            throws BitbucketClientException, IOException {
+            throws BitbucketClientException {
         return makeCall(
+                BASE_URL,
                 null,
                 responseCode,
                 readCapabilitiesResponseFromFile(),
@@ -477,7 +429,7 @@ public class BitbucketClientFactoryImplTest {
     }
 
     private <T> T makeCall(Credentials credentials, int responseCode, String body, Class<T> type)
-            throws BitbucketClientException, IOException {
+            throws BitbucketClientException {
         return makeCall(BASE_URL, credentials, responseCode, body, type);
     }
 
@@ -487,39 +439,19 @@ public class BitbucketClientFactoryImplTest {
             int responseCode,
             String body,
             Class<T> type)
-            throws BitbucketClientException, IOException {
-        mockBasicResponseWithBody(url, responseCode, body);
+            throws BitbucketClientException {
+        mockRemoteHttpServer.mapUrlToResultWithResponseCode(url, responseCode, body);
         BitbucketClientFactoryImpl df = getClientFactory(url, credentials);
 
-        return df.makeGetRequest(HttpUrl.parse(url), type).getBody();
+        return df.makeGetRequest(parse(url), type).getBody();
     }
 
-    private AtlassianServerCapabilities makeCallThatThrows(Exception exception) throws IOException {
+    private AtlassianServerCapabilities makeCallThatThrows(Exception exception) {
         String url = "http://localhost:7990/bitbucket";
-        when(mockClient.newCall(any())).thenReturn(mockCall);
-        when(mockCall.execute()).thenThrow(exception);
+        mockRemoteHttpServer.mapUrlToException(url, exception);
         return getClientFactory(url, null)
-                .makeGetRequest(HttpUrl.parse(url), AtlassianServerCapabilities.class)
+                .makeGetRequest(parse(url), AtlassianServerCapabilities.class)
                 .getBody();
-    }
-
-    private void mockBasicResponseWithBody(String url, int responseCode, String body)
-            throws IOException {
-        mockBasicResponseWithBody(url, responseCode, body, Collections.emptyMap());
-    }
-
-    private void mockBasicResponseWithBody(
-            String url, int responseCode, String body, Map<String, String> headers)
-            throws IOException {
-        when(mockClient.newCall(
-                argThat(argument -> url.equalsIgnoreCase(argument.url().url().toString()))))
-                .thenReturn(mockCall);
-        when(mockCall.execute()).thenReturn(getResponse(url, responseCode, headers));
-        BufferedSource bufferedSource = mock(BufferedSource.class);
-        when(mockBody.source()).thenReturn(bufferedSource);
-        when(bufferedSource.readString(any())).thenReturn(body);
-        when(bufferedSource.select(any())).thenReturn(0);
-        when(mockBody.byteStream()).thenReturn(new StringInputStream(body));
     }
 
     private String readCapabilitiesResponseFromFile() {
@@ -546,4 +478,111 @@ public class BitbucketClientFactoryImplTest {
     private String readProjectFromFile() {
         return readFileToString("/project-response.json");
     }
+
+    private String readWebhookCapabilitiesResponseFromFile() {
+        return readFileToString("/webhook-capabilities-response.json");
+    }
+
+    private class MockRemoteHttpServer implements Call.Factory {
+
+        private final Map<String, Map<String, String>> headers = new HashMap<>();
+        private final Map<String, Exception> urlToException = new HashMap<>();
+        private final Map<String, String> urlToResult = new HashMap<>();
+        private final Map<String, Integer> urlToReturnCode = new HashMap<>();
+        private final Map<String, ResponseBody> urlToResponseBody = new HashMap<>();
+        private final Map<String, Request> urlToRequest = new HashMap<>();
+
+        @Override
+        public Call newCall(Request request) {
+            String url = request.url().url().toString();
+            if (urlToException.containsKey(url)) {
+                return mockCallToThrowException(url);
+            } else {
+                String result = urlToResult.get(url);
+                ResponseBody body = mockResponseBody(result);
+                urlToResponseBody.put(url, body);
+                urlToRequest.put(url, request);
+                return mockCallToThrowResult(url, body);
+            }
+        }
+
+        void ensureResponseBodyClosed() {
+            urlToResponseBody.values().stream().filter(Objects::nonNull).forEach(b -> verify(b).close());
+        }
+
+        Request getCapturedRequest(String url) {
+            return urlToRequest.get(url);
+        }
+
+        void mapUrlToResult(String url, String result) {
+            urlToResult.put(url, result);
+            headers.put(url, emptyMap());
+            urlToReturnCode.put(url, 200);
+        }
+
+        void mapUrlToResultWithResponseCode(String url, int responseCode, String result) {
+            urlToResult.put(url, result);
+            headers.put(url, emptyMap());
+            urlToReturnCode.put(url, responseCode);
+        }
+
+        void mapUrlToResultWithHeaders(String url, String result, Map<String, String> h) {
+            urlToResult.put(url, result);
+            headers.put(url, h);
+            urlToReturnCode.put(url, 200);
+        }
+
+        void mapUrlToException(String url, Exception exception) {
+            urlToException.put(url, exception);
+        }
+
+        private Response getResponse(String url, int responseCode, Map<String, String> headers, ResponseBody body) {
+            return new Response.Builder()
+                    .code(responseCode)
+                    .request(new Request.Builder().url(url).build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .message("Hello handsome!")
+                    .body(body)
+                    .headers(Headers.of(headers))
+                    .build();
+        }
+
+        private Call mockCallToThrowResult(String url, ResponseBody mockBody) {
+            try {
+                Call mockCall = mock(Call.class);
+                when(mockCall.execute()).thenReturn(getResponse(url, urlToReturnCode.get(url), headers.get(url), mockBody));
+                return mockCall;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        private Call mockCallToThrowException(String url) {
+            try {
+                Call mockCall = mock(Call.class);
+                when(mockCall.execute()).thenThrow(urlToException.get(url));
+                return mockCall;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        private ResponseBody mockResponseBody(String result) {
+            try {
+                ResponseBody mockBody = null;
+                if (!isBlank(result)) {
+                    mockBody = mock(ResponseBody.class);
+                    BufferedSource bufferedSource = mock(BufferedSource.class);
+                    when(bufferedSource.readString(any())).thenReturn(result);
+                    when(bufferedSource.select(any())).thenReturn(0);
+                    when(mockBody.source()).thenReturn(bufferedSource);
+                    when(mockBody.byteStream()).thenReturn(new StringInputStream(result));
+                }
+                return mockBody;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
@@ -46,10 +46,10 @@ import static org.mockito.Mockito.*;
 public class BitbucketClientFactoryImplTest {
 
     private static final String BASE_URL = "http://localhost:7990/bitbucket";
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private BitbucketClientFactoryImpl anonymousClientFactory;
-    private MockRemoteHttpServer mockRemoteHttpServer = new MockRemoteHttpServer();
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final MockRemoteHttpServer mockRemoteHttpServer = new MockRemoteHttpServer();
 
     @Before
     public void setup() {
@@ -159,8 +159,10 @@ public class BitbucketClientFactoryImplTest {
     @Test
     public void testGetCapabilties() {
         mockRemoteHttpServer.mapUrlToResult(
-                BASE_URL + "/rest/capabilities",readCapabilitiesResponseFromFile());
+                BASE_URL + "/rest/capabilities", readCapabilitiesResponseFromFile());
+
         AtlassianServerCapabilities response = anonymousClientFactory.getCapabilityClient().get();
+
         assertTrue(response.isBitbucketServer());
         assertEquals("stash", response.getApplication());
         assertThat(response.getCapabilities(), hasKey("webhooks"));
@@ -176,7 +178,6 @@ public class BitbucketClientFactoryImplTest {
         BitbucketWebhookSupportedEvents hookSupportedEvents =
                 anonymousClientFactory.getWebhookCapabilities().get();
         assertThat(hookSupportedEvents.getApplicationWebHooks(), hasItem(REFS_CHANGED_EVENT));
-
     }
 
     @Test
@@ -584,5 +585,4 @@ public class BitbucketClientFactoryImplTest {
             }
         }
     }
-
 }

--- a/src/test/resources/capabilities-response.json
+++ b/src/test/resources/capabilities-response.json
@@ -18,6 +18,7 @@
     "code-insights": "http://localhost:7990/bitbucket/rest/insights/latest/capabilities",
     "smart-commit-producer": "http://localhost:7990/bitbucket/rest/jira-dev/latest/smart-commit",
     "atlassian-remote-event-consumer": "http://localhost:7990/bitbucket/rest/remote-event-consumer/1/capabilities",
-    "atlassian-remote-event-producer": "http://localhost:7990/bitbucket/rest/remote-event-producer/1/capabilities"
+    "atlassian-remote-event-producer": "http://localhost:7990/bitbucket/rest/remote-event-producer/1/capabilities",
+    "webhooks": "http://localhost:7990/bitbucket/rest/webhooks/latest/capabilities"
   }
 }

--- a/src/test/resources/webhook-capabilities-response.json
+++ b/src/test/resources/webhook-capabilities-response.json
@@ -1,0 +1,29 @@
+{
+  "application-webhooks": [
+    "mirror:repo_synchronized",
+    "project:created",
+    "project:deleted",
+    "project:modified",
+    "repo:created",
+    "repo:forked",
+    "repo:deleted",
+    "repo:modified",
+    "repo:refs_changed",
+    "repo:default_branch_modified",
+    "repo:comment:added",
+    "repo:comment:edited",
+    "repo:comment:deleted",
+    "pr:opened",
+    "pr:merged",
+    "pr:declined",
+    "pr:deleted",
+    "pr:modified",
+    "pr:reviewer:updated",
+    "pr:reviewer:approved",
+    "pr:reviewer:unapproved",
+    "pr:reviewer:needs_work",
+    "pr:comment:added",
+    "pr:comment:edited",
+    "pr:comment:deleted"
+  ]
+}


### PR DESCRIPTION
We need to check if the remote Bitbucket Server support specific event
type before registering a web hook. The Factory client tests are
refactored so that multiple URL and their response can be mocked.