### PR TITLE
Add Nonnull and guava to illegal packages style

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -50,7 +50,7 @@
         <module name="TypeName"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="clover, junit.framework, org.apache.commons.lang, org.slf4j"/>
+            <property name="illegalPkgs" value="clover, junit.framework, org.apache.commons.lang, org.slf4j, javax.annotation.Nonnull, com.google.common.collect"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
@@ -4,7 +4,6 @@ import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryPro
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
-import com.google.common.collect.ImmutableList;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -14,6 +13,7 @@ import org.junit.*;
 import java.io.IOException;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -59,7 +59,7 @@ public class BitbucketSCMIT {
         BitbucketSCM bitbucketSCM =
                 new BitbucketSCM(
                         "",
-                        ImmutableList.of(new BranchSpec(branchSpec)),
+                        singletonList(new BranchSpec(branchSpec)),
                         bbJenkinsRule.getBitbucketServer().getAdminCredentialsId(),
                         emptyList(),
                         "",


### PR DESCRIPTION
Adding Nonull as an illegal import as we should never use that (given we have package level annotations for that)
Adding google collections (guava) on the banned list as well so we don't have to look for it in PRs.