### PR TITLE
JENKINS-60116 reduce required permissions

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -40,7 +40,7 @@ import java.util.*;
 import java.util.logging.Logger;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.RepositoryState.AVAILABLE;
-import static hudson.security.Permission.CONFIGURE;
+import static hudson.model.Item.CONFIGURE;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findProjects;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findRepositories;
-import static hudson.security.Permission.CONFIGURE;
+import static hudson.model.Item.CONFIGURE;
 import static hudson.util.HttpResponses.okJSON;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -19,7 +19,7 @@ import javax.inject.Singleton;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getProjectByNameOrKey;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getRepositoryByNameOrSlug;
-import static hudson.security.Permission.CONFIGURE;
+import static hudson.model.Item.CONFIGURE;
 import static hudson.util.FormValidation.Kind.ERROR;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;


### PR DESCRIPTION
When using the role based plugin you may not want to give overall configure to everyone. This changes the permission to the more correct and restrictive Item.CONFIGURE permission