### PR TITLE
JENKSIN-60642 removed all permission check calls made to Jenkins in B…

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -24,7 +24,6 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.scm.*;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
@@ -40,7 +39,6 @@ import java.util.*;
 import java.util.logging.Logger;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.RepositoryState.AVAILABLE;
-import static hudson.model.Item.CONFIGURE;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -374,7 +372,6 @@ public class BitbucketSCM extends SCM {
         @Override
         @POST
         public FormValidation doCheckCredentialsId(@QueryParameter String credentialsId) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formValidation.doCheckCredentialsId(credentialsId);
         }
 
@@ -382,7 +379,6 @@ public class BitbucketSCM extends SCM {
         @POST
         public FormValidation doCheckProjectName(@QueryParameter String serverId, @QueryParameter String credentialsId,
                                                  @QueryParameter String projectName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formValidation.doCheckProjectName(serverId, credentialsId, projectName);
         }
 
@@ -392,14 +388,12 @@ public class BitbucketSCM extends SCM {
                                                     @QueryParameter String credentialsId,
                                                     @QueryParameter String projectName,
                                                     @QueryParameter String repositoryName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formValidation.doCheckRepositoryName(serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
         public FormValidation doCheckServerId(@QueryParameter String serverId) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formValidation.doCheckServerId(serverId);
         }
 
@@ -407,7 +401,6 @@ public class BitbucketSCM extends SCM {
         @POST
         public ListBoxModel doFillCredentialsIdItems(@QueryParameter String baseUrl,
                                                      @QueryParameter String credentialsId) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillCredentialsIdItems(baseUrl, credentialsId);
         }
 
@@ -423,7 +416,6 @@ public class BitbucketSCM extends SCM {
 
         @POST
         public ListBoxModel doFillGitToolItems() {
-            Jenkins.get().checkPermission(CONFIGURE);
             return gitScmDescriptor.doFillGitToolItems();
         }
 
@@ -432,7 +424,6 @@ public class BitbucketSCM extends SCM {
         public HttpResponse doFillProjectNameItems(@QueryParameter String serverId,
                                                    @QueryParameter String credentialsId,
                                                    @QueryParameter String projectName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillProjectNameItems(serverId, credentialsId, projectName);
         }
 
@@ -442,14 +433,12 @@ public class BitbucketSCM extends SCM {
                                                       @QueryParameter String credentialsId,
                                                       @QueryParameter String projectName,
                                                       @QueryParameter String repositoryName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillRepositoryNameItems(serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
         public ListBoxModel doFillServerIdItems(@QueryParameter String serverId) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillServerIdItems(serverId);
         }
 
@@ -460,7 +449,6 @@ public class BitbucketSCM extends SCM {
                                                   @QueryParameter String projectName,
                                                   @QueryParameter String repositoryName,
                                                   @QueryParameter String mirrorName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillMirrorNameItems(serverId, credentialsId, projectName, repositoryName, mirrorName);
         }
 
@@ -471,19 +459,16 @@ public class BitbucketSCM extends SCM {
 
         @Override
         public List<GitSCMExtensionDescriptor> getExtensionDescriptors() {
-            Jenkins.get().checkPermission(CONFIGURE);
             return gitScmDescriptor.getExtensionDescriptors();
         }
 
         @Override
         public List<GitTool> getGitTools() {
-            Jenkins.get().checkPermission(CONFIGURE);
             return gitScmDescriptor.getGitTools();
         }
 
         @Override
         public boolean getShowGitToolOptions() {
-            Jenkins.get().checkPermission(CONFIGURE);
             return gitScmDescriptor.showGitToolOptions();
         }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -32,7 +32,6 @@ import java.util.logging.Logger;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findProjects;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findRepositories;
-import static hudson.model.Item.CONFIGURE;
 import static hudson.util.HttpResponses.okJSON;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
@@ -67,7 +66,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
     @Override
     public ListBoxModel doFillCredentialsIdItems(String baseUrl, String credentialsId) {
         Jenkins instance = Jenkins.get();
-        instance.checkPermission(CONFIGURE);
         if (!instance.hasPermission(Jenkins.ADMINISTER)) {
             return new StandardListBoxModel().includeCurrentValue(credentialsId);
         }
@@ -90,7 +88,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
 
     @Override
     public HttpResponse doFillProjectNameItems(String serverId, String credentialsId, String projectName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         if (isBlank(serverId)) {
             return errorWithoutStack(HTTP_BAD_REQUEST, "A Bitbucket Server serverId must be provided");
         }
@@ -125,7 +122,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
     @Override
     public HttpResponse doFillRepositoryNameItems(String serverId, String credentialsId, String projectName,
                                                   String repositoryName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         if (isBlank(serverId)) {
             return errorWithoutStack(HTTP_BAD_REQUEST, "A Bitbucket Server serverId must be provided");
         }
@@ -162,7 +158,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
 
     @Override
     public ListBoxModel doFillServerIdItems(String serverId) {
-        Jenkins.get().checkPermission(CONFIGURE);
         //Filtered to only include valid server configurations
         StandardListBoxModel model =
                 bitbucketPluginConfiguration.getServerList()
@@ -184,7 +179,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
     @Override
     public ListBoxModel doFillMirrorNameItems(String serverId, String credentialsId, String projectName,
                                               String repositoryName, String mirrorName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         BitbucketMirrorHandler bitbucketMirrorHandler = createMirrorHandlerUsingRepoSearch();
         return bitbucketPluginConfiguration.getServerById(serverId)
                 .map(serverConfiguration ->

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -12,14 +12,12 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.cloudbees.plugins.credentials.Credentials;
 import hudson.util.FormValidation;
-import jenkins.model.Jenkins;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getProjectByNameOrKey;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getRepositoryByNameOrSlug;
-import static hudson.model.Item.CONFIGURE;
 import static hudson.util.FormValidation.Kind.ERROR;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -43,7 +41,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
 
     @Override
     public FormValidation doCheckCredentialsId(String credentialsId) {
-        Jenkins.get().checkPermission(CONFIGURE);
         Credentials providedCredentials = CredentialUtils.getCredentials(credentialsId);
         if (!isBlank(credentialsId) && providedCredentials == null) {
             return FormValidation.error("No credentials exist for the provided credentialsId");
@@ -53,7 +50,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
 
     @Override
     public FormValidation doCheckProjectName(String serverId, String credentialsId, String projectName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         if (isBlank(projectName)) {
             return FormValidation.error("Project name is required");
         }
@@ -87,7 +83,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     @Override
     public FormValidation doCheckRepositoryName(String serverId, String credentialsId, String projectName,
                                                 String repositoryName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         if (isBlank(projectName)) {
             return FormValidation.ok(); // There will be an error on the projectName field
         }
@@ -124,7 +119,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
 
     @Override
     public FormValidation doCheckServerId(String serverId) {
-        Jenkins.get().checkPermission(CONFIGURE);
         // Users can only demur in providing a server name if none are available to select
         if (bitbucketPluginConfiguration.getValidServerList().stream().noneMatch(server -> server.getId().equals(serverId))) {
             return FormValidation.error("Bitbucket instance is required");
@@ -138,7 +132,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     @Override
     public FormValidation doTestConnection(String serverId, String credentialsId, String projectName,
                                            String repositoryName, String mirrorName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         FormValidation serverIdValidation = doCheckServerId(serverId);
         if (serverIdValidation.kind == ERROR) {
             return serverIdValidation;
@@ -173,7 +166,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
 
     private FormValidation doCheckMirrorName(String serverId, String credentialsId, String projectName,
                                              String repositoryName, String mirrorName) {
-        Jenkins.get().checkPermission(CONFIGURE);
         if (isBlank(serverId) || isBlank(projectName) || isBlank(repositoryName)) {
             return FormValidation.ok(); // Validation error would have been in one of the other fields
         }


### PR DESCRIPTION
Addressing https://issues.jenkins-ci.org/browse/JENKINS-60642
The cause of the bug are calls made to the `Jenkins.get().checkPermissions(CONFIGURE)`, which is checking to see whether or not the user has configuration permissions on Jenkins- which requires admin or global write privileges and fails if, for example, they have item privileges from the Role-Based Permissions plugin.
I don't think we need permission checks for the form fill at all, as these checks are being done before the descriptor is even loaded- so they should not even see the rendered groovy page if they don't have item configure permissions, so permission checking seems redundant (and is not used in other plugins such as e.g. GitSCM).
I wasn't quite sure how to write IT tests for this, but I think it needs them so suggestions for that would be appreciated.