### PR TITLE
Switched from displayURL to Jenkins.getRootUrl

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
@@ -3,13 +3,14 @@ package com.atlassian.bitbucket.jenkins.internal.status;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
 import com.atlassian.bitbucket.jenkins.internal.model.TestResults;
+import com.atlassian.bitbucket.jenkins.internal.provider.DefaultJenkinsProvider;
+import com.atlassian.bitbucket.jenkins.internal.provider.JenkinsProvider;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.junit.TestResultAction;
 import jenkins.branch.MultiBranchProject;
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -19,14 +20,14 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
 
     private static final Collection<Result> successfulResults = Arrays.asList(Result.SUCCESS, Result.UNSTABLE);
 
-    private final DisplayURLProvider displayURLProvider;
+    private final JenkinsProvider jenkinsProvider;
 
     public BitbucketBuildStatusFactoryImpl() {
-        this(DisplayURLProvider.get());
+        this(new DefaultJenkinsProvider());
     }
 
-    BitbucketBuildStatusFactoryImpl(DisplayURLProvider displayURLProvider) {
-        this.displayURLProvider = displayURLProvider;
+    BitbucketBuildStatusFactoryImpl(JenkinsProvider jenkinsProvider) {
+        this.jenkinsProvider = jenkinsProvider;
     }
 
     @Override
@@ -42,7 +43,7 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
     private BitbucketBuildStatus fromBuild(Run<?, ?> build, boolean isRich) {
         Job<?, ?> job = build.getParent();
         String key = job.getFullName();
-        String url = displayURLProvider.getRunURL(build);
+        String url = jenkinsProvider.get().getRootUrl() + build.getUrl();
         BuildState state;
         if (build.isBuilding()) {
             state = BuildState.INPROGRESS;

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
@@ -266,7 +266,7 @@ public class BuildStatusPosterIT {
                                        "\"parent\":\"%s\"," +
                                        "\"ref\":\"%s\"," +
                                        "\"state\":\"%s\"," +
-                                       "\"url\":\"%s%sdisplay/redirect\"" +
+                                       "\"url\":\"%s%s\"" +
                                        "}",
                                         build.getId(),
                                         buildState.getDescriptiveText(build.getDisplayName(), build.getDurationString()),


### PR DESCRIPTION
This removes the "display/redirect" from the end of build URL status. This means we can use it directly for link generation, rather than having to fiddle with the build keys 