### PR TITLE
Added build environment override to SCM

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -175,6 +175,11 @@ public class BitbucketSCM extends SCM {
         return gitTool;
     }
 
+    @Override
+    public void buildEnvironment(Run<?, ?> build, Map<String, String> env) {
+        gitSCM.buildEnvironment(build, env);
+    }
+
     @CheckForNull
     @Override
     public SCMRevisionState calcRevisionsFromBuild(


### PR DESCRIPTION
Addressing https://issues.jenkins-ci.org/browse/JENKINS-60809
This simply adds an override to the buildEnvironment that delegates the job to the GitSCM, making sure git variables in the pipeline are resolved correctly (the default SCM behaviour is to ignore them).