### PR TITLE
JENKINS-60956: Append full name of the `Job` to build status key  along with the build id

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.status;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
+import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
@@ -14,7 +15,9 @@ public final class BitbucketBuildStatusFactory {
     private static final Collection<Result> successfulResults = Arrays.asList(Result.SUCCESS, Result.UNSTABLE);
 
     public static BitbucketBuildStatus fromBuild(Run<?, ?> build) {
-        String key = build.getId();
+        Job<?, ?> parent = build.getParent();
+        String key = parent.getFullName();
+        String name = parent.getFullDisplayName();
         String url = DisplayURLProvider.get().getRunURL(build);
         BuildState state;
         if (build.isBuilding()) {
@@ -27,7 +30,7 @@ public final class BitbucketBuildStatusFactory {
 
         return new BitbucketBuildStatus.Builder(key, state, url)
                 .setDescription(state.getDescriptiveText(build.getDisplayName(), build.getDurationString()))
-                .setName(build.getParent().getName())
+                .setName(name)
                 .build();
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryTest.java
@@ -5,6 +5,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
 import hudson.model.AbstractBuild;
 import hudson.model.Project;
 import hudson.model.Result;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,7 +22,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketBuildStatusFactoryTest {
 
-    private static final String BUILD_ID = "Test ID";
     private static final String BUILD_URL = "http://www.example.com:8000";
     private static final String BUILD_DISPLAY_NAME = "#15";
     private static final String BUILD_DURATION = "400 secs";
@@ -32,16 +32,21 @@ public class BitbucketBuildStatusFactoryTest {
     @Mock
     private AbstractBuild build;
     @Mock
+    private Jenkins parent;
+    @Mock
     private Project project;
 
     @Before
     public void setup() {
-        when(build.getId()).thenReturn(BUILD_ID);
         when(build.getUrl()).thenReturn(BUILD_URL);
         when(build.getDisplayName()).thenReturn(BUILD_DISPLAY_NAME);
         when(build.getDurationString()).thenReturn(BUILD_DURATION);
-        when(build.getProject()).thenReturn(project);
+        when(build.getParent()).thenReturn(project);
         when(project.getName()).thenReturn(PROJECT_NAME);
+        when(project.getDisplayName()).thenReturn(PROJECT_NAME);
+        when(project.getParent()).thenReturn(parent);
+        when(parent.getFullName()).thenReturn("");
+        when(parent.getFullDisplayName()).thenReturn("");
     }
 
     @Test
@@ -73,7 +78,7 @@ public class BitbucketBuildStatusFactoryTest {
         assertThat(result.getName(), equalTo(PROJECT_NAME));
         assertThat(result.getDescription(), equalTo(BuildState.SUCCESSFUL.getDescriptiveText(
                 BUILD_DISPLAY_NAME, BUILD_DURATION)));
-        assertThat(result.getKey(), equalTo(BUILD_ID));
+        assertThat(result.getKey(), equalTo(PROJECT_NAME));
         assertThat(result.getState(), equalTo(BuildState.SUCCESSFUL.toString()));
         assertThat(result.getUrl(), equalTo(DisplayURLProvider.get().getRunURL(build)));
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -14,6 +14,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class BuildStatusPosterTest {
 
+    private static final String PROJECT_NAME = "Project Name";
     private static final String REVISION_SHA1 = "67d71c2133aab0e070fb8100e3e71220332c5af1";
     private static final String SERVER_ID = "FakeServerId";
     private static final String SERVER_URL = "http://www.example.com";
@@ -59,6 +61,8 @@ public class BuildStatusPosterTest {
     @Mock
     private PrintStream logger;
     @Mock
+    private Jenkins parent;
+    @Mock
     private BitbucketPluginConfiguration pluginConfiguration;
     @Mock
     private BitbucketBuildStatusClient postClient;
@@ -73,6 +77,11 @@ public class BuildStatusPosterTest {
 
     @Before
     public void setup() {
+        when(project.getName()).thenReturn(PROJECT_NAME);
+        when(project.getDisplayName()).thenReturn(PROJECT_NAME);
+        when(project.getParent()).thenReturn(parent);
+        when(parent.getFullName()).thenReturn("");
+        when(parent.getFullDisplayName()).thenReturn("");
         when(build.isBuilding()).thenReturn(true);
         when(build.getId()).thenReturn("10");
         when(build.getDurationString()).thenReturn("23 sec");
@@ -127,6 +136,6 @@ public class BuildStatusPosterTest {
         buildStatusPoster.postBuildStatus(build, listener);
         verify(postClient).post(captor.capture());
         BitbucketBuildStatus status = captor.getValue();
-        assertThat(status.getKey(), equalTo(build.getId()));
+        assertThat(status.getKey(), equalTo(PROJECT_NAME));
     }
 }


### PR DESCRIPTION
This is required to keep the build status unique across multiple jobs for the same commit.