### PR TITLE
JENKINS-60917: first webhook build

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -74,8 +74,12 @@ public class BitbucketWebhookConsumer {
     private static Collection<? extends SCM> getScms(ParameterizedJobMixIn.ParameterizedJob<?, ?> job) {
         SCMTriggerItem triggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
         if (triggerItem instanceof WorkflowJob) {
-            if (((WorkflowJob) triggerItem).getDefinition() instanceof CpsScmFlowDefinition) {
-                return Collections.singletonList(((CpsScmFlowDefinition) ((WorkflowJob) triggerItem).getDefinition()).getScm());
+            WorkflowJob workflowJob = (WorkflowJob) triggerItem;
+            if (workflowJob.getDefinition() instanceof CpsScmFlowDefinition) {
+                CpsScmFlowDefinition scmFlowDefinition = (CpsScmFlowDefinition) workflowJob.getDefinition();
+                return Collections.singletonList(scmFlowDefinition.getScm());
+            } else {
+                LOGGER.info(format("Webhook triggering job with no SCM: %s ", workflowJob.getFullDisplayName()));
             }
         } else if (triggerItem != null) {
             return triggerItem.getSCMs();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -20,6 +20,9 @@ import jenkins.plugins.git.GitBranchSCMRevision;
 import jenkins.scm.api.*;
 import jenkins.triggers.SCMTriggerItem;
 import org.eclipse.jgit.transport.RemoteConfig;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -32,6 +35,7 @@ import static java.lang.String.format;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.wrap;
 
 @Singleton
 public class BitbucketWebhookConsumer {
@@ -98,7 +102,11 @@ public class BitbucketWebhookConsumer {
 
     private static Collection<? extends SCM> getScms(ParameterizedJobMixIn.ParameterizedJob<?, ?> job) {
         SCMTriggerItem triggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
-        if (triggerItem != null) {
+        if (triggerItem instanceof WorkflowJob) {
+            if (((WorkflowJob) triggerItem).getDefinition() instanceof CpsScmFlowDefinition) {
+                return Collections.singletonList(((CpsScmFlowDefinition)((WorkflowJob) triggerItem).getDefinition()).getScm());
+            }
+        } else if (triggerItem != null) {
             return triggerItem.getSCMs();
         }
         return Collections.emptySet();


### PR DESCRIPTION
Addressing https://issues.jenkins-ci.org/browse/JENKINS-60917

This is the same issue as JENKINS-60649 but manifesting in the consumer rather than the trigger impl, and the solution is the same (https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/pull/112)
Thanks to Daniel fixing the Java 10 bug with workflow jobs, we can finally func test them! I've added some here, and hope we can do something similar with the rest of our tests.