### PR TITLE
Guard against empty credentials

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/JenkinsToBitbucketCredentialsImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/JenkinsToBitbucketCredentialsImpl.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import java.util.Base64;
 
 import static com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials.ANONYMOUS_CREDENTIALS;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class JenkinsToBitbucketCredentialsImpl implements JenkinsToBitbucketCredentials {
 
@@ -39,7 +40,7 @@ public class JenkinsToBitbucketCredentialsImpl implements JenkinsToBitbucketCred
     @Override
     public BitbucketCredentials toBitbucketCredentials(@Nullable String credentials,
                                                        BitbucketServerConfiguration serverConfiguration) {
-        if (credentials != null) {
+        if (!isBlank(credentials)) {
             return toBitbucketCredentials(credentials);
         }
         return usingGlobalCredentials(serverConfiguration);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/credentials/JenkinsToBitbucketCredentialsImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/credentials/JenkinsToBitbucketCredentialsImplTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class JenkinsToBitbucketCredentialsImplTest {
@@ -36,6 +36,20 @@ public class JenkinsToBitbucketCredentialsImplTest {
         when(cred.getSecret()).thenReturn(secret);
 
         assertThat(toHeaderValue(cred), is(equalTo("Bearer adminUtiSecretoMaiestatisSignumLepus")));
+    }
+
+    @Test
+    public void testBlankCredentialsUsesFallbaclCredentials() {
+        BitbucketServerConfiguration conf = mock(BitbucketServerConfiguration.class);
+
+        UsernamePasswordCredentials userNamePasswordCred = mock(UsernamePasswordCredentials.class);
+        Secret passwordSecret = SecretFactory.getSecret("password");
+        when(userNamePasswordCred.getPassword()).thenReturn(passwordSecret);
+        when(userNamePasswordCred.getUsername()).thenReturn("username");
+        when(conf.getCredentials()).thenReturn(userNamePasswordCred);
+
+        BitbucketCredentials bbCreds = createInstance().toBitbucketCredentials("  ", conf);
+        assertThat(bbCreds.toHeaderValue(), is(equalTo("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")));
     }
 
     @Test
@@ -101,5 +115,4 @@ public class JenkinsToBitbucketCredentialsImplTest {
     private JenkinsToBitbucketCredentials createInstance() {
         return new JenkinsToBitbucketCredentialsImpl();
     }
-
 }


### PR DESCRIPTION
Somewhere during one of the refactorings, null credentials were converted to empty credentials in BitbucketSCM. This made the client silently not use any credentials (anonymous credentials). This is reproducible when there are no credentials configured on the item. 

Let this be an example for future work for us to handle null towards the edge of the application and use a representation for the absence of value. 