### PR TITLE
Remove Atlassian from name and description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <jenkins.version>2.162</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <name>Atlassian Bitbucket Server Integration</name>
-    <description>Atlassian supported plugin to connect Jenkins and Bitbucket Server.</description>
+    <name>Bitbucket Server Integration</name>
+    <description>This Jenkins plugin streamlines configuring Jenkins jobs to clone/fetch from Bitbucket Server.</description>
 
     <licenses>
         <license>


### PR DESCRIPTION
 but leaving the artifactId as it is, given we should not/cannot change it