### PR TITLE
Fix leaking file descriptor

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorker.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorker.java
@@ -59,8 +59,7 @@ public class BitbucketTriggerWorker implements Runnable {
             return;
         }
         File logFile = new File(job.getRootDir(), "bitbucket-webhook-trigger.log");
-        try {
-            StreamTaskListener listener = new StreamTaskListener(logFile);
+        try (StreamTaskListener listener = new StreamTaskListener(logFile)) {
 
             long start = System.currentTimeMillis();
             PrintStream logger = listener.getLogger();

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
@@ -7,7 +7,6 @@ import hudson.util.StreamTaskListener;
 import jenkins.model.RunAction2;
 import jenkins.triggers.SCMTriggerItem;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,11 +43,7 @@ public class BitbucketTriggerWorkerTest {
 
     @After
     public void tearDown() throws Exception {
-        FileUtils.cleanDirectory(tempDir);
-        if (!SystemUtils.IS_OS_WINDOWS) {
-            //The delete of temp directories does not work under windows
-            Files.delete(tempDir.toPath());
-        }
+        FileUtils.deleteDirectory(tempDir);
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -46,8 +45,10 @@ public class BitbucketTriggerWorkerTest {
     @After
     public void tearDown() throws Exception {
         FileUtils.cleanDirectory(tempDir);
-        assumeFalse("The delete of temp directories does not work under windows", SystemUtils.IS_OS_WINDOWS);
-        Files.delete(tempDir.toPath());
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            //The delete of temp directories does not work under windows
+            Files.delete(tempDir.toPath());
+        }
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
@@ -43,7 +43,8 @@ public class BitbucketTriggerWorkerTest {
 
     @After
     public void tearDown() throws Exception {
-        FileUtils.deleteDirectory(tempDir);
+        FileUtils.cleanDirectory(tempDir);
+        Files.delete(tempDir.toPath());
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketTriggerWorkerTest.java
@@ -7,6 +7,7 @@ import hudson.util.StreamTaskListener;
 import jenkins.model.RunAction2;
 import jenkins.triggers.SCMTriggerItem;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +20,7 @@ import java.nio.file.Files;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -44,6 +46,7 @@ public class BitbucketTriggerWorkerTest {
     @After
     public void tearDown() throws Exception {
         FileUtils.cleanDirectory(tempDir);
+        assumeFalse("The delete of temp directories does not work under windows", SystemUtils.IS_OS_WINDOWS);
         Files.delete(tempDir.toPath());
     }
 


### PR DESCRIPTION
We didn't close the file descriptor properly, and so we were leaking them. This made some tests fail under windows. This PR fixes that problem