### PR TITLE
post the correct ref name to bitbucket

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketRefNameExtractor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketRefNameExtractor.java
@@ -1,0 +1,25 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.model.Run;
+
+/**
+ * Extracts the ref name from a given {@code branchSpec}, which can contain different values based on what type of
+ * {@link Run build} is running
+ *
+ * @see BitbucketRefNameExtractorFactory
+ */
+public interface BitbucketRefNameExtractor {
+
+    /**
+     * Extracts the ref name from the given {@code branchSpec}
+     * <p>
+     * Based on the build type, the {@code branchSpec} may be prepended with {@code '<repository-name>/'}, in which case
+     * the {@code repositoryName} and the leading '/' are removed from the beginning of the {@code branchSpec} and the
+     * branch name is returned. Otherwise, the branchSpec is returned unchanged.
+     *
+     * @param branchSpec     the {@code branchSpec} to extract the branch name from
+     * @param repositoryName the name of the SCM repository (that the {@code branchSpec} may be prepended with)
+     * @return the branch name, with the {@code repositoryName} prefix removed if necessary
+     */
+    String extractRefName(String branchSpec, String repositoryName);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketRefNameExtractorFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketRefNameExtractorFactory.java
@@ -1,0 +1,60 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Run;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+
+/**
+ * Factory class for {@link BitbucketRefNameExtractor}
+ */
+public class BitbucketRefNameExtractorFactory {
+
+    /**
+     * Returns the proper {@link BitbucketRefNameExtractor} implementation based on the {@link Run job type}
+     * <p>
+     * The {@link Branch#getName() branch names} inside the {@link Revision} instance passed in to
+     * {@link GitSCMExtension} when invoked by {@link GitSCM} can look different for the same branch, based on the build
+     * type (e.g. {@link FreeStyleBuild free-style} vs. {@link WorkflowRun multi-branch builds}), which is why we need a
+     * different implementation of this interface for different build types.
+     *
+     * @param buildType the type of the build being run
+     * @return the {@link BitbucketRefNameExtractor} implementation for the given build type
+     */
+    public BitbucketRefNameExtractor forBuildType(@SuppressWarnings("rawtypes") Class<? extends Run> buildType) {
+        if (WorkflowRun.class.isAssignableFrom(requireNonNull(buildType, "buildType"))) {
+            return new WorkflowRunBitbucketRefNameExtractor();
+        }
+        return new DefaultBitbucketRefNameExtractor();
+    }
+
+    /**
+     * The default implementation that expects the {@code branchSpec} to be prepended with the {@code repositoryName}
+     */
+    private static final class DefaultBitbucketRefNameExtractor implements BitbucketRefNameExtractor {
+
+        @Override
+        public String extractRefName(String branchSpec, String repositoryName) {
+            return removeStart(branchSpec, requireNonNull(repositoryName, "repositoryName") + "/");
+        }
+    }
+
+    /**
+     * The {@link BitbucketRefNameExtractor} implementation for the {@link WorkflowRun multi-branch build type}
+     */
+    @VisibleForTesting
+    static final class WorkflowRunBitbucketRefNameExtractor implements BitbucketRefNameExtractor {
+
+        @Override
+        public String extractRefName(String branchSpec, String repositoryName) {
+            return branchSpec;
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -74,7 +74,7 @@ public class BitbucketSCM extends SCM {
             @CheckForNull String repositoryName,
             @CheckForNull String serverId,
             @CheckForNull String mirrorName) {
-        this(id, branches, extensions, gitTool, serverId);
+        this(id, branches, extensions, gitTool, serverId, repositoryName);
 
         DescriptorImpl descriptor = (DescriptorImpl) getDescriptor();
         Optional<BitbucketServerConfiguration> mayBeServerConf = descriptor.getConfiguration(serverId);
@@ -134,7 +134,7 @@ public class BitbucketSCM extends SCM {
             @CheckForNull String gitTool,
             @CheckForNull String serverId,
             BitbucketRepository repository) {
-        this(id, branches, extensions, gitTool, serverId);
+        this(id, branches, extensions, gitTool, serverId, repository.getName());
         setRepositoryDetails(credentialsId, serverId, "", repository);
     }
 
@@ -153,7 +153,8 @@ public class BitbucketSCM extends SCM {
             @CheckForNull List<BranchSpec> branches,
             @CheckForNull List<GitSCMExtension> extensions,
             @CheckForNull String gitTool,
-            @CheckForNull String serverId) {
+            @CheckForNull String serverId,
+            String repositoryName) {
         this.id = isBlank(id) ? UUID.randomUUID().toString() : id;
         this.branches = new ArrayList<>();
         this.extensions = new ArrayList<>();
@@ -167,7 +168,7 @@ public class BitbucketSCM extends SCM {
             this.extensions.addAll(extensions);
         }
         if (!isBlank(serverId)) {
-            this.extensions.add(new BitbucketPostBuildStatus(serverId));
+            this.extensions.add(new BitbucketPostBuildStatus(serverId, repositoryName));
         }
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -201,7 +201,7 @@ public class BitbucketSCMSource extends SCMSource {
         repository = bitbucketSCMRepository;
         UserRemoteConfig remoteConfig =
                 new UserRemoteConfig(cloneUrl, bitbucketSCMRepository.getRepositorySlug(), null, bitbucketSCMRepository.getCredentialsId());
-        gitSCMSource = new CustomGitSCMSource(remoteConfig.getUrl(), serverId);
+        gitSCMSource = new CustomGitSCMSource(remoteConfig.getUrl(), serverId, bitbucketSCMRepository.getRepositoryName());
         gitSCMSource.setTraits(traits);
         gitSCMSource.setCredentialsId(bitbucketSCMRepository.getCredentialsId());
     }
@@ -435,10 +435,12 @@ public class BitbucketSCMSource extends SCMSource {
     private static class CustomGitSCMSource extends GitSCMSource {
 
         private final String serverId;
+        private final String repositoryName;
 
-        public CustomGitSCMSource(String remote, @Nullable String serverId) {
+        public CustomGitSCMSource(String remote, @Nullable String serverId, String repositoryName) {
             super(remote);
             this.serverId = serverId == null ? "" : serverId;
+            this.repositoryName = repositoryName;
         }
 
         public void accessibleRetrieve(@CheckForNull SCMSourceCriteria criteria, SCMHeadObserver observer,
@@ -449,7 +451,7 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         public List<GitSCMExtension> getExtensions() {
-            return Collections.singletonList(new BitbucketPostBuildStatus(serverId));
+            return Collections.singletonList(new BitbucketPostBuildStatus(serverId, repositoryName));
         }
     }
 }


### PR DESCRIPTION
Based on the build type, the branch name we get from the `Revision` instance passed in to
`GitSCMExtension` (when invoked by `GitSCM`) can look different for the same branch: for most build types (e.g. `FreeStyleBuild`), the branch name is prefixed with `<repo-name>/`, but for multi-branch builds (` WorkflowRun`), the branch name is not prefixed with the repo name.
So, we check for the build type and extract the branch name accordingly, then prefix it with `refs/heads/` before including it in the data we post back to Bitbucket in `BitbucketPostBuildStatus`.