### PR TITLE
Jenkins version upgraded to 2.190

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -16,7 +16,7 @@
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
         <jenkins.acceptance-test-harness.version>1.71</jenkins.acceptance-test-harness.version>
         <httpclient.version>4.5.10</httpclient.version>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>2.4.12</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <properties>
         <bitbucket.version>5.5.9</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
-        <disableTestInjection>false</disableTestInjection>
+        <disableTestInjection>true</disableTestInjection>
+        <surefireTestExclusions>nothing-to-exclude</surefireTestExclusions>
         <java.level>8</java.level>
         <jackson.version>2.9.9</jackson.version>
         <jenkins.version>2.190.1</jenkins.version>
@@ -271,6 +272,7 @@
                          exclude integration tests here. -->
                     <excludes>
                         <exclude>it/**/*.java</exclude>
+                        <exclude>${surefireTestExclusions}</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -416,6 +418,15 @@
                     </plugin>
                 </plugins>
             </reporting>
+        </profile>
+        <profile>
+            <!-- The Injected Tests are causing issues with Mockito with Java 11 on this version of the plugin, so they
+            are disabled by default. For full test coverage, this should profile should be run as well.-->
+            <id>injectedTests</id>
+            <properties>
+                <disableTestInjection>false</disableTestInjection>
+                <surefireTestExclusions>com/**/*.java</surefireTestExclusions>
+            </properties>
         </profile>
         <profile>
             <id>it</id>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <disableTestInjection>false</disableTestInjection>
         <java.level>8</java.level>
         <jackson.version>2.9.9</jackson.version>
-        <jenkins.version>2.162</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
     </properties>
@@ -164,6 +164,26 @@
             <artifactId>instance-identity</artifactId>
             <version>2.2</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.26</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,13 @@
         <bitbucket.version>5.5.9</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
-        <surefireTestExclusions>nothing-to-exclude</surefireTestExclusions>
+        <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.9.9</jackson.version>
         <jenkins.version>2.190.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
+        <surefireTestExclusions>nothing-to-exclude</surefireTestExclusions>
     </properties>
     <name>Bitbucket Server Integration</name>
     <description>This Jenkins plugin streamlines configuring Jenkins jobs to clone/fetch from Bitbucket Server.</description>
@@ -180,13 +181,13 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.2</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.41</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -165,26 +165,6 @@
             <version>2.2</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.26</version>
-        </dependency>
 
         <dependency>
             <groupId>net.oauth.core</groupId>
@@ -195,6 +175,18 @@
             <groupId>net.oauth.core</groupId>
             <artifactId>oauth-provider</artifactId>
             <version>${net.oauth.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The plugin enables this in two ways. It adds a Bitbucket Server Source Code Mana
 ## Requirements
 
 - Bitbucket Server 5.5 and above
-- Jenkins 2.162 and above
+- Jenkins 2.190.1 and above
 
 ## Plugin features
 


### PR DESCRIPTION
This is necessary for our SSH work, but I've been warned about version issues even on master, so we should update our latest version (and document it) before we release 1.1.1