### PR TITLE
Fixing webhook related issues

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
@@ -1,7 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketMissingCapabilityException;
-import com.atlassian.bitbucket.jenkins.internal.client.exception.WebhookNotSupportedException;
 import com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
 import okhttp3.HttpUrl;
@@ -29,10 +28,11 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
 
     @Override
     public BitbucketWebhookSupportedEvents getWebhookSupportedEvents() throws BitbucketMissingCapabilityException {
-        AtlassianServerCapabilities capabilities = new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor).getServerCapabilities();
+        AtlassianServerCapabilities capabilities =
+                new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor).getServerCapabilities();
         String urlStr = capabilities.getCapabilities().get(WEBHOOK_CAPABILITY_KEY);
         if (urlStr == null) {
-            throw new WebhookNotSupportedException(
+            throw new BitbucketMissingCapabilityException(
                     "Remote Bitbucket Server does not support Webhooks. Make sure " +
                     "Bitbucket server supports webhooks or correct version of it is installed.");
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -283,7 +283,7 @@ public class BitbucketSCM extends SCM {
         String cloneUrl = getCloneUrl(repository.getMirroringDetails().getCloneUrls());
         BitbucketRepository underlyingRepo = repository.getRepository();
         BitbucketSCMRepository bitbucketSCMRepository =
-                new BitbucketSCMRepository(credentialsId, underlyingRepo.getName(),
+                new BitbucketSCMRepository(credentialsId, underlyingRepo.getProject().getName(),
                         underlyingRepo.getProject().getKey(), underlyingRepo.getName(), underlyingRepo.getSlug(),
                         serverId, repository.getMirroringDetails().getMirrorName());
         initialize(cloneUrl, underlyingRepo.getSelfLink(), bitbucketSCMRepository);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
+import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketMissingCapabilityException;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
 import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
@@ -270,6 +271,14 @@ public class BitbucketClientFactoryImplTest {
         BitbucketWebhookSupportedEvents hookSupportedEvents =
                 anonymousClientFactory.getCapabilityClient().getWebhookSupportedEvents();
         assertThat(hookSupportedEvents.getApplicationWebHooks(), hasItem(REPO_REF_CHANGE.getEventId()));
+    }
+
+    @Test(expected = BitbucketMissingCapabilityException.class)
+    public void testThrowsExceptionIfWebhookCapabilityNotSupported() {
+        mockExecutor.mapUrlToResult(
+                BITBUCKET_BASE_URL + "/rest/capabilities", readFileToString("/capabilities-missing-webhook.json"));
+        BitbucketWebhookSupportedEvents hookSupportedEvents =
+                anonymousClientFactory.getCapabilityClient().getWebhookSupportedEvents();
     }
 
     private BitbucketClientFactoryImpl getClientFactory(

--- a/src/test/resources/capabilities-missing-webhook.json
+++ b/src/test/resources/capabilities-missing-webhook.json
@@ -1,0 +1,23 @@
+{
+  "links": {
+    "self": "http://localhost:7990/bitbucket/rest/capabilities"
+  },
+  "application": "stash",
+  "buildDate": "2019-05-13T07:28:00Z",
+  "capabilities": {
+    "dev-status-detail-repository": "http://localhost:7990/bitbucket/rest/jira-dev/latest/detail/repository",
+    "dev-status-pull-changes": "http://localhost:7990/bitbucket/rest/jira-dev/latest/updated-issues",
+    "atlassian-remote-event-diagnostics-v1": "http://localhost:7990/bitbucket/rest/remote-event/1/status",
+    "bitbucket-remote-event-support": "http://localhost:7990/bitbucket/rest/bitbucket-remote/latest/remote-event-support",
+    "dev-status-summary": "http://localhost:7990/bitbucket/rest/remote-link-aggregation/latest/aggregation",
+    "dev-status-detail-pullrequest": "http://localhost:7990/bitbucket/rest/jira-dev/latest/detail/pullrequest",
+    "remote-link-aggregation": "http://localhost:7990/bitbucket/rest/remote-link-aggregation/1/capabilities",
+    "atlassian-remote-event-status": "http://localhost:7990/bitbucket/rest/remote-event/1/status",
+    "navigation": "http://localhost:7990/bitbucket/rest/capabilities/navigation",
+    "repository-mirroring": "http://localhost:7990/bitbucket/rest/mirroring/latest/capabilities",
+    "code-insights": "http://localhost:7990/bitbucket/rest/insights/latest/capabilities",
+    "smart-commit-producer": "http://localhost:7990/bitbucket/rest/jira-dev/latest/smart-commit",
+    "atlassian-remote-event-consumer": "http://localhost:7990/bitbucket/rest/remote-event-consumer/1/capabilities",
+    "atlassian-remote-event-producer": "http://localhost:7990/bitbucket/rest/remote-event-producer/1/capabilities"
+  }
+}


### PR DESCRIPTION
This should fix the problem with registering webhooks with Bitbucket 5.5 version