### PR TITLE
JENKINS-59802 Add ID field to BitbucketTokenCredentialsImpl

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl.java
@@ -1,6 +1,5 @@
 package com.atlassian.bitbucket.jenkins.internal.config;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
 import hudson.util.Secret;
@@ -11,6 +10,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
 
+import static com.cloudbees.plugins.credentials.CredentialsScope.SYSTEM;
+
 public class BitbucketTokenCredentialsImpl extends BaseStandardCredentials
         implements BitbucketTokenCredentials {
 
@@ -20,11 +21,10 @@ public class BitbucketTokenCredentialsImpl extends BaseStandardCredentials
 
     @DataBoundConstructor
     public BitbucketTokenCredentialsImpl(
-            @CheckForNull CredentialsScope scope,
             @CheckForNull String id,
             @CheckForNull String description,
             Secret secret) {
-        super(scope, id, description);
+        super(SYSTEM, id, description);
         this.secret = secret;
     }
 

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/config/BitbucketTokenCredentialsImpl/config.groovy
@@ -9,3 +9,7 @@ f.entry(title: _("bitbucket.admin.token"), field: "secret") {
 f.entry(title: _("bitbucket.admin.token.description"), field: "description") {
     f.textbox(placeholder: "To help administrators identify this token")
 }
+
+f.invisibleEntry(field: "id") {
+    f.input(type: "hidden", name: "id", value: "${instance?.id}")
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
@@ -5,7 +5,6 @@ import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfigurat
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentialsImpl;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -107,8 +106,7 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
         CredentialsStore store = CredentialsProvider.lookupStores(jenkins).iterator().next();
         Domain domain = Domain.global();
         Credentials credentials =
-                new BitbucketTokenCredentialsImpl(
-                        CredentialsScope.GLOBAL, credentialId, "", SecretFactory.getSecret(secret));
+                new BitbucketTokenCredentialsImpl(credentialId, "", SecretFactory.getSecret(secret));
         store.addCredentials(domain, credentials);
     }
 }

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketJenkinsRule.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketJenkinsRule.java
@@ -116,8 +116,8 @@ public final class BitbucketJenkinsRule extends JenkinsRule {
             Runtime.getRuntime().addShutdownHook(new BitbucketTokenCleanUpThread(ADMIN_PERSONAL_TOKEN.get().getId()));
         }
         String adminCredentialsId = UUID.randomUUID().toString();
-        Credentials adminCredentials = new BitbucketTokenCredentialsImpl(CredentialsScope.GLOBAL, adminCredentialsId,
-                "", SecretFactory.getSecret(ADMIN_PERSONAL_TOKEN.get().getSecret()));
+        Credentials adminCredentials = new BitbucketTokenCredentialsImpl(adminCredentialsId, "",
+                SecretFactory.getSecret(ADMIN_PERSONAL_TOKEN.get().getSecret()));
         addCredentials(adminCredentials);
 
         if (READ_PERSONAL_TOKEN.get() == null) {


### PR DESCRIPTION
Creating a new token doesn't require an ID to be set, but if one isn't provided when editing then it won't work.