### PR TITLE
Improve project repo config page

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketPage.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketPage.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -20,7 +21,7 @@ public class BitbucketPage<T> {
     private int limit;
     private int size;
     private int start;
-    private List<T> values;
+    private List<T> values = new ArrayList<>();
     private int nextPageStart;
 
     public int getLimit() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.CheckForNull;
 import java.util.List;
 import java.util.Map;
 
@@ -19,13 +20,15 @@ public class BitbucketProject {
     @JsonCreator
     public BitbucketProject(
             @JsonProperty(value = "key", required = true) String key,
-            @JsonProperty("links") Map<String, List<BitbucketNamedLink>> links,
+            @CheckForNull @JsonProperty("links") Map<String, List<BitbucketNamedLink>> links,
             @JsonProperty(value = "name", required = true) String name) {
         this.key = requireNonNull(key, "key");
         this.name = requireNonNull(name, "name");
-        List<BitbucketNamedLink> link = requireNonNull(links, "links").get("self");
-        if (link != null && !link.isEmpty()) { // there should always be exactly one self link.
-            selfLink = link.get(0).getHref();
+        if (links != null) {
+            List<BitbucketNamedLink> self = requireNonNull(links, "links").get("self");
+            if (self != null && !self.isEmpty()) { // there should always be exactly one self link.
+                selfLink = self.get(0).getHref();
+            }
         }
     }
 
@@ -37,6 +40,7 @@ public class BitbucketProject {
         return name;
     }
 
+    @CheckForNull
     public String getSelfLink() {
         return selfLink;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -11,13 +14,19 @@ public class BitbucketProject {
 
     private final String key;
     private final String name;
+    private String selfLink;
 
     @JsonCreator
     public BitbucketProject(
             @JsonProperty(value = "key", required = true) String key,
+            @JsonProperty("links") Map<String, List<BitbucketNamedLink>> links,
             @JsonProperty(value = "name", required = true) String name) {
         this.key = requireNonNull(key, "key");
         this.name = requireNonNull(name, "name");
+        List<BitbucketNamedLink> link = requireNonNull(links, "links").get("self");
+        if (link != null && !link.isEmpty()) { // there should always be exactly one self link.
+            selfLink = link.get(0).getHref();
+        }
     }
 
     public String getKey() {
@@ -26,5 +35,9 @@ public class BitbucketProject {
 
     public String getName() {
         return name;
+    }
+
+    public String getSelfLink() {
+        return selfLink;
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketProject.java
@@ -25,7 +25,7 @@ public class BitbucketProject {
         this.key = requireNonNull(key, "key");
         this.name = requireNonNull(name, "name");
         if (links != null) {
-            List<BitbucketNamedLink> self = requireNonNull(links, "links").get("self");
+            List<BitbucketNamedLink> self = links.get("self");
             if (self != null && !self.isEmpty()) { // there should always be exactly one self link.
                 selfLink = self.get(0).getHref();
             }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRepository.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRepository.java
@@ -2,8 +2,6 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import javax.annotation.Nullable;
 
-import static com.google.common.base.Objects.firstNonNull;
-
 public class BitbucketSCMRepository {
 
     private final String credentialsId;
@@ -14,18 +12,19 @@ public class BitbucketSCMRepository {
     private final String serverId;
     private final boolean isMirror;
 
-    public BitbucketSCMRepository(String credentialsId, String projectName, @Nullable String projectKey,
-                                  String repositoryName, @Nullable String repositorySlug, String serverId,
+    public BitbucketSCMRepository(@Nullable String credentialsId, String projectName, String projectKey,
+                                  String repositoryName, String repositorySlug, @Nullable String serverId,
                                   boolean isMirror) {
         this.credentialsId = credentialsId;
         this.projectName = projectName;
-        this.projectKey = firstNonNull(projectKey, projectName);
+        this.projectKey = projectKey;
         this.repositoryName = repositoryName;
-        this.repositorySlug = firstNonNull(repositorySlug, repositoryName);
+        this.repositorySlug = repositorySlug;
         this.serverId = serverId;
         this.isMirror = isMirror;
     }
 
+    @Nullable
     public String getCredentialsId() {
         return credentialsId;
     }
@@ -46,6 +45,7 @@ public class BitbucketSCMRepository {
         return repositorySlug;
     }
 
+    @Nullable
     public String getServerId() {
         return serverId;
     }

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
@@ -14,13 +14,11 @@ f.section() {
     }
 
     f.entry(title: _("bitbucket.scm.projectName"), field: "projectName") {
-        f.combobox(context: app, placeholder: "Project Name", checkMethod: "post", clazz:'searchable',
-                valueField: 'projectKey', valueIdentifier: 'key')
+        f.combobox(context: app, placeholder: "Project Name", checkMethod: "post", clazz:'searchable')
     }
 
     f.entry(title: _("bitbucket.scm.repositoryName"), field: "repositoryName") {
-        f.combobox(context: app, placeholder: "Repository Name", checkMethod: "post", clazz:'searchable',
-                valueField: 'repositorySlug', valueIdentifier: 'slug')
+        f.combobox(context: app, placeholder: "Repository Name", checkMethod: "post", clazz:'searchable')
     }
 
     f.entry(title: _("Branches to build")) {
@@ -41,11 +39,6 @@ f.section() {
         f.invisibleEntry(field: "id") {
             f.input(type: "hidden", name: "id", value: "${instance.id}")
         }
-    }
-
-    f.invisibleEntry() {
-        f.textbox(id: 'projectKey', name: 'projectKey', clazz: 'hidden', field: 'projectKey')
-        f.textbox(id: 'repositorySlug', name:'repositorySlug', clazz: 'hidden', field: 'repositorySlug')
     }
 
     script(src:"${rootURL}${h.getResourcePath()}/plugin/atlassian-bitbucket-server-integration/js/searchableField.js")

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
@@ -5,10 +5,7 @@ import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClient
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketMockJenkinsRule;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
-import com.atlassian.bitbucket.jenkins.internal.model.RepositoryState;
+import com.atlassian.bitbucket.jenkins.internal.model.*;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -35,14 +32,13 @@ import org.mockito.stubbing.Answer;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
+import java.util.*;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -97,15 +93,15 @@ public class BitbucketSCMDescriptorTest {
             String partialProjectName = invocation.getArgument(0);
             BitbucketPage<BitbucketProject> page = new BitbucketPage<>();
             ArrayList<BitbucketProject> results = new ArrayList<>();
-            results.add(new BitbucketProject(partialProjectName + "-key", partialProjectName + "-full-name"));
-            results.add(new BitbucketProject(partialProjectName + "-key2", partialProjectName + "-full-name2"));
+            results.add(new BitbucketProject(partialProjectName + "-key", getSelfLink(partialProjectName + "-key1"), partialProjectName + "-full-name"));
+            results.add(new BitbucketProject(partialProjectName + "-key2", getSelfLink(partialProjectName + "-key2"), partialProjectName + "-full-name2"));
             page.setValues(results);
             return page;
         });
         when(bitbucketClientFactory.getRepositorySearchClient(any()))
                 .thenAnswer((Answer<BitbucketRepositorySearchClient>) invocation -> {
                     String projectName = invocation.getArgument(0);
-                    BitbucketProject project = new BitbucketProject(projectName + "-key", projectName);
+                    BitbucketProject project = new BitbucketProject(projectName + "-key", getSelfLink(projectName + "-key"), projectName);
                     BitbucketRepositorySearchClient client = mock(BitbucketRepositorySearchClient.class);
                     when(client.get(any())).thenAnswer((Answer<BitbucketPage<BitbucketRepository>>) invocation1 -> {
                         String partialRepositoryName = invocation1.getArgument(0);
@@ -122,6 +118,26 @@ public class BitbucketSCMDescriptorTest {
                 });
         when(clientFactoryProvider.getClient(eq(SERVER_BASE_URL_VALID), any(BitbucketCredentials.class)))
                 .thenReturn(bitbucketClientFactory);
+        when(bitbucketClientFactory.getProjectClient(any())).thenAnswer((Answer<BitbucketProjectClient>) getProjectClientArgs -> {
+            String projectKey = getProjectClientArgs.getArgument(0);
+            BitbucketProject project = new BitbucketProject(projectKey, getSelfLink(projectKey), projectKey + "-name");
+            BitbucketProjectClient projectClient = mock(BitbucketProjectClient.class);
+            when(projectClient.get()).thenReturn(project);
+            when(projectClient.getRepositoryClient(any())).thenAnswer((Answer<BitbucketRepositoryClient>) getRepositoryClientArgs -> {
+                String repositoryKey = getRepositoryClientArgs.getArgument(0);
+                BitbucketRepositoryClient repositoryClient = mock(BitbucketRepositoryClient.class);
+                when(repositoryClient.get()).thenAnswer((Answer<BitbucketRepository>) repositoryClientArgs ->
+                        new BitbucketRepository(repositoryKey + "-full-name", emptyMap(), project, repositoryKey, RepositoryState.AVAILABLE));
+                return repositoryClient;
+            });
+            return projectClient;
+        });
+    }
+
+    @Test
+    public void testDoFillProjectNameItemsProjectNameBlank() throws Exception {
+        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillProjectNameItems(SERVER_ID_VALID, null, "");
+        verifyBadRequest(response, "The project name must be at least 2 characters long");
     }
 
     @Test
@@ -162,21 +178,21 @@ public class BitbucketSCMDescriptorTest {
     }
 
     @Test
-    public void testDoFillProjectNameItemsProjectNameBlank() throws Exception {
-        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillProjectNameItems(SERVER_ID_VALID, null, "");
-        verifyBadRequest(response, "The project name must be at least 3 characters long");
-    }
-
-    @Test
     public void testDoFillProjectNameItemsProjectNameNull() throws Exception {
         HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillProjectNameItems(SERVER_ID_VALID, null, null);
-        verifyBadRequest(response, "The project name must be at least 3 characters long");
+        verifyBadRequest(response, "The project name must be at least 2 characters long");
     }
 
     @Test
     public void testDoFillProjectNameItemsProjectNameShort() throws Exception {
-        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillProjectNameItems(SERVER_ID_VALID, null, "ab");
-        verifyBadRequest(response, "The project name must be at least 3 characters long");
+        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillProjectNameItems(SERVER_ID_VALID, null, "a");
+        verifyBadRequest(response, "The project name must be at least 2 characters long");
+    }
+
+    @Test
+    public void testDoFillRepositoryNameItemsRepositoryNameBlank() throws Exception {
+        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillRepositoryNameItems(SERVER_ID_VALID, null, "myProject", "");
+        verifyBadRequest(response, "The repository name must be at least 2 characters long");
     }
 
     @Test
@@ -250,21 +266,15 @@ public class BitbucketSCMDescriptorTest {
     }
 
     @Test
-    public void testDoFillRepositoryNameItemsRepositoryNameBlank() throws Exception {
-        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillRepositoryNameItems(SERVER_ID_VALID, null, "myProject", "");
-        verifyBadRequest(response, "The repository name must be at least 3 characters long");
-    }
-
-    @Test
     public void testDoFillRepositoryNameItemsRepositoryNameNull() throws Exception {
         HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillRepositoryNameItems(SERVER_ID_VALID, null, "myProject", null);
-        verifyBadRequest(response, "The repository name must be at least 3 characters long");
+        verifyBadRequest(response, "The repository name must be at least 2 characters long");
     }
 
     @Test
     public void testDoFillRepositoryNameItemsRepositoryNameShort() throws Exception {
-        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillRepositoryNameItems(SERVER_ID_VALID, null, "myProject", "ab");
-        verifyBadRequest(response, "The repository name must be at least 3 characters long");
+        HttpResponses.HttpResponseException response = (HttpResponses.HttpResponseException) descriptor.doFillRepositoryNameItems(SERVER_ID_VALID, null, "myProject", "a");
+        verifyBadRequest(response, "The repository name must be at least 2 characters long");
     }
 
     @Test
@@ -336,32 +346,32 @@ public class BitbucketSCMDescriptorTest {
 
     @Test
     public void testNonEmptyRepositoryName() {
-        assertEquals(Kind.OK, descriptor.doCheckRepositoryName("repo").kind);
+        assertEquals(Kind.OK, descriptor.doCheckRepositoryName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), "PROJECT_1", "repo").kind);
     }
 
     @Test
     public void testProjectNameEmpty() {
-        assertEquals(Kind.ERROR, descriptor.doCheckProjectName("").kind);
+        assertEquals(Kind.ERROR, descriptor.doCheckProjectName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), "").kind);
     }
 
     @Test
     public void testProjectNameNonEmpty() {
-        assertEquals(Kind.OK, descriptor.doCheckProjectName("PROJECT").kind);
+        assertEquals(Kind.OK, descriptor.doCheckProjectName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), "PROJECT").kind);
     }
 
     @Test
     public void testProjectNameNull() {
-        assertEquals(Kind.ERROR, descriptor.doCheckProjectName(null).kind);
+        assertEquals(Kind.ERROR, descriptor.doCheckProjectName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), null).kind);
     }
 
     @Test
     public void testRepositoryNameEmpty() {
-        assertEquals(Kind.ERROR, descriptor.doCheckRepositoryName("").kind);
+        assertEquals(Kind.ERROR, descriptor.doCheckRepositoryName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), "PROJECT_1", "").kind);
     }
 
     @Test
     public void testRepositoryNameNull() {
-        assertEquals(Kind.ERROR, descriptor.doCheckRepositoryName(null).kind);
+        assertEquals(Kind.ERROR, descriptor.doCheckRepositoryName(serverConfigurationValid.getId(), serverConfigurationValid.getCredentialsId(), "PROJECT_1", null).kind);
     }
 
     @Test
@@ -394,6 +404,10 @@ public class BitbucketSCMDescriptorTest {
         when(pluginConfiguration.getValidServerList()).thenReturn(Arrays.asList(serverConfigurationValid, serverConfigurationInvalid));
         when(pluginConfiguration.hasAnyInvalidConfiguration()).thenReturn(false);
         assertEquals(Kind.OK, descriptor.doCheckServerId(SERVER_ID_VALID).kind);
+    }
+
+    private Map<String, List<BitbucketNamedLink>> getSelfLink(String projectKey) {
+        return singletonMap("self", singletonList(new BitbucketNamedLink(null, "http://localhost:7990/bitbucket/projects/" + projectKey)));
     }
 
     private static void verifyBadRequest(HttpResponses.HttpResponseException response, String message) throws IOException, ServletException {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
@@ -52,16 +52,13 @@ public class BitbucketSCMTest {
                 new BitbucketSCM(
                         "",
                         emptyList(),
-                        bbJenkinsRule.getCredentialsId(),
                         emptyList(),
                         "",
-                        PROJECT_NAME,
-                        PROJECT_KEY,
-                        REPO_NAME,
-                        REPO_SLUG,
                         bbJenkinsRule.getServerId());
         scm.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl()));
         scm.setBitbucketPluginConfiguration(new BitbucketPluginConfiguration());
+        scm.addRepositories(new BitbucketSCMRepository(bbJenkinsRule.getCredentialsId(), PROJECT_NAME, PROJECT_KEY,
+                REPO_NAME, REPO_SLUG, bbJenkinsRule.getServerId(), false));
         scm.createGitSCM();
         bbJenkinsRule
                 .service()

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.*;
 
 import static com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookEvent.REPO_REF_CHANGE;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -199,7 +201,9 @@ public class BitbucketWebhookConsumerTest {
         List<BitbucketNamedLink> cloneLinks = Collections.singletonList(cloneLink);
         Map<String, List<BitbucketNamedLink>> links =
                 Maps.of("clone", cloneLinks, "self", Collections.singletonList(selfLink));
-        BitbucketProject project = new BitbucketProject(projectKey, projectKey);
+        BitbucketProject project = new BitbucketProject(projectKey,
+                singletonMap("self", singletonList(new BitbucketNamedLink(null, "http://localhost:7990/bitbucket/projects/" + projectKey))),
+                projectKey);
         return new BitbucketRepository(
                 repoSlug, links, project, repoSlug, RepositoryState.AVAILABLE);
     }

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorIT.java
@@ -144,7 +144,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .formParam("projectName", "")
                 .post(getProjectSearchUrl());
-        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characterslong"));
+        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characters long"));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("serverId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getId())
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .post(getProjectSearchUrl());
-        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characterslong"));
+        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characters long"));
     }
 
     @Test
@@ -387,7 +387,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .formParam("projectName", "Project 1")
                 .post(getReposUrl());
-        assertThat(response.getBody().print(), containsString("The repository name must be at least 2 characterslong"));
+        assertThat(response.getBody().print(), containsString("The repository name must be at least 2 characters long"));
     }
 
     @Test

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorIT.java
@@ -4,12 +4,12 @@ import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfigurat
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import hudson.model.FreeStyleProject;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.Response;
-import it.com.atlassian.bitbucket.jenkins.internal.util.JsonUtils;
+import it.com.atlassian.bitbucket.jenkins.internal.util.JsonUtils.JenkinsBitbucketProject;
+import it.com.atlassian.bitbucket.jenkins.internal.util.JsonUtils.JenkinsBitbucketRepository;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class BitbucketSCMDescriptorIT {
 
     @Test
     public void testFindProjects() throws Exception {
-        HudsonResponse<BitbucketPage<BitbucketProject>> response =
+        HudsonResponse<BitbucketPage<JenkinsBitbucketProject>> response =
                 RestAssured.expect()
                         .statusCode(200)
                         .log()
@@ -50,23 +50,23 @@ public class BitbucketSCMDescriptorIT {
                         .formParam("projectName", "proj")
                         .post(getProjectSearchUrl())
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketProject>>>() {
                         });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<BitbucketProject> results = response.getData();
+        BitbucketPage<JenkinsBitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<BitbucketProject> values = results.getValues();
+        List<JenkinsBitbucketProject> values = results.getValues();
         assertThat(values.size(), equalTo(1));
-        BitbucketProject project = values.get(0);
+        JenkinsBitbucketProject project = values.get(0);
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
     }
 
     @Test
     public void testFindProjectsCredentialsIdBlank() throws Exception {
-        HudsonResponse<BitbucketPage<BitbucketProject>> response =
+        HudsonResponse<BitbucketPage<JenkinsBitbucketProject>> response =
                 RestAssured.expect()
                         .statusCode(200)
                         .log()
@@ -78,16 +78,16 @@ public class BitbucketSCMDescriptorIT {
                         .formParam("projectName", "proj")
                         .post(getProjectSearchUrl())
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketProject>>>() {
                         });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<BitbucketProject> results = response.getData();
+        BitbucketPage<JenkinsBitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<BitbucketProject> values = results.getValues();
+        List<JenkinsBitbucketProject> values = results.getValues();
         assertThat(values.size(), equalTo(1));
-        BitbucketProject project = values.get(0);
+        JenkinsBitbucketProject project = values.get(0);
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
     }
@@ -111,7 +111,7 @@ public class BitbucketSCMDescriptorIT {
                 bitbucketJenkinsRule.getBitbucketServerConfiguration().getAdminCredentialsId(),
                 bitbucketJenkinsRule.getBitbucketServerConfiguration().getBaseUrl(), null, null);
         bitbucketJenkinsRule.addBitbucketServer(bitbucketServerWithoutCredentials);
-        HudsonResponse<BitbucketPage<BitbucketProject>> response =
+        HudsonResponse<BitbucketPage<JenkinsBitbucketProject>> response =
                 RestAssured.expect()
                         .statusCode(200)
                         .log()
@@ -122,10 +122,10 @@ public class BitbucketSCMDescriptorIT {
                         .formParam("projectName", "proj")
                         .post(getProjectSearchUrl())
                         .getBody()
-                        .as(new TypeRef<HudsonResponse<BitbucketPage<BitbucketProject>>>() {
+                        .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketProject>>>() {
                         });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<BitbucketProject> results = response.getData();
+        BitbucketPage<JenkinsBitbucketProject> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
@@ -144,7 +144,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .formParam("projectName", "")
                 .post(getProjectSearchUrl());
-        assertThat(response.getBody().print(), containsString("The project name must be at least 3 characters long"));
+        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characterslong"));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("serverId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getId())
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .post(getProjectSearchUrl());
-        assertThat(response.getBody().print(), containsString("The project name must be at least 3 characters long"));
+        assertThat(response.getBody().print(), containsString("The project name must be at least 2 characterslong"));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class BitbucketSCMDescriptorIT {
 
     @Test
     public void testFindRepo() throws Exception {
-        HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>> response = RestAssured.expect().statusCode(200)
+        HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>> response = RestAssured.expect().statusCode(200)
                 .log()
                 .all()
                 .given()
@@ -199,16 +199,16 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("repositoryName", "rep")
                 .post(getReposUrl())
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>>>() {
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
                 });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<JsonUtils.JenkinsBitbucketRepository> results = response.getData();
+        BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<JsonUtils.JenkinsBitbucketRepository> values = results.getValues();
+        List<JenkinsBitbucketRepository> values = results.getValues();
         assertThat(values.size(), equalTo(1));
-        JsonUtils.JenkinsBitbucketRepository repo = values.get(0);
+        JenkinsBitbucketRepository repo = values.get(0);
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
@@ -216,14 +216,14 @@ public class BitbucketSCMDescriptorIT {
                 .findAny()
                 .orElseThrow(() -> new AssertionError("There should be an http clone url"));
         assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
-        BitbucketProject project = repo.getProject();
+        JenkinsBitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
     }
 
     @Test
     public void testFindRepoNotExist() throws Exception {
-        HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>> response = RestAssured.expect()
+        HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>> response = RestAssured.expect()
                 .statusCode(200)
                 .log()
                 .ifError()
@@ -235,20 +235,20 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("repositoryName", "non-existent repo")
                 .post(getReposUrl())
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>>>() {
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
                 });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<JsonUtils.JenkinsBitbucketRepository> results = response.getData();
+        BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<JsonUtils.JenkinsBitbucketRepository> values = results.getValues();
+        List<JenkinsBitbucketRepository> values = results.getValues();
         assertThat(values.size(), equalTo(0));
     }
 
     @Test
     public void testFindRepoProjectNotExist() throws Exception {
-        HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>> response = RestAssured.expect()
+        HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>> response = RestAssured.expect()
                 .statusCode(200)
                 .log()
                 .ifError()
@@ -260,20 +260,20 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("repositoryName", "rep")
                 .post(getReposUrl())
                 .getBody()
-                .as(new TypeRef<HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>>>() {
+                .as(new TypeRef<HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>>>() {
                 });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<JsonUtils.JenkinsBitbucketRepository> results = response.getData();
+        BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(0));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<JsonUtils.JenkinsBitbucketRepository> values = results.getValues();
+        List<JenkinsBitbucketRepository> values = results.getValues();
         assertThat(values.size(), equalTo(0));
     }
 
     @Test
     public void testFindReposCredentialsIdBlank() throws Exception {
-        HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>> response =
+        HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>> response =
                 RestAssured.expect()
                         .statusCode(200)
                         .log()
@@ -289,16 +289,16 @@ public class BitbucketSCMDescriptorIT {
                         .as(
                                 new TypeRef<
                                         HudsonResponse<
-                                                BitbucketPage<JsonUtils.JenkinsBitbucketRepository>>>() {
+                                                BitbucketPage<JenkinsBitbucketRepository>>>() {
                                 });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<JsonUtils.JenkinsBitbucketRepository> results = response.getData();
+        BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<JsonUtils.JenkinsBitbucketRepository> values = results.getValues();
+        List<JenkinsBitbucketRepository> values = results.getValues();
         assertThat(values.size(), equalTo(1));
-        JsonUtils.JenkinsBitbucketRepository repo = values.get(0);
+        JenkinsBitbucketRepository repo = values.get(0);
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
@@ -306,7 +306,7 @@ public class BitbucketSCMDescriptorIT {
                 .findAny()
                 .orElseThrow(() -> new AssertionError("There should be an http clone url"));
         assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
-        BitbucketProject project = repo.getProject();
+        JenkinsBitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
     }
@@ -326,7 +326,7 @@ public class BitbucketSCMDescriptorIT {
 
     @Test
     public void testFindReposCredentialsMissing() throws Exception {
-        HudsonResponse<BitbucketPage<JsonUtils.JenkinsBitbucketRepository>> response =
+        HudsonResponse<BitbucketPage<JenkinsBitbucketRepository>> response =
                 RestAssured.expect()
                         .statusCode(200)
                         .log()
@@ -341,16 +341,16 @@ public class BitbucketSCMDescriptorIT {
                         .as(
                                 new TypeRef<
                                         HudsonResponse<
-                                                BitbucketPage<JsonUtils.JenkinsBitbucketRepository>>>() {
+                                                BitbucketPage<JenkinsBitbucketRepository>>>() {
                                 });
         assertThat(response.getStatus(), equalTo("ok"));
-        BitbucketPage<JsonUtils.JenkinsBitbucketRepository> results = response.getData();
+        BitbucketPage<JenkinsBitbucketRepository> results = response.getData();
         assertThat(results.getSize(), equalTo(1));
         assertThat(results.getStart(), equalTo(0));
         assertThat(results.getLimit(), equalTo(25));
-        List<JsonUtils.JenkinsBitbucketRepository> values = results.getValues();
+        List<JenkinsBitbucketRepository> values = results.getValues();
         assertThat(values.size(), equalTo(1));
-        JsonUtils.JenkinsBitbucketRepository repo = values.get(0);
+        JenkinsBitbucketRepository repo = values.get(0);
         assertThat(repo.getSlug(), equalTo("rep_1"));
         assertThat(repo.getName(), equalTo("rep_1"));
         assertThat(repo.getCloneUrls().size(), equalTo(2));
@@ -358,7 +358,7 @@ public class BitbucketSCMDescriptorIT {
                 .findAny()
                 .orElseThrow(() -> new AssertionError("There should be an http clone url"));
         assertThat(httpCloneUrl.getHref(), equalTo("http://admin@localhost:7990/bitbucket/scm/project_1/rep_1.git"));
-        BitbucketProject project = repo.getProject();
+        JenkinsBitbucketProject project = repo.getProject();
         assertThat(project.getKey(), equalTo("PROJECT_1"));
         assertThat(project.getName(), equalTo("Project 1"));
     }
@@ -387,7 +387,7 @@ public class BitbucketSCMDescriptorIT {
                 .formParam("credentialsId", bitbucketJenkinsRule.getBitbucketServerConfiguration().getCredentialsId())
                 .formParam("projectName", "Project 1")
                 .post(getReposUrl());
-        assertThat(response.getBody().print(), containsString("The repository name must be at least 3 characters long"));
+        assertThat(response.getBody().print(), containsString("The repository name must be at least 2 characterslong"));
     }
 
     @Test

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
@@ -5,6 +5,7 @@ import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfigurat
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
 import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.status.BitbucketRevisionAction;
 import com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookTriggerImpl;
 import hudson.model.FreeStyleBuild;
@@ -30,7 +31,9 @@ import static hudson.model.Result.SUCCESS;
 import static it.com.atlassian.bitbucket.jenkins.internal.util.AsyncTestUtils.waitFor;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BitbucketSCMIT {
 
@@ -134,20 +137,18 @@ public class BitbucketSCMIT {
         List<BranchSpec> branchSpecs = Arrays.stream(refs)
                 .map(BranchSpec::new)
                 .collect(Collectors.toList());
+        String serverId = bbJenkinsRule.getBitbucketServerConfiguration().getId();
         BitbucketSCM bitbucketSCM =
                 new BitbucketSCM(
                         "",
                         branchSpecs,
-                        bbJenkinsRule.getBitbucketServerConfiguration().getCredentialsId(),
                         emptyList(),
                         "",
-                        PROJECT_NAME,
-                        PROJECT_KEY,
-                        REPO_NAME,
-                        REPO_SLUG,
-                        bbJenkinsRule.getBitbucketServerConfiguration().getId());
+                        serverId);
         bitbucketSCM.setBitbucketClientFactoryProvider(new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl()));
         bitbucketSCM.setBitbucketPluginConfiguration(new BitbucketPluginConfiguration());
+        bitbucketSCM.addRepositories(new BitbucketSCMRepository(bbJenkinsRule.getBitbucketServerConfiguration().getCredentialsId(),
+                PROJECT_NAME, PROJECT_KEY, REPO_NAME, REPO_SLUG, serverId, false));
         bitbucketSCM.createGitSCM();
         return bitbucketSCM;
     }

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/util/JsonUtils.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/util/JsonUtils.java
@@ -1,7 +1,6 @@
 package it.com.atlassian.bitbucket.jenkins.internal.util;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
@@ -23,15 +22,36 @@ public class JsonUtils {
         }
     }
 
-    // We wrap the actual BitbucketRepository response and hide the 'links' field behind a
-    // 'cloneUrls' field so the
+    // We wrap the actual BitbucketProject response and hide the 'links' field behind a 'selfLink' field so the
+    // response from Jenkins is actually different to the one from Bitbucket
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class JenkinsBitbucketProject {
+
+        private String key;
+        private String name;
+        private String selfLink;
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getSelfLink() {
+            return selfLink;
+        }
+    }
+
+    // We wrap the actual BitbucketRepository response and hide the 'links' field behind a 'cloneUrls' field so the
     // response from Jenkins is actually different to the one from Bitbucket
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class JenkinsBitbucketRepository {
 
         private List<BitbucketNamedLink> cloneUrls;
         private String name;
-        private BitbucketProject project;
+        private JenkinsBitbucketProject project;
         private String slug;
 
         public List<BitbucketNamedLink> getCloneUrls() {
@@ -42,7 +62,7 @@ public class JsonUtils {
             return name;
         }
 
-        public BitbucketProject getProject() {
+        public JenkinsBitbucketProject getProject() {
             return project;
         }
 


### PR DESCRIPTION
* Remove projectKey and repoSlug fields from the form that were previously hidden and filled by javascript.
    * There was a race condition between the form being submitted and the projectKey/repoSlug fields being filled with the javascript.
    * Removing the projectKey/repoSlug fields removes the race condition.
    * Calculate the projectKey/repoSlug on form submission instead
* Add some extra validation to the projectKey/repoSlug fields


![project_repo_dropdown_improved](https://user-images.githubusercontent.com/53158073/64936111-ae73d980-d897-11e9-81ae-b098f738f4ed.gif)
