### PR TITLE
JENKINS-61915: Only reject servers whose name ends with bitbucket.org

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketServerConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketServerConfiguration.java
@@ -229,7 +229,7 @@ public class BitbucketServerConfiguration
             if (isBlank(base.getHost())) {
                 return FormValidation.error(
                         "This isn't a valid URL. Check for typos and make sure to include http:// or https://");
-            } else if (base.getHost().contains("bitbucket.org")) {
+            } else if (base.getHost().endsWith("bitbucket.org")) {
                 return FormValidation.error("This plugin does not support connecting to bitbucket.org. It is for Bitbucket Server instances only.");
             }
         } catch (MalformedURLException e) {


### PR DESCRIPTION
Hello,

Our internal infrastructure is set up in a way that conflicts with the plugin. Bitbucket.org is part of the name of the host but it is a server installation.

I changed the check to look at the end of the hostname instead of whether it is in the name.
