### PR TITLE
Expose userRemoteConfigs on SCM class

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -278,6 +278,13 @@ public class BitbucketSCM extends SCM {
     public String getServerId() {
         return getBitbucketSCMRepository().getServerId();
     }
+    
+    public List<UserRemoteConfig> getUserRemoteConfigs() {
+        if (gitSCM == null) {
+            return emptyList();
+        }
+        return gitSCM.getUserRemoteConfigs();
+    }
 
     public void setWebhookRegistered(boolean isWebhookRegistered) {
         this.isWebhookRegistered = isWebhookRegistered;


### PR DESCRIPTION
Hi!

We have some global-library accessing scm.userRemoteConfigs during checkout and would be nice to access directly userRemoteConfigs

```
ERROR: groovy.lang.MissingPropertyException: No such property: userRemoteConfigs for class: com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM
```

Regards,