### PR TITLE
Jenkins OAuth dance integration test

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -1,0 +1,142 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>acceptance-tests</artifactId>
+    <name>Bitbucket Server Integration Plugin Acceptance Tests</name>
+    <description>Includes the integration/acceptance tests for the Bitbucket Server Jenkins integration plugin</description>
+    <packaging>jar</packaging>
+    <version>1.1.1-SNAPSHOT</version>
+
+    <properties>
+        <jenkins.version>2.176.1</jenkins.version>
+        <scribejava.version>6.8.1</scribejava.version>
+        <jackson.version>2.10.3</jackson.version>
+        <groovy.version>2.4.12</groovy.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-apis</artifactId>
+            <version>${scribejava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-core</artifactId>
+            <version>${scribejava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>acceptance-test-harness</artifactId>
+            <version>1.70</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>3.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <environmentVariables>
+                        <!-- Used by Jenkins Acceptance Test Harness -->
+                        <JENKINS_VERSION>${jenkins.version}</JENKINS_VERSION>
+                        <!-- The path to the plugin under test (i.e. the Bitbucket Server integration plugin) -->
+                        <LOCAL_JARS>../target/atlassian-bitbucket-server-integration.hpi</LOCAL_JARS>
+                        <!-- Always update the (local) plugins with the latest snapshot. This is especially useful if
+                        running the tests against an existing (external) Jenkins instance (see readme.md). -->
+                        <LOCAL_SNAPSHOTS>true</LOCAL_SNAPSHOTS>
+                        <!-- This runs Firefox inside a container. To be able to see the browser when running the test
+                        locally, change it to 'firefox' or 'chrome' (or whatever browser of choice).
+                        See https://github.com/jenkinsci/acceptance-test-harness/blob/master/docs/BROWSER.md for more
+                        details and the full list of browsers. -->
+                        <BROWSER>firefox-container</BROWSER>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Do not deploy the acceptance-test module -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- Jenkins Acceptance Test Harness doesn't support Windows -->
+            <id>no-ath-on-win</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/acceptance-tests/readme.md
+++ b/acceptance-tests/readme.md
@@ -1,0 +1,100 @@
+# Acceptance Tests
+
+This module contains the acceptance tests for the Bitbucket Server integration plugin, including the UI tests.
+
+## Running the tests
+
+The Jenkins [Acceptance Test Harness framework](https://github.com/jenkinsci/acceptance-test-harness) runs an instance 
+of Jenkins per test and installs the plugin under test using the `.hpi` file in the `../target` folder, defined using 
+the `LOCAL_JARS` environment variable. For example, using `maven-surefire-plugin`:
+
+```
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>3.0.0-M4</version>
+    <configuration>
+        <reuseForks>false</reuseForks>
+        <environmentVariables>
+            ...
+            <LOCAL_JARS>../target/atlassian-bitbucket-server-integration.hpi</LOCAL_JARS>
+            ...
+        </environmentVariables>
+    </configuration>
+</plugin>
+```
+
+To build the `.hpi` file, build the plugin from the project root folder:
+
+```
+mvn clean package -DskipTests
+```
+
+---
+If you see the following error when running the tests, it means you haven't built the plugin:
+
+```
+java.lang.IllegalArgumentException: Unable to honor LOCAL_JARS environment variable
+
+	at org.jenkinsci.test.acceptance.update_center.LocalOverrideUpdateCenterMetadataDecoratorImpl.decorate(LocalOverrideUpdateCenterMetadataDecoratorImpl.java:83)
+	at org.jenkinsci.test.acceptance.update_center.CachedUpdateCenterMetadataLoader.get(CachedUpdateCenterMetadataLoader.java:48)
+	at org.jenkinsci.test.acceptance.update_center.MockUpdateCenter.ensureRunning(MockUpdateCenter.java:100)
+	at org.jenkinsci.test.acceptance.po.PluginManager.checkForUpdates(PluginManager.java:87)
+	at org.jenkinsci.test.acceptance.po.PluginManager.installPlugins(PluginManager.java:182)
+...
+Caused by: java.lang.IllegalArgumentException: Plugin file does not exist: <path-to-project-root->/acceptance-tests/../target/atlassian-bitbucket-server-integration.hpi
+	at org.jenkinsci.test.acceptance.update_center.LocalOverrideUpdateCenterMetadataDecoratorImpl.override(LocalOverrideUpdateCenterMetadataDecoratorImpl.java:91)
+	at org.jenkinsci.test.acceptance.update_center.LocalOverrideUpdateCenterMetadataDecoratorImpl.decorate(LocalOverrideUpdateCenterMetadataDecoratorImpl.java:81)
+	... 27 more
+```
+---
+
+Then run the tests from inside the `acceptance-tests` folder:
+
+```
+cd acceptance-tests
+mvn test
+```
+
+This will run all the tests.
+
+You can also run individual tests inside Intellij as usual.
+
+## Running against an existing Jenkins instance
+
+Having the test framework start up and set up a Jenkins instance per test is very slow, so sometimes we might want to 
+run the tests against an external running instance of Jenkins. To do that, use the following environment variables:
+
+```
+TYPE=existing
+JENKINS_URL=<jenkins-instance-url> (e.g. http://localhost:8080/)
+```
+
+(e.g. if running the tests from inside Intellij, pass the environment variables in the run configuration)
+This is, for example, handy when developing new tests and having to run the test over and over again, so that you don't 
+have to wait for Jenkins to startup every single time.
+
+### Running an external Jenkins instance for testing
+
+Unfortunately, running a vanilla Jenkins instance (e.g. using a downloaded `war` or the maven `hpi` plugin) won't work 
+because of some missing plugins that the Jenkins acceptance test framework seems to rely on, e.g.:
+
+```
+java.lang.RuntimeException: Test suite requires in pre-installed Jenkins plugin https://wiki.jenkins-ci.org/display/JENKINS/Form+Element+Path+Plugin
+```
+
+The surest way to run a Jenkins instance for these tests is to clone the Jenkins 
+[Acceptance Test Harness framework](https://github.com/jenkinsci/acceptance-test-harness) and run the `jut-server.sh` script:
+
+```
+git clone git@github.com:jenkinsci/acceptance-test-harness.git
+cd acceptance-test-harness
+./jut-server.sh
+```
+
+For more details see: [prelaunching Jenkins under test](https://github.com/jenkinsci/acceptance-test-harness/blob/master/docs/PRELAUNCH.md)
+
+## Developing new tests
+
+The `acceptance-tests` Maven module may not be automatically picked up and imported by Intellij when you import the 
+project. To import the module, right click on the `pom.xml` in the `acceptance-tests` module and click `Add as Maven Project`.

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsApplinksClient.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsApplinksClient.java
@@ -1,0 +1,49 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.model.OAuthConsumer;
+
+import static io.restassured.http.ContentType.URLENC;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+
+public class JenkinsApplinksClient {
+
+    private static final String CREATE_OAUTH_CONSUMER_PATH = "/bbs-oauth/create/performCreate";
+
+    private final ObjectMapper jsonSerializer = new ObjectMapper();
+
+    private final String baseUrl;
+
+    public JenkinsApplinksClient(String baseUrl) {
+        this.baseUrl = removeEnd(baseUrl, "/");
+    }
+
+    public OAuthConsumer createOAuthConsumer() throws JsonProcessingException {
+        OAuthConsumer consumer = newConsumer();
+        String consumerCreateUri = absoluteUrl(CREATE_OAUTH_CONSUMER_PATH);
+        RestAssured.given()
+                .contentType(URLENC)
+                .formParam("json", jsonSerializer.writeValueAsString(consumer))
+                .when()
+                .post(consumerCreateUri)
+                .then()
+                .statusCode(302);
+        return consumer;
+    }
+
+    private OAuthConsumer newConsumer() {
+        String uniqueConsumerIdentifier = randomNumeric(8);
+        return new OAuthConsumer("test-consumer" + uniqueConsumerIdentifier,
+                "Test Consumer " + uniqueConsumerIdentifier, randomAlphanumeric(10),
+                "http://whatever.com/redirect" + uniqueConsumerIdentifier);
+    }
+
+    private String absoluteUrl(String relativeUrl) {
+        return baseUrl + "/" + removeStart(relativeUrl, "/");
+    }
+}

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsOAuthApi.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsOAuthApi.java
@@ -1,0 +1,36 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.client;
+
+import com.github.scribejava.core.builder.api.DefaultApi10a;
+import com.github.scribejava.core.services.HMACSha1SignatureService;
+import com.github.scribejava.core.services.SignatureService;
+
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+
+public class JenkinsOAuthApi extends DefaultApi10a {
+
+    private final String baseUrl;
+
+    public JenkinsOAuthApi(String baseUrl) {
+        this.baseUrl = removeEnd(baseUrl, "/") + "/";
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return baseUrl + "bitbucket/oauth/access-token";
+    }
+
+    @Override
+    protected String getAuthorizationBaseUrl() {
+        return baseUrl + "bbs-oauth/authorize";
+    }
+
+    @Override
+    public String getRequestTokenEndpoint() {
+        return baseUrl + "bitbucket/oauth/request-token";
+    }
+
+    @Override
+    public SignatureService getSignatureService() {
+        return new HMACSha1SignatureService();
+    }
+}

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsOAuthClient.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/client/JenkinsOAuthClient.java
@@ -1,0 +1,40 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.client;
+
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.model.OAuth1AccessToken;
+import com.github.scribejava.core.model.OAuth1RequestToken;
+import com.github.scribejava.core.oauth.OAuth10aService;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class JenkinsOAuthClient {
+
+    private final OAuth10aService oAuthService;
+
+    public JenkinsOAuthClient(String baseUrl, String consumerKey, String consumerSecret) {
+        oAuthService = new ServiceBuilder(consumerKey)
+                .apiSecret(consumerSecret)
+                .build(new JenkinsOAuthApi(baseUrl));
+    }
+
+    public OAuth1RequestToken getRequestToken() {
+        try {
+            return oAuthService.getRequestToken();
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getAuthorizationUrl(OAuth1RequestToken requestToken) {
+        return oAuthService.getAuthorizationUrl(requestToken);
+    }
+
+    public OAuth1AccessToken getAccessToken(OAuth1RequestToken requestToken, String oauthVerifier) {
+        try {
+            return oAuthService.getAccessToken(requestToken, oauthVerifier);
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/model/OAuthConsumer.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/model/OAuthConsumer.java
@@ -1,0 +1,44 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OAuthConsumer {
+
+    private final String key;
+    private final String name;
+    private final String secret;
+    private final String callback;
+
+    @JsonCreator
+    public OAuthConsumer(@JsonProperty("consumerKey") String key,
+                         @JsonProperty("consumerName") String name,
+                         @JsonProperty("consumerSecret") String secret,
+                         @JsonProperty("callbackUrl") String callback) {
+        this.key = key;
+        this.name = name;
+        this.secret = secret;
+        this.callback = callback;
+    }
+
+    @JsonGetter("consumerKey")
+    public String getKey() {
+        return key;
+    }
+
+    @JsonGetter("consumerName")
+    public String getName() {
+        return name;
+    }
+
+    @JsonGetter("consumerSecret")
+    public String getSecret() {
+        return secret;
+    }
+
+    @JsonGetter("callbackUrl")
+    public String getCallback() {
+        return callback;
+    }
+}

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/pageobjects/AuthorizeTokenPage.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/pageobjects/AuthorizeTokenPage.java
@@ -1,0 +1,87 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.pageobjects;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.jenkinsci.test.acceptance.junit.Wait;
+import org.jenkinsci.test.acceptance.po.CapybaraPortingLayer;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.po.PageObject;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.net.URI;
+import java.net.URL;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+/**
+ * The page where user authorizes an OAuth request token.
+ */
+public class AuthorizeTokenPage extends PageObject {
+
+    public static final long TIMEOUT_SECONDS = 5L;
+
+    private final String requestToken;
+
+    public AuthorizeTokenPage(Jenkins context, URL pageUrl, String requestTokenValue) {
+        super(context, pageUrl);
+        this.requestToken = requestTokenValue;
+    }
+
+    /**
+     * Authorizes the request token and returns the {@code oauth_verifier} query parameter from the redirect URL
+     *
+     * @return the {@code oauth_verifier} query parameter from the redirect URL after authorizing the token
+     */
+    public String authorize() {
+        openAndVerify();
+        control(By.cssSelector("span[name=\"authorize\"] > span.first-child > button")).click();
+        return waitWithTimeout()
+                .withMessage("Redirect URL must contain the 'oauth_verifier' query param")
+                .until(() -> URLEncodedUtils.parse(URI.create(getCurrentUrl()), UTF_8).stream()
+                        .filter(nvp -> "oauth_verifier".equalsIgnoreCase(nvp.getName()))
+                        .findFirst()
+                        .map(NameValuePair::getValue)
+                        .orElseThrow(() ->
+                                new AssertionError("Redirect url must contain an 'oauth_verifier' query parameter")));
+    }
+
+    /**
+     * Cancels (denies) the authorization and checks that the {@code oauth_verifier} query parameter in the redirect URL
+     * has the value {@code 'denied'}
+     */
+    public void cancel() {
+        openAndVerify();
+        control(By.cssSelector("span[name=\"cancel\"] > span.first-child > button")).click();
+        String oAuthVerifier = waitWithTimeout()
+                .withMessage("Redirect URL must contain the 'oauth_verifier' query param")
+                .until(() -> URLEncodedUtils.parse(URI.create(getCurrentUrl()), UTF_8).stream()
+                        .filter(nvp -> "oauth_verifier".equalsIgnoreCase(nvp.getName()))
+                        .findFirst()
+                        .map(NameValuePair::getValue)
+                        .orElseThrow(() ->
+                                new AssertionError("Redirect url must contain an 'oauth_verifier' query parameter")));
+        assertThat(oAuthVerifier, equalToIgnoringWhiteSpace("denied"));
+    }
+
+    private void openAndVerify() {
+        open();
+        String requestTokenValue = waitWithTimeout()
+                .withMessage("Authorize page must contain a hidden input holding the request token value")
+                .until(() -> {
+                    WebElement oauthToken =
+                            driver.findElement(By.cssSelector("input.setting-input[name=\"oauth_token\"]"));
+                    return ofNullable(oauthToken).map(ot -> ot.getAttribute("value")).orElse(null);
+                });
+        assertThat("Request token to be authorized has the wrong value", requestTokenValue,
+                equalToIgnoringWhiteSpace(requestToken));
+    }
+
+    private Wait<CapybaraPortingLayer> waitWithTimeout() {
+        return waitFor().withTimeout(TIMEOUT_SECONDS, SECONDS);
+    }
+}

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/Applinks3LOAuthTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/Applinks3LOAuthTest.java
@@ -1,0 +1,84 @@
+package it.com.atlassian.bitbucket.jenkins.internal.applink.oauth;
+
+import com.github.scribejava.core.model.OAuth1AccessToken;
+import com.github.scribejava.core.model.OAuth1RequestToken;
+import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.client.JenkinsApplinksClient;
+import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.client.JenkinsOAuthClient;
+import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.model.OAuthConsumer;
+import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.pageobjects.AuthorizeTokenPage;
+import org.jenkinsci.test.acceptance.controller.JenkinsController;
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.jenkinsci.test.acceptance.po.JenkinsDatabaseSecurityRealm;
+import org.jenkinsci.test.acceptance.po.Login;
+import org.jenkinsci.test.acceptance.po.User;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.net.URI;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
+import static org.junit.Assert.assertNotNull;
+
+@WithPlugins({"mailer", "matrix-auth", "atlassian-bitbucket-server-integration"})
+public class Applinks3LOAuthTest extends AbstractJUnitTest {
+
+    @Inject
+    private JenkinsController controller;
+
+    private JenkinsApplinksClient applinksClient;
+    private JenkinsOAuthClient oAuthClient;
+    private OAuthConsumer oAuthConsumer;
+    private User stashUser;
+
+    @Before
+    public void setup() throws Exception {
+        applinksClient = new JenkinsApplinksClient(getBaseUrl());
+        oAuthConsumer = applinksClient.createOAuthConsumer();
+        oAuthClient = new JenkinsOAuthClient(getBaseUrl(), oAuthConsumer.getKey(), oAuthConsumer.getSecret());
+
+        // Enable security
+        GlobalSecurityConfig sc = new GlobalSecurityConfig(jenkins);
+        sc.configure();
+        JenkinsDatabaseSecurityRealm realm = sc.useRealm(JenkinsDatabaseSecurityRealm.class);
+        realm.allowUsersToSignUp(true);
+        sc.save();
+
+        stashUser = realm.signup("bbsuser" + randomNumeric(8));
+    }
+
+    @Test
+    public void testOAuthDance() throws Exception {
+        login(stashUser);
+
+        OAuth1RequestToken requestToken = oAuthClient.getRequestToken();
+        assertNotNull(requestToken);
+        assertThat(requestToken.getToken(), not(isEmptyOrNullString()));
+
+        String authzUrl = oAuthClient.getAuthorizationUrl(requestToken);
+        String oAuthVerifier = new AuthorizeTokenPage(jenkins, URI.create(authzUrl).toURL(), requestToken.getToken())
+                .authorize();
+
+        OAuth1AccessToken accessToken = oAuthClient.getAccessToken(requestToken, oAuthVerifier);
+        assertNotNull(accessToken);
+        assertThat(accessToken.getToken(), not(isEmptyOrNullString()));
+    }
+
+    private void login(User user) {
+        Login login = jenkins.login().doLogin(user);
+        waitFor(login)
+                .withTimeout(10, SECONDS)
+                .until(loggedInAs(user.fullName()));
+    }
+
+    private String getBaseUrl() {
+        return controller.getUrl().toString();
+    }
+}


### PR DESCRIPTION
Adds the following:
- the `acceptance-tests` module/sub-directory to the repo
- a dependency on the Jenkins `acceptance-test-harness` framework inside that module + some other dependencies needed for the acceptance tests
- a page object for the OAuth (request token) authorization page
- an acceptance test that simulates an OAuth dance by an end user:
-- get a new request token using the `/request-token` rest endpoint
-- redirect to the OAuth authorize page where user would authorize the request token
-- use the authorized request token to get an access token from the `/access-token` rest endpoint

I'll raise a separate PR for testing matrix-based authorization of resources via the OAuth `AuthorizeServlet`.