### PR TITLE
Exclude junit from script-security because of cyclic dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.46</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
We're getting this error:
```
java.lang.Error: Plugin command-launcher failed to start
	at org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive(PluginAutomaticTestBuilder.java:99)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	...
Caused by: hudson.util.CyclicGraphDetector$CycleDetectedException: Cycle detected: Plugin:command-launcher -> Plugin:script-security -> Plugin:junit -> Plugin:bouncycastle-api -> Plugin:command-launcher
	at hudson.PluginManager$1$3$2$1.reactOnCycle(PluginManager.java:490)
	at hudson.PluginManager$1$3$2$1.reactOnCycle(PluginManager.java:466)
	at hudson.util.CyclicGraphDetector.detectedCycle(CyclicGraphDetector.java:64)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:53)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.visit(CyclicGraphDetector.java:54)
	at hudson.util.CyclicGraphDetector.run(CyclicGraphDetector.java:25)
	at hudson.PluginManager$1$3$2.run(PluginManager.java:495)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1120)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	... 3 more
```