### PR TITLE
* Added REST endpoint to get mirrored repositories for a given repository ID

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -16,10 +16,18 @@ public interface BitbucketClientFactory {
     BitbucketCapabilitiesClient getCapabilityClient();
 
     /**
+     * Construct a client that can retrieve the list of mirrored repositories for a given {@code repoId} from Bitbucket.
+     *
+     * @param repoId the ID of the repository
+     * @return a client that is ready to use
+     */
+    BitbucketMirroredRepositoryDescriptorClient getMirroredRepositoriesClient(int repoId);
+
+    /**
      * Return a project client.
      *
      * @param projectKey key of the project, if a project with this key does not exist all
-     *         subsequent calls on this client will throw a {@link NotFoundException}
+     *                   subsequent calls on this client will throw a {@link NotFoundException}
      * @return a client that is ready to use
      */
     BitbucketProjectClient getProjectClient(String projectKey);
@@ -35,7 +43,6 @@ public interface BitbucketClientFactory {
      * Return a repository search client
      *
      * @param projectName The project name to scope the repository search
-     *
      * @return a client that it ready to use
      */
     BitbucketRepositorySearchClient getRepositorySearchClient(String projectName);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -44,6 +44,23 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     }
 
     @Override
+    public BitbucketMirroredRepositoryDescriptorClient getMirroredRepositoriesClient(int repoId) {
+        return () -> {
+            HttpUrl url =
+                    bitbucketRequestExecutor.getBaseUrl().newBuilder()
+                            .addPathSegment("rest")
+                            .addPathSegment("mirroring")
+                            .addPathSegment("1.0")
+                            .addPathSegment("repos")
+                            .addPathSegment(String.valueOf(repoId))
+                            .addPathSegment("mirrors")
+                            .build();
+            return bitbucketRequestExecutor.makeGetRequest(url, new TypeReference<BitbucketPage<BitbucketMirroredRepositoryDescriptor>>() {
+            }).getBody();
+        };
+    }
+
+    @Override
     public BitbucketProjectClient getProjectClient(String projectKey) {
         return new BitbucketProjectClient() {
             @Override
@@ -166,7 +183,7 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
             if (urlStr == null) {
                 throw new WebhookNotSupportedException(
                         "Remote Bitbucket Server does not support Webhooks. Make sure " +
-                        "Bitbucket server supports webhooks or correct version of it is installed.");
+                                "Bitbucket server supports webhooks or correct version of it is installed.");
             }
 
             HttpUrl url = parse(urlStr);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryProvider.java
@@ -1,18 +1,10 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
-import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import hudson.Plugin;
-import jenkins.model.Jenkins;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import org.apache.log4j.Logger;
 
 import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -24,13 +16,18 @@ import static java.util.Objects.requireNonNull;
 public class BitbucketClientFactoryProvider {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final OkHttpClient okHttpClient =
-            new OkHttpClient.Builder().addInterceptor(new UserAgentInterceptor()).build();
+
+    private HttpRequestExecutor httpRequestExecutor;
+
+    @Inject
+    public BitbucketClientFactoryProvider(HttpRequestExecutor httpRequestExecutor) {
+        this.httpRequestExecutor = httpRequestExecutor;
+    }
 
     /**
      * Return a client factory for the given base URL.
      *
-     * @param baseUrl the URL to connect to
+     * @param baseUrl     the URL to connect to
      * @param credentials the credentials to use while making the HTTP request
      * @return a ready to use client factory
      */
@@ -41,35 +38,6 @@ public class BitbucketClientFactoryProvider {
                 baseUrl,
                 credentials,
                 objectMapper,
-                new HttpRequestExecutorImpl(okHttpClient));
-    }
-
-    /**
-     * Having this as a client level interceptor means we can configure it once to set the
-     * user-agent and not have to worry about setting the header for every request.
-     */
-    private static class UserAgentInterceptor implements Interceptor {
-
-        private final String bbJenkinsUserAgent;
-
-        UserAgentInterceptor() {
-            String version = "unknown";
-            try {
-                Plugin plugin = Jenkins.get().getPlugin("atlassian-bitbucket-server-scm");
-                if (plugin != null) {
-                    version = plugin.getWrapper().getVersion();
-                }
-            } catch (IllegalStateException e) {
-                Logger.getLogger(UserAgentInterceptor.class).warn("Jenkins not available", e);
-            }
-            bbJenkinsUserAgent = "Bitbucket Jenkins Integration/" + version;
-        }
-
-        @Override
-        public Response intercept(Chain chain) throws IOException {
-            Request request =
-                    chain.request().newBuilder().header("User-Agent", bbJenkinsUserAgent).build();
-            return chain.proceed(request);
-        }
+                httpRequestExecutor);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketMirroredRepositoryDescriptorClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketMirroredRepositoryDescriptorClient.java
@@ -1,0 +1,10 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketMirroredRepositoryDescriptor;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
+
+/**
+ * Client to get the mirrored repository descriptor for a given repository.
+ */
+public interface BitbucketMirroredRepositoryDescriptorClient extends BitbucketClient<BitbucketPage<BitbucketMirroredRepositoryDescriptor>> {
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/HttpRequestExecutor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/HttpRequestExecutor.java
@@ -1,6 +1,8 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
+import com.google.inject.ImplementedBy;
 import okhttp3.HttpUrl;
 import okhttp3.Response;
 
@@ -9,6 +11,7 @@ import okhttp3.Response;
  * bound with OkHttpClient library. Methods also takes {@link ResponseConsumer} instead of returning response in order
  * to have better handle on cleaning of resources.
  */
+@ImplementedBy(HttpRequestExecutorImpl.class)
 public interface HttpRequestExecutor {
 
     /**

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/BitbucketCredentialsAdaptor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/BitbucketCredentialsAdaptor.java
@@ -34,6 +34,10 @@ public final class BitbucketCredentialsAdaptor implements BitbucketCredentials {
                 .orElseGet(() -> create(configuration));
     }
 
+    public static BitbucketCredentials create(Credentials credentials) {
+        return new BitbucketCredentialsAdaptor(credentials);
+    }
+
     @Override
     public String toHeaderValue() {
         if (credentials instanceof StringCredentials) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirror.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirror.java
@@ -1,0 +1,37 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketMirror {
+
+    private final String baseUrl;
+    private final boolean enabled;
+    private final String name;
+
+    @JsonCreator
+    public BitbucketMirror(
+            @JsonProperty(value = "baseUrl", required = true) String baseUrl,
+            @JsonProperty(value = "enabled", required = true) boolean enabled,
+            @JsonProperty(value = "name", required = true) String name) {
+        this.baseUrl = requireNonNull(baseUrl, "baseUrl");
+        this.enabled = enabled;
+        this.name = requireNonNull(name, "name");
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepository.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepository.java
@@ -1,0 +1,54 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketMirroredRepository {
+
+    private final boolean available;
+    private final Map<String, List<BitbucketNamedLink>> links;
+    private final String mirrorName;
+    private final int repositoryId;
+    private final BitbucketMirroredRepositoryStatus status;
+
+    @JsonCreator
+    public BitbucketMirroredRepository(
+            @JsonProperty(value = "available", required = true) boolean available,
+            @JsonProperty(value = "links", required = true) Map<String, List<BitbucketNamedLink>> links,
+            @JsonProperty(value = "mirrorName", required = true) String mirrorName,
+            @JsonProperty(value = "repositoryId", required = true) int repositoryId,
+            @JsonProperty(value = "status", required = true) BitbucketMirroredRepositoryStatus status) {
+        this.available = available;
+        this.links = requireNonNull(links, "links");
+        this.mirrorName = requireNonNull(mirrorName, "mirrorName");
+        this.repositoryId = requireNonNull(repositoryId, "repositoryId");
+        this.status = requireNonNull(status, "status");
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public Map<String, List<BitbucketNamedLink>> getLinks() {
+        return links;
+    }
+
+    public String getMirrorName() {
+        return mirrorName;
+    }
+
+    public int getRepositoryId() {
+        return repositoryId;
+    }
+
+    public BitbucketMirroredRepositoryStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepositoryDescriptor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepositoryDescriptor.java
@@ -1,0 +1,39 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketMirroredRepositoryDescriptor {
+
+    private final Map<String, List<BitbucketNamedLink>> links;
+    private final BitbucketMirror mirrorServer;
+
+    @JsonCreator
+    public BitbucketMirroredRepositoryDescriptor(
+            @JsonProperty(value = "links", required = true) Map<String, List<BitbucketNamedLink>> links,
+            @JsonProperty(value = "mirrorServer", required = true) BitbucketMirror mirrorServer) {
+        this.links = requireNonNull(links, "links");
+        this.mirrorServer = requireNonNull(mirrorServer, "mirrorServer");
+    }
+
+    public BitbucketMirror getMirrorServer() {
+        return mirrorServer;
+    }
+
+    @Nullable
+    public String getSelfLink() {
+        List<BitbucketNamedLink> link = links.get("self");
+        if (link != null && link.size() > 0) {
+            return link.get(0).getHref();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepositoryStatus.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketMirroredRepositoryStatus.java
@@ -1,0 +1,9 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+public enum BitbucketMirroredRepositoryStatus {
+    NOT_MIRRORED,
+    INITIALIZING,
+    AVAILABLE,
+    ERROR_INITIALIZING,
+    ERROR_AVAILABLE
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketPage.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketPage.java
@@ -3,7 +3,11 @@ package com.atlassian.bitbucket.jenkins.internal.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Basic implementation of a page as returned by all paged resources in Bitbucket Server.
@@ -67,5 +71,20 @@ public class BitbucketPage<T> {
     @JsonProperty("isLastPage")
     public void setLastPage(boolean lastPage) {
         this.lastPage = lastPage;
+    }
+
+    @Nonnull
+    public <E> BitbucketPage<E> transform(@Nonnull Function<? super T, ? extends E> transformFunction) {
+        List<E> list = values.stream()
+                .map(transformFunction)
+                .collect(toList());
+
+        BitbucketPage<E> page = new BitbucketPage<>();
+        page.setValues(list);
+        page.setLimit(limit);
+        page.setSize(size);
+        page.setLastPage(lastPage);
+        page.setStart(start);
+        return page;
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointTest.java
@@ -1,10 +1,8 @@
 package com.atlassian.bitbucket.jenkins.internal.config;
 
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactory;
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketProjectSearchClient;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
+import com.atlassian.bitbucket.jenkins.internal.client.*;
+import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
+import com.atlassian.bitbucket.jenkins.internal.model.*;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -13,6 +11,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.ExtensionList;
 import io.restassured.http.ContentType;
+import okhttp3.HttpUrl;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -22,15 +21,13 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static com.atlassian.bitbucket.jenkins.internal.config.BitbucketSearchEndpoint.BITBUCKET_SERVER_SEARCH_URL;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,16 +35,26 @@ public class BitbucketSearchEndpointTest {
 
     @ClassRule
     public static JenkinsRule jenkins = new JenkinsRule();
+    private static final int REPO_ID = 99;
+    private static final String REPO_MIRROR_LINK = "http://mirror%d.example.com/rest/mirroring/latest/upstreamServers" +
+            "/8dc0bb6c-b31b-3d96-8835-eea2516116bd/repos/99?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9";
+    private static final String MIRROR_NAME = "Mirror %d";
+    private static final String MIRROR_URL = "http://mirror%d.example.com";
 
+    private final String BB_SEARCH_URL = jenkins.getInstance().getRootUrl() + BITBUCKET_SERVER_SEARCH_URL;
+    private final String BB_FIND_PROJECT_URL = BB_SEARCH_URL + "/findProjects/";
+    private final String BB_FIND_MIRRORED_REPOS_URL = BB_SEARCH_URL + "/findMirroredRepositories/";
     @Mock
     private BitbucketClientFactoryProvider bitbucketClientFactoryProvider;
     @Mock
     private BitbucketClientFactory bbClientFactory;
     @Mock
     private BitbucketProjectSearchClient bbProjectSearchClient;
+    @Mock
+    private BitbucketMirroredRepositoryDescriptorClient bbRepoMirrorsClient;
+    @Mock
+    private HttpRequestExecutor httpRequestExecutor;
 
-    private final String BB_WEBHOOK_URL =
-            jenkins.getInstance().getRootUrl() + BITBUCKET_SERVER_SEARCH_URL + "/findProjects/";
     private String credentialId = UUID.randomUUID().toString();
     private String serverId = UUID.randomUUID().toString();
 
@@ -62,9 +69,106 @@ public class BitbucketSearchEndpointTest {
                                 credentialId, "http://stash.example.com", credentialId, serverId)));
         setupCredentials(credentialId, "admin");
 
-        when(bitbucketClientFactoryProvider.getClient(any(), any())).thenReturn(bbClientFactory);
+        when(bitbucketClientFactoryProvider.getClient(anyString(), any())).thenReturn(bbClientFactory);
         when(bbClientFactory.getProjectSearchClient()).thenReturn(bbProjectSearchClient);
-        setBitbucketClientFactoryProvider();
+        when(bbClientFactory.getMirroredRepositoriesClient(REPO_ID)).thenReturn(bbRepoMirrorsClient);
+        setBitbucketSearchEndpoint();
+    }
+
+    @Test
+    public void testFindMirroredRepository() {
+        BitbucketPage<BitbucketMirroredRepositoryDescriptor> page = createMirroredRepoDescriptors(2);
+        when(bbRepoMirrorsClient.get()).thenReturn(page);
+
+        Map<String, List<BitbucketNamedLink>> repoLinks = new HashMap<>();
+        String repoCloneUrl = "http://mirror1.example.com/scm/stash/jenkins/jenkins.git";
+        repoLinks.put("clone", Collections.singletonList(new BitbucketNamedLink("http", repoCloneUrl)));
+        BitbucketMirroredRepository mirroredRepo = new BitbucketMirroredRepository(true, repoLinks, "Mirror 0", REPO_ID, BitbucketMirroredRepositoryStatus.AVAILABLE);
+        when(httpRequestExecutor.executeGet(eq(HttpUrl.parse(String.format(REPO_MIRROR_LINK, 0))), eq(BitbucketCredentials.ANONYMOUS_CREDENTIALS),
+                any(HttpRequestExecutor.ResponseConsumer.class))).thenReturn(mirroredRepo);
+
+        when(httpRequestExecutor.executeGet(eq(HttpUrl.parse(String.format(REPO_MIRROR_LINK, 1))), eq(BitbucketCredentials.ANONYMOUS_CREDENTIALS),
+                any(HttpRequestExecutor.ResponseConsumer.class))).thenThrow(new NotFoundException("Not found", "Not found"));
+
+        given().contentType(ContentType.JSON)
+                .log()
+                .ifValidationFails()
+                .when()
+                .param("credentialsId", credentialId)
+                .param("serverId", serverId)
+                .param("repositoryId", REPO_ID)
+                .get(BB_FIND_MIRRORED_REPOS_URL)
+                .then()
+                .statusCode(StaplerResponse.SC_OK)
+                .body("data.values[0].available", equalTo(true))
+                .body("data.values[0].links.clone[0].name", equalTo("http"))
+                .body("data.values[0].links.clone[0].href", equalTo(repoCloneUrl))
+                .body("data.values[0].mirrorName", equalTo("Mirror 0"))
+                .body("data.values[0].repositoryId", equalTo(REPO_ID))
+                .body("data.values[0].status", equalTo("AVAILABLE"))
+                .body("data.values[1].available", equalTo(false))
+                .body("data.values[1].links", equalTo(Collections.emptyMap()))
+                .body("data.values[1].mirrorName", equalTo("Mirror 1"))
+                .body("data.values[1].repositoryId", equalTo(REPO_ID))
+                .body("data.values[1].status", equalTo(BitbucketMirroredRepositoryStatus.NOT_MIRRORED.name()));
+    }
+
+    @Test
+    public void testFindMirroredRepositoryShouldFailIfRepoIdNotSpecified() {
+        given().contentType(ContentType.JSON)
+                .log()
+                .ifValidationFails()
+                .when()
+                .param("credentialsId", credentialId)
+                .param("serverId", serverId)
+                .get(BB_FIND_MIRRORED_REPOS_URL)
+                .then()
+                .statusCode(StaplerResponse.SC_BAD_REQUEST)
+                .body(containsString("Repository ID must be provided as a query parameter"));
+    }
+
+    @Test
+    public void testFindMirroredRepositoryShouldFailIfServerIdNotSpecified() {
+        given().contentType(ContentType.JSON)
+                .log()
+                .ifValidationFails()
+                .when()
+                .param("credentialsId", credentialId)
+                .param("repositoryId", REPO_ID)
+                .get(BB_FIND_MIRRORED_REPOS_URL)
+                .then()
+                .statusCode(StaplerResponse.SC_BAD_REQUEST)
+                .body(containsString("A Bitbucket Server serverId must be provided as a query parameter"));
+    }
+
+    @Test
+    public void testFindMirroredRepositoryShouldFailIfServerIdIsInvalid() {
+        given().contentType(ContentType.JSON)
+                .log()
+                .ifValidationFails()
+                .when()
+                .param("credentialsId", credentialId)
+                .param("serverId", "invalid")
+                .param("repositoryId", REPO_ID)
+                .get(BB_FIND_MIRRORED_REPOS_URL)
+                .then()
+                .statusCode(StaplerResponse.SC_BAD_REQUEST)
+                .body(containsString("The provided Bitbucket Server serverId does not exist"));
+    }
+
+    @Test
+    public void testFindMirroredRepositoryShouldFailIfCredentialIdIsInvalid() {
+        given().contentType(ContentType.JSON)
+                .log()
+                .ifValidationFails()
+                .when()
+                .param("credentialsId", "invalid")
+                .param("serverId", serverId)
+                .param("repositoryId", REPO_ID)
+                .get(BB_FIND_MIRRORED_REPOS_URL)
+                .then()
+                .statusCode(StaplerResponse.SC_BAD_REQUEST)
+                .body(containsString("No corresponding credentials for the provided credentialsId"));
     }
 
     @Test
@@ -84,18 +188,35 @@ public class BitbucketSearchEndpointTest {
                 .when()
                 .param("credentialId", credentialId)
                 .param("serverId", serverId)
-                .get(BB_WEBHOOK_URL)
+                .get(BB_FIND_PROJECT_URL)
                 .then()
                 .statusCode(StaplerResponse.SC_OK)
                 .body("data.values[0].key", equalTo("stash"))
                 .body("data.values[0].name", equalTo("STASH"));
     }
 
-    private void setBitbucketClientFactoryProvider() throws IllegalAccessException {
+    private BitbucketPage<BitbucketMirroredRepositoryDescriptor> createMirroredRepoDescriptors(int count) {
+        BitbucketPage<BitbucketMirroredRepositoryDescriptor> page = new BitbucketPage<>();
+        List<BitbucketMirroredRepositoryDescriptor> mirroredRepoDescs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Map<String, List<BitbucketNamedLink>> links = new HashMap<>();
+            String repoMirrorLink = String.format(REPO_MIRROR_LINK, i);
+            String mirrorName = String.format(MIRROR_NAME, i);
+            String mirrorUrl = String.format(MIRROR_URL, i);
+            links.put("self", Collections.singletonList(new BitbucketNamedLink("self", repoMirrorLink)));
+            mirroredRepoDescs.add(new BitbucketMirroredRepositoryDescriptor(links, new BitbucketMirror(mirrorUrl,
+                    true, mirrorName)));
+        }
+        page.setValues(mirroredRepoDescs);
+        return page;
+    }
+
+    private void setBitbucketSearchEndpoint() {
         ExtensionList<BitbucketSearchEndpoint> extensionList =
                 jenkins.getInstance().getExtensionList(BitbucketSearchEndpoint.class);
         BitbucketSearchEndpoint bitbucketSearchEndpoint = extensionList.get(0);
         bitbucketSearchEndpoint.setBitbucketClientFactoryProvider(bitbucketClientFactoryProvider);
+        bitbucketSearchEndpoint.setHttpRequestExecutor(httpRequestExecutor);
     }
 
     private void setupCredentials(String credentialId, String secret) throws Exception {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketMockJenkinsRule;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import hudson.model.FreeStyleProject;
@@ -55,7 +56,7 @@ public class BitbucketSCMTest {
                         PROJECT_KEY,
                         REPO_SLUG,
                         bbJenkinsRule.getServerId());
-        scm.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider());
+        scm.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl()));
         scm.setBitbucketPluginConfiguration(new BitbucketPluginConfiguration());
         scm.createGitSCM();
         bbJenkinsRule

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketProjectConfigurationIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketProjectConfigurationIT.java
@@ -3,6 +3,7 @@ package it.com.atlassian.bitbucket.jenkins.internal.config;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.gargoylesoftware.htmlunit.html.*;
 import hudson.model.FreeStyleProject;
@@ -151,7 +152,7 @@ public class BitbucketProjectConfigurationIT {
                 PROJECT_KEY,
                 REPO_SLUG,
                 bbJenkinsRule.getBitbucketServerConfiguration().getId());
-        bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider());
+        bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl()));
         bitbucketSCM.setBitbucketPluginConfiguration(new BitbucketPluginConfiguration());
         bitbucketSCM.createGitSCM();
         project.setScm(bitbucketSCM);

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/config/BitbucketSearchEndpointIT.java
@@ -2,6 +2,7 @@ package it.com.atlassian.bitbucket.jenkins.internal.config;
 
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketMirroredRepository;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
@@ -14,14 +15,39 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class BitbucketSearchEndpointIT {
 
+    private static final String FIND_MIRRORED_REPOS_URL = "bitbucket-server-search/findMirroredRepositories";
     private static final String FIND_PROJECT_URL = "bitbucket-server-search/findProjects";
     private static final String FIND_REPO_URL = "bitbucket-server-search/findRepositories";
     @ClassRule
     public static BitbucketJenkinsRule bitbucketJenkinsRule = new BitbucketJenkinsRule();
+
+    @Test
+    public void testFindMirroredRepositories() throws Exception {
+        HudsonResponse<BitbucketPage<BitbucketMirroredRepository>> response =
+                RestAssured.expect()
+                        .statusCode(200)
+                        .log()
+                        .ifError()
+                        .given()
+                        .queryParam("serverId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getId())
+                        .queryParam("repositoryId", 1)
+                        .get(bitbucketJenkinsRule.getURL() + FIND_MIRRORED_REPOS_URL)
+                        .getBody()
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketMirroredRepository>>>() {
+                        });
+
+        assertThat(response.getStatus(), equalTo("ok"));
+        BitbucketPage<BitbucketMirroredRepository> results = response.getData();
+        assertThat(results.getSize(), equalTo(0));
+        assertThat(results.getStart(), equalTo(0));
+        assertThat(results.getLimit(), equalTo(25));
+        List<BitbucketMirroredRepository> values = results.getValues();
+        assertThat(values.size(), equalTo(0));
+    }
 
     @Test
     public void testFindProjects() throws Exception {
@@ -36,7 +62,8 @@ public class BitbucketSearchEndpointIT {
                         .queryParam("name", "proj")
                         .get(bitbucketJenkinsRule.getURL() + FIND_PROJECT_URL)
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {});
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<BitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -62,7 +89,8 @@ public class BitbucketSearchEndpointIT {
                         .queryParam("name", "proj")
                         .get(bitbucketJenkinsRule.getURL() + FIND_PROJECT_URL)
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {});
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<BitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -102,7 +130,8 @@ public class BitbucketSearchEndpointIT {
                         .queryParam("name", "proj")
                         .get(bitbucketJenkinsRule.getURL() + FIND_PROJECT_URL)
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {});
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<BitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
@@ -124,7 +153,8 @@ public class BitbucketSearchEndpointIT {
                         .queryParam("name", "")
                         .get(bitbucketJenkinsRule.getURL() + FIND_PROJECT_URL)
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {});
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<BitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -149,7 +179,8 @@ public class BitbucketSearchEndpointIT {
                         .queryParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                         .get(bitbucketJenkinsRule.getURL() + FIND_PROJECT_URL)
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {});
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<BitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -195,7 +226,8 @@ public class BitbucketSearchEndpointIT {
                 .queryParam("filter", "rep")
                 .get(bitbucketJenkinsRule.getURL() + FIND_REPO_URL)
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
+                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -229,7 +261,8 @@ public class BitbucketSearchEndpointIT {
                 .queryParam("filter", "non-existent repo")
                 .get(bitbucketJenkinsRule.getURL() + FIND_REPO_URL)
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
+                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
@@ -252,7 +285,8 @@ public class BitbucketSearchEndpointIT {
                 .queryParam("filter", "rep")
                 .get(bitbucketJenkinsRule.getURL() + FIND_REPO_URL)
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
+                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
@@ -279,7 +313,8 @@ public class BitbucketSearchEndpointIT {
                         .as(
                                 new TypeRef<
                                         HudsonResponse<
-                                                BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                                                BitbucketPage<JenkinsBitbucketRepository>>>() {
+                                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -328,7 +363,8 @@ public class BitbucketSearchEndpointIT {
                         .as(
                                 new TypeRef<
                                         HudsonResponse<
-                                                BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                                                BitbucketPage<JenkinsBitbucketRepository>>>() {
+                                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
@@ -376,7 +412,8 @@ public class BitbucketSearchEndpointIT {
                         .as(
                                 new TypeRef<
                                         HudsonResponse<
-                                                BitbucketPage<JenkinsBitbucketRepository>>>() {});
+                                                BitbucketPage<JenkinsBitbucketRepository>>>() {
+                                });
         assertThat(response.getStatus(), equalTo("ok"));
         BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
@@ -3,6 +3,7 @@ package it.com.atlassian.bitbucket.jenkins.internal.scm;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -95,7 +96,7 @@ public class BitbucketSCMIT {
                         PROJECT_KEY,
                         REPO_SLUG,
                         bbJenkinsRule.getBitbucketServerConfiguration().getId());
-        bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider());
+        bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl()));
         bitbucketSCM.setBitbucketPluginConfiguration(new BitbucketPluginConfiguration());
         bitbucketSCM.createGitSCM();
         return bitbucketSCM;

--- a/src/test/resources/mirrored-repositories-response.json
+++ b/src/test/resources/mirrored-repositories-response.json
@@ -1,0 +1,43 @@
+{
+  "size": 2,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "mirrorServer": {
+        "id": "BSERV-1337-ABCD-R2D2-C3P0",
+        "baseUrl": "https://us-east.bitbucket.example.com",
+        "name": "US East Mirror",
+        "productType": "Bitbucket Server",
+        "productVersion": "4.2.0",
+        "lastSeenDate": 1453879734348,
+        "enabled": true
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://us-east.bitbucket.example.com/rest/mirroring/1.0/repos/1?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+          }
+        ]
+      }
+    },
+    {
+      "mirrorServer": {
+        "id": "BSERV-1337-ABCD-R2D2-C3P1",
+        "baseUrl": "https://us-west.bitbucket.example.com",
+        "name": "US West Mirror",
+        "productType": "Bitbucket Server",
+        "productVersion": "4.2.0",
+        "lastSeenDate": 1453879734388,
+        "enabled": true
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://us-west.bitbucket.example.com/rest/mirroring/1.0/repos/1?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* This endpoint will query Bitbucket upstream to get all the mirrored repository and then make a request to the mirror with the `selfLink` and verify if the repository is available on the mirror or not. It it's not available then the returned mirrored repository will have it's status set to `UNAVAILABLE`.

* Moved JSON parsing to `HttpRequestExecutor` because consumers of `HttpRequestExecutor` don't have to worry about parsing the response as it's being used in multiple places now.