### PR TITLE
mh/plugin delete fix

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfiguration.java
@@ -26,6 +26,9 @@ public class BitbucketPluginConfiguration extends GlobalConfiguration {
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) {
+        if (json.isEmpty()) {
+            setServerList(Collections.emptyList());
+        }
         req.bindJSON(this, json);
         FormValidation aggregate = FormValidation.aggregate(serverList.stream()
                 .map(BitbucketServerConfiguration::validate)

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -370,7 +370,7 @@ public class BitbucketSCM extends SCM {
 
         @Override
         public String getDisplayName() {
-            return "Bitbucket";
+            return "Bitbucket Server";
         }
 
         public List<GitSCMExtensionDescriptor> getExtensionDescriptors() {


### PR DESCRIPTION
Addresses two bugs:
- Text in SCM was display "Bitbucket", and has been changed to display "Bitbucket Server"
- If an empty JSON was sent to the `configure` method, stapler was not calling `setServerList`. That bug has been fixed by manually setting the server list whenever the JSON is empty.