### PR TITLE
JENKINS-60116: Allow 'EXTENDED_READ' permission to select credentials

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -13,6 +13,7 @@ import com.google.inject.Guice;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -27,6 +28,7 @@ import hudson.scm.*;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -413,9 +415,10 @@ public class BitbucketSCM extends SCM {
 
         @Override
         @POST
-        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String baseUrl,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
+                                                     @QueryParameter String baseUrl,
                                                      @QueryParameter String credentialsId) {
-            return formFill.doFillCredentialsIdItems(baseUrl, credentialsId);
+            return formFill.doFillCredentialsIdItems(context, baseUrl, credentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -9,13 +9,19 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.trigger.RetryingWebhookHandler;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.model.TaskListener;
+import hudson.model.queue.Tasks;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.scm.SCM;
+import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
@@ -27,6 +33,8 @@ import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.UncategorizedSCMHeadCategory;
 import jenkins.scm.impl.form.NamedArrayList;
 import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -311,10 +319,10 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         @POST
-        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String baseUrl,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
+                                                     @QueryParameter String baseUrl,
                                                      @QueryParameter String credentialsId) {
-            Jenkins.get().checkPermission(CONFIGURE);
-            return formFill.doFillCredentialsIdItems(baseUrl, credentialsId);
+            return formFill.doFillCredentialsIdItems(context, baseUrl, credentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -12,6 +12,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.model.RepositoryState;
 import com.google.inject.Guice;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
@@ -20,6 +21,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.steps.scm.SCMStep;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -261,9 +263,10 @@ public class BitbucketSCMStep extends SCMStep {
 
         @Override
         @POST
-        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String baseUrl,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
+                                                     @QueryParameter String baseUrl,
                                                      @QueryParameter String credentialsId) {
-            return formFill.doFillCredentialsIdItems(baseUrl, credentialsId);
+            return formFill.doFillCredentialsIdItems(context, baseUrl, credentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFill.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFill.java
@@ -1,15 +1,17 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import hudson.model.Item;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.util.ListBoxModel;
 import org.kohsuke.stapler.HttpResponse;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public interface BitbucketScmFormFill {
 
-    ListBoxModel doFillCredentialsIdItems(String baseUrl, String credentialsId);
+    ListBoxModel doFillCredentialsIdItems(@Nullable Item context, String baseUrl, String credentialsId);
 
     HttpResponse doFillProjectNameItems(String serverId, String credentialsId, String projectName);
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -14,6 +14,7 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import hudson.model.Item;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.security.ACL;
@@ -24,6 +25,7 @@ import net.sf.json.JSONArray;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.HttpResponse;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Collection;
@@ -64,9 +66,11 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
     }
 
     @Override
-    public ListBoxModel doFillCredentialsIdItems(String baseUrl, String credentialsId) {
+    public ListBoxModel doFillCredentialsIdItems(@Nullable Item context, String baseUrl, String credentialsId) {
         Jenkins instance = Jenkins.get();
-        if (!instance.hasPermission(Jenkins.ADMINISTER)) {
+
+        if (context == null && !instance.hasPermission(Jenkins.ADMINISTER) ||
+                context != null && !context.hasPermission(Item.EXTENDED_READ)) {
             return new StandardListBoxModel().includeCurrentValue(credentialsId);
         }
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
@@ -4,6 +4,7 @@ import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryPro
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketMockJenkinsRule;
+import hudson.model.Item;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,8 @@ public class BitbucketSCMDescriptorTest {
     private BitbucketPluginConfiguration bitbucketPluginConfiguration;
     @Mock
     private JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
+    @Mock
+    private Item item;
 
     @Test
     public void testDoCheckCredentialsId() {
@@ -61,8 +64,8 @@ public class BitbucketSCMDescriptorTest {
 
     @Test
     public void testDoFillCredentialsIdItems() {
-        descriptor.doFillCredentialsIdItems("myBaseUrl", "myCredentialsId");
-        verify(formFill).doFillCredentialsIdItems("myBaseUrl", "myCredentialsId");
+        descriptor.doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
+        verify(formFill).doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import hudson.model.Item;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -18,6 +19,8 @@ public class BitbucketSCMStepDescriptorTest {
     private BitbucketScmFormFillDelegate formFill;
     @Mock
     private BitbucketScmFormValidationDelegate formValidation;
+    @Mock
+    private Item item;
 
     @Test
     public void testDoCheckCredentialsId() {
@@ -45,8 +48,8 @@ public class BitbucketSCMStepDescriptorTest {
 
     @Test
     public void testDoFillCredentialsIdItems() {
-        descriptor.doFillCredentialsIdItems("myBaseUrl", "myCredentialsId");
-        verify(formFill).doFillCredentialsIdItems("myBaseUrl", "myCredentialsId");
+        descriptor.doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
+        verify(formFill).doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
     }
 
     @Test


### PR DESCRIPTION
Although JENKINS-60116 already has been closed in November 2019, the faulted
behaviour has not actually been fixed yet as reported by users in that ticket
this year and reproduced by myself.

The method `BitbucketSCMSource.DescriptorImpl.doFillCredentialsIdItems` was
obviously still doing a check for the global 'CONFIGURE' permissions (which
already explains the wrong behaviour and is redundant to the checks in the
called method `BitbucketScmFormFillDelegate.doFillCredentialsIdItems` anyway).

This commit adds the wanted behaviour of a context (item) based permission
check. If a context is given, only the `Item.EXTENDED_READ` permission is
required which follows the approach used by other SCM plugins (Git, Subversion).
Furthermore, the redundant checks are removed and the tests have been adjusted,
to use a mock of the now necessary context parameter.