### PR TITLE
Added form exception screen for inputting non-matching credentials

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -402,15 +402,15 @@ public class BitbucketSCM extends SCM {
                 scm.setBitbucketPluginConfiguration(bitbucketPluginConfiguration);
                 scm.createGitSCM();
                 return scm;
-            } catch (Error e) {
-                Throwable cause = e.getCause();
-                while (cause != null) {
+            } catch (Error | RuntimeException e) {
+                Throwable cause = e;
+                do {
                     if (cause instanceof BitbucketSCMException) {
                         throw new FormException(
                                 cause.getMessage(), ((BitbucketSCMException) cause).getField());
                     }
                     cause = cause.getCause();
-                }
+                } while (cause != null);
                 throw e; // didn't match any known error, so throw it up and let Jenkins handle it
             }
         }


### PR DESCRIPTION
This little fix means an error screen appears if incorrect credentials are passed through to the SCM rather than a stack trace.