### PR TITLE
Bump depenendencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.6</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -17,7 +17,7 @@
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.11.2</jackson.version>
         <jenkins.version>2.190.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.1</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Update jackson version to fix security vulnerabilities.
Update parent pom to get latest enforcer rules and prevent bitrot