### PR TITLE
Mh/add item context permission checks

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketLinkActionFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketLinkActionFactory.java
@@ -27,8 +27,8 @@ public class BitbucketLinkActionFactory extends TransientActionFactory<Project> 
 
         FormValidation configValid = FormValidation.aggregate(Arrays.asList(
                 maybeConfig.map(BitbucketServerConfiguration::validate).orElse(FormValidation.error("Config not present")),
-                descriptor.doCheckProjectName(serverId, credentialsId, bitbucketSCM.getProjectName()),
-                descriptor.doCheckRepositoryName(serverId, credentialsId, bitbucketSCM.getProjectName(), bitbucketSCM.getRepositoryName())
+                descriptor.doCheckProjectName(target, serverId, credentialsId, bitbucketSCM.getProjectName()),
+                descriptor.doCheckRepositoryName(target, serverId, credentialsId, bitbucketSCM.getProjectName(), bitbucketSCM.getRepositoryName())
         ));
 
         if (configValid.kind == FormValidation.Kind.ERROR) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -380,30 +380,35 @@ public class BitbucketSCM extends SCM {
 
         @Override
         @POST
-        public FormValidation doCheckCredentialsId(@QueryParameter String credentialsId) {
-            return formValidation.doCheckCredentialsId(credentialsId);
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item context,
+                                                   @QueryParameter String credentialsId) {
+            return formValidation.doCheckCredentialsId(context, credentialsId);
         }
 
         @Override
         @POST
-        public FormValidation doCheckProjectName(@QueryParameter String serverId, @QueryParameter String credentialsId,
+        public FormValidation doCheckProjectName(@AncestorInPath Item context,
+                                                 @QueryParameter String serverId,
+                                                 @QueryParameter String credentialsId,
                                                  @QueryParameter String projectName) {
-            return formValidation.doCheckProjectName(serverId, credentialsId, projectName);
+            return formValidation.doCheckProjectName(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckRepositoryName(@QueryParameter String serverId,
+        public FormValidation doCheckRepositoryName(@AncestorInPath Item context,
+                                                    @QueryParameter String serverId,
                                                     @QueryParameter String credentialsId,
                                                     @QueryParameter String projectName,
                                                     @QueryParameter String repositoryName) {
-            return formValidation.doCheckRepositoryName(serverId, credentialsId, projectName, repositoryName);
+            return formValidation.doCheckRepositoryName(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckServerId(@QueryParameter String serverId) {
-            return formValidation.doCheckServerId(serverId);
+        public FormValidation doCheckServerId(@AncestorInPath Item context,
+                                              @QueryParameter String serverId) {
+            return formValidation.doCheckServerId(context, serverId);
         }
 
         @Override
@@ -416,12 +421,14 @@ public class BitbucketSCM extends SCM {
 
         @Override
         @POST
-        public FormValidation doTestConnection(@QueryParameter String serverId,
+        public FormValidation doTestConnection(@AncestorInPath Item context,
+                                               @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName,
+                    mirrorName);
         }
 
         @POST

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -438,35 +438,39 @@ public class BitbucketSCM extends SCM {
 
         @Override
         @POST
-        public HttpResponse doFillProjectNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillProjectNameItems(@AncestorInPath Item context,
+                                                   @QueryParameter String serverId,
                                                    @QueryParameter String credentialsId,
                                                    @QueryParameter String projectName) {
-            return formFill.doFillProjectNameItems(serverId, credentialsId, projectName);
+            return formFill.doFillProjectNameItems(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public HttpResponse doFillRepositoryNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillRepositoryNameItems(@AncestorInPath Item context,
+                                                      @QueryParameter String serverId,
                                                       @QueryParameter String credentialsId,
                                                       @QueryParameter String projectName,
                                                       @QueryParameter String repositoryName) {
-            return formFill.doFillRepositoryNameItems(serverId, credentialsId, projectName, repositoryName);
+            return formFill.doFillRepositoryNameItems(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public ListBoxModel doFillServerIdItems(@QueryParameter String serverId) {
-            return formFill.doFillServerIdItems(serverId);
+        public ListBoxModel doFillServerIdItems(@AncestorInPath Item context, @QueryParameter String serverId) {
+            return formFill.doFillServerIdItems(context, serverId);
         }
 
         @Override
         @POST
-        public ListBoxModel doFillMirrorNameItems(@QueryParameter String serverId,
+        public ListBoxModel doFillMirrorNameItems(@AncestorInPath Item context,
+                                                  @QueryParameter String serverId,
                                                   @QueryParameter String credentialsId,
                                                   @QueryParameter String projectName,
                                                   @QueryParameter String repositoryName,
                                                   @QueryParameter String mirrorName) {
-            return formFill.doFillMirrorNameItems(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formFill.doFillMirrorNameItems(context, serverId, credentialsId, projectName, repositoryName,
+                    mirrorName);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -46,6 +46,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.RepositoryState.AVAILABLE;
+import static hudson.model.Item.*;
 import static hudson.model.Item.CONFIGURE;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -319,34 +320,35 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         @POST
-        public FormValidation doCheckCredentialsId(@QueryParameter String credentialsId) {
-            Jenkins.get().checkPermission(CONFIGURE);
-            return formValidation.doCheckCredentialsId(credentialsId);
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item context,
+                                                   @QueryParameter String credentialsId) {
+            return formValidation.doCheckCredentialsId(context, credentialsId);
         }
 
         @Override
         @POST
-        public FormValidation doCheckProjectName(@QueryParameter String serverId, @QueryParameter String credentialsId,
+        public FormValidation doCheckProjectName(@AncestorInPath Item context,
+                                                 @QueryParameter String serverId,
+                                                 @QueryParameter String credentialsId,
                                                  @QueryParameter String projectName) {
-            Jenkins.get().checkPermission(CONFIGURE);
-            return formValidation.doCheckProjectName(serverId, credentialsId, projectName);
+            return formValidation.doCheckProjectName(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckRepositoryName(@QueryParameter String serverId,
+        public FormValidation doCheckRepositoryName(@AncestorInPath Item context,
+                                                    @QueryParameter String serverId,
                                                     @QueryParameter String credentialsId,
                                                     @QueryParameter String projectName,
                                                     @QueryParameter String repositoryName) {
-            Jenkins.get().checkPermission(CONFIGURE);
-            return formValidation.doCheckRepositoryName(serverId, credentialsId, projectName, repositoryName);
+            return formValidation.doCheckRepositoryName(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckServerId(@QueryParameter String serverId) {
-            Jenkins.get().checkPermission(CONFIGURE);
-            return formValidation.doCheckServerId(serverId);
+        public FormValidation doCheckServerId(@AncestorInPath Item context,
+                                              @QueryParameter String serverId) {
+            return formValidation.doCheckServerId(context, serverId);
         }
 
         @Override
@@ -364,7 +366,6 @@ public class BitbucketSCMSource extends SCMSource {
                                                   @QueryParameter String projectName,
                                                   @QueryParameter String repositoryName,
                                                   @QueryParameter String mirrorName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillMirrorNameItems(serverId, credentialsId, projectName, repositoryName, mirrorName);
         }
 
@@ -373,7 +374,6 @@ public class BitbucketSCMSource extends SCMSource {
         public HttpResponse doFillProjectNameItems(@QueryParameter String serverId,
                                                    @QueryParameter String credentialsId,
                                                    @QueryParameter String projectName) {
-            Jenkins.get().checkPermission(CONFIGURE);
             return formFill.doFillProjectNameItems(serverId, credentialsId, projectName);
         }
 
@@ -396,12 +396,14 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         @POST
-        public FormValidation doTestConnection(@QueryParameter String serverId,
+        public FormValidation doTestConnection(@AncestorInPath Item context,
+                                               @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName,
+                    mirrorName);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -361,37 +361,41 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         @POST
-        public ListBoxModel doFillMirrorNameItems(@QueryParameter String serverId,
+        public ListBoxModel doFillMirrorNameItems(@AncestorInPath Item context,
+                                                  @QueryParameter String serverId,
                                                   @QueryParameter String credentialsId,
                                                   @QueryParameter String projectName,
                                                   @QueryParameter String repositoryName,
                                                   @QueryParameter String mirrorName) {
-            return formFill.doFillMirrorNameItems(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formFill.doFillMirrorNameItems(context, serverId, credentialsId, projectName, repositoryName,
+                    mirrorName);
         }
 
         @Override
         @POST
-        public HttpResponse doFillProjectNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillProjectNameItems(@AncestorInPath Item context,
+                                                   @QueryParameter String serverId,
                                                    @QueryParameter String credentialsId,
                                                    @QueryParameter String projectName) {
-            return formFill.doFillProjectNameItems(serverId, credentialsId, projectName);
+            return formFill.doFillProjectNameItems(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public HttpResponse doFillRepositoryNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillRepositoryNameItems(@AncestorInPath Item context,
+                                                      @QueryParameter String serverId,
                                                       @QueryParameter String credentialsId,
                                                       @QueryParameter String projectName,
                                                       @QueryParameter String repositoryName) {
             Jenkins.get().checkPermission(CONFIGURE);
-            return formFill.doFillRepositoryNameItems(serverId, credentialsId, projectName, repositoryName);
+            return formFill.doFillRepositoryNameItems(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public ListBoxModel doFillServerIdItems(@QueryParameter String serverId) {
+        public ListBoxModel doFillServerIdItems(@AncestorInPath Item context, @QueryParameter String serverId) {
             Jenkins.get().checkPermission(CONFIGURE);
-            return formFill.doFillServerIdItems(serverId);
+            return formFill.doFillServerIdItems(context, serverId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -277,33 +277,38 @@ public class BitbucketSCMStep extends SCMStep {
 
         @Override
         @POST
-        public HttpResponse doFillProjectNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillProjectNameItems(@AncestorInPath Item context,
+                                                   @QueryParameter String serverId,
                                                    @QueryParameter String credentialsId,
                                                    @QueryParameter String projectName) {
-            return formFill.doFillProjectNameItems(serverId, credentialsId, projectName);
+            return formFill.doFillProjectNameItems(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public HttpResponse doFillRepositoryNameItems(@QueryParameter String serverId,
+        public HttpResponse doFillRepositoryNameItems(@AncestorInPath Item context,
+                                                      @QueryParameter String serverId,
                                                       @QueryParameter String credentialsId,
                                                       @QueryParameter String projectName,
                                                       @QueryParameter String repositoryName) {
-            return formFill.doFillRepositoryNameItems(serverId, credentialsId, projectName, repositoryName);
+            return formFill.doFillRepositoryNameItems(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public ListBoxModel doFillServerIdItems(@QueryParameter String serverId) {
-            return formFill.doFillServerIdItems(serverId);
+        public ListBoxModel doFillServerIdItems(@AncestorInPath Item context, @QueryParameter String serverId) {
+            return formFill.doFillServerIdItems(context, serverId);
         }
 
         @Override
-        public ListBoxModel doFillMirrorNameItems(@QueryParameter String serverId, @QueryParameter String credentialsId,
+        public ListBoxModel doFillMirrorNameItems(@AncestorInPath Item context,
+                                                  @QueryParameter String serverId,
+                                                  @QueryParameter String credentialsId,
                                                   @QueryParameter String projectName,
                                                   @QueryParameter String repositoryName,
                                                   @QueryParameter String mirrorName) {
-            return formFill.doFillMirrorNameItems(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formFill.doFillMirrorNameItems(context, serverId, credentialsId, projectName, repositoryName,
+                    mirrorName);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -226,39 +226,45 @@ public class BitbucketSCMStep extends SCMStep {
 
         @Override
         @POST
-        public FormValidation doCheckCredentialsId(@QueryParameter String credentialsId) {
-            return formValidation.doCheckCredentialsId(credentialsId);
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item context,
+                                                   @QueryParameter String credentialsId) {
+            return formValidation.doCheckCredentialsId(context, credentialsId);
         }
 
         @Override
         @POST
-        public FormValidation doCheckProjectName(@QueryParameter String serverId, @QueryParameter String credentialsId,
+        public FormValidation doCheckProjectName(@AncestorInPath Item context,
+                                                 @QueryParameter String serverId,
+                                                 @QueryParameter String credentialsId,
                                                  @QueryParameter String projectName) {
-            return formValidation.doCheckProjectName(serverId, credentialsId, projectName);
+            return formValidation.doCheckProjectName(context, serverId, credentialsId, projectName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckRepositoryName(@QueryParameter String serverId,
+        public FormValidation doCheckRepositoryName(@AncestorInPath Item context,
+                                                    @QueryParameter String serverId,
                                                     @QueryParameter String credentialsId,
                                                     @QueryParameter String projectName,
                                                     @QueryParameter String repositoryName) {
-            return formValidation.doCheckRepositoryName(serverId, credentialsId, projectName, repositoryName);
+            return formValidation.doCheckRepositoryName(context, serverId, credentialsId, projectName, repositoryName);
         }
 
         @Override
         @POST
-        public FormValidation doCheckServerId(@QueryParameter String serverId) {
-            return formValidation.doCheckServerId(serverId);
+        public FormValidation doCheckServerId(@AncestorInPath Item context,
+                                              @QueryParameter String serverId) {
+            return formValidation.doCheckServerId(context, serverId);
         }
 
         @Override
-        public FormValidation doTestConnection(@QueryParameter String serverId,
+        public FormValidation doTestConnection(@AncestorInPath Item context,
+                                               @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName, mirrorName);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFill.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFill.java
@@ -13,16 +13,18 @@ public interface BitbucketScmFormFill {
 
     ListBoxModel doFillCredentialsIdItems(@Nullable Item context, String baseUrl, String credentialsId);
 
-    HttpResponse doFillProjectNameItems(String serverId, String credentialsId, String projectName);
+    HttpResponse doFillProjectNameItems(@Nullable Item context, String serverId, String credentialsId, String projectName);
 
-    HttpResponse doFillRepositoryNameItems(String serverId,
+    HttpResponse doFillRepositoryNameItems(@Nullable Item context,
+                                           String serverId,
                                            String credentialsId,
                                            String projectName,
                                            String repositoryName);
 
-    ListBoxModel doFillServerIdItems(String serverId);
+    ListBoxModel doFillServerIdItems(@Nullable Item context, String serverId);
 
-    ListBoxModel doFillMirrorNameItems(String serverId,
+    ListBoxModel doFillMirrorNameItems(@Nullable Item context,
+                                       String serverId,
                                        String credentialsId,
                                        String projectName,
                                        String repositoryName,

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
@@ -1,16 +1,20 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import hudson.model.Item;
 import hudson.util.FormValidation;
+
+import javax.annotation.Nullable;
 
 public interface BitbucketScmFormValidation {
 
-    FormValidation doCheckCredentialsId(String credentialsId);
+    FormValidation doCheckCredentialsId(@Nullable Item context, String credentialsId);
 
-    FormValidation doCheckProjectName(String serverId, String credentialsId, String projectName);
+    FormValidation doCheckProjectName(@Nullable Item context, String serverId, String credentialsId, String projectName);
 
-    FormValidation doCheckRepositoryName(String serverId, String credentialsId, String projectName, String repositoryName);
+    FormValidation doCheckRepositoryName(@Nullable Item context, String serverId, String credentialsId, String projectName, String repositoryName);
 
-    FormValidation doCheckServerId(String serverId);
+    FormValidation doCheckServerId(@Nullable Item context, String serverId);
 
-    FormValidation doTestConnection(String serverId, String credentialsId, String projectName, String repositoryName, String mirrorName);
+    FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId,
+                                    String projectName, String repositoryName, String mirrorName);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -24,6 +24,7 @@ import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHel
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getRepositoryByNameOrSlug;
 import static hudson.util.FormValidation.Kind.ERROR;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -40,10 +41,14 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
                                               BitbucketPluginConfiguration bitbucketPluginConfiguration,
                                               JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials,
                                               JenkinsProvider jenkinsProvider) {
-        this.bitbucketClientFactoryProvider = bitbucketClientFactoryProvider;
-        this.bitbucketPluginConfiguration = bitbucketPluginConfiguration;
-        this.jenkinsToBitbucketCredentials = jenkinsToBitbucketCredentials;
-        this.jenkinsProvider = jenkinsProvider;
+        this.bitbucketClientFactoryProvider =
+                requireNonNull(bitbucketClientFactoryProvider, "bitbucketClientFactoryProvider");
+        this.bitbucketPluginConfiguration =
+                requireNonNull(bitbucketPluginConfiguration, "bitbucketPluginConfiguration");
+        this.jenkinsToBitbucketCredentials =
+                requireNonNull(jenkinsToBitbucketCredentials, "jenkinsToBitbucketCredentials");
+        this.jenkinsProvider =
+                requireNonNull(jenkinsProvider, "jenkinsProvider");
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -10,9 +10,13 @@ import com.atlassian.bitbucket.jenkins.internal.credentials.CredentialUtils;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
+import com.atlassian.bitbucket.jenkins.internal.provider.JenkinsProvider;
 import com.cloudbees.plugins.credentials.Credentials;
+import hudson.model.Item;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -29,18 +33,22 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     private final BitbucketClientFactoryProvider bitbucketClientFactoryProvider;
     private final BitbucketPluginConfiguration bitbucketPluginConfiguration;
     private final JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
+    private final JenkinsProvider jenkinsProvider;
 
     @Inject
     public BitbucketScmFormValidationDelegate(BitbucketClientFactoryProvider bitbucketClientFactoryProvider,
                                               BitbucketPluginConfiguration bitbucketPluginConfiguration,
-                                              JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials) {
+                                              JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials,
+                                              JenkinsProvider jenkinsProvider) {
         this.bitbucketClientFactoryProvider = bitbucketClientFactoryProvider;
         this.bitbucketPluginConfiguration = bitbucketPluginConfiguration;
         this.jenkinsToBitbucketCredentials = jenkinsToBitbucketCredentials;
+        this.jenkinsProvider = jenkinsProvider;
     }
 
     @Override
-    public FormValidation doCheckCredentialsId(String credentialsId) {
+    public FormValidation doCheckCredentialsId(@Nullable Item context, String credentialsId) {
+        checkPermission(context);
         Credentials providedCredentials = CredentialUtils.getCredentials(credentialsId);
         if (!isBlank(credentialsId) && providedCredentials == null) {
             return FormValidation.error("No credentials exist for the provided credentialsId");
@@ -49,7 +57,8 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
-    public FormValidation doCheckProjectName(String serverId, String credentialsId, String projectName) {
+    public FormValidation doCheckProjectName(@Nullable Item context, String serverId, String credentialsId, String projectName) {
+        checkPermission(context);
         if (isBlank(projectName)) {
             return FormValidation.error("Project name is required");
         }
@@ -81,8 +90,9 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
-    public FormValidation doCheckRepositoryName(String serverId, String credentialsId, String projectName,
+    public FormValidation doCheckRepositoryName(@Nullable Item context, String serverId, String credentialsId, String projectName,
                                                 String repositoryName) {
+        checkPermission(context);
         if (isBlank(projectName)) {
             return FormValidation.ok(); // There will be an error on the projectName field
         }
@@ -118,7 +128,8 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
-    public FormValidation doCheckServerId(String serverId) {
+    public FormValidation doCheckServerId(@Nullable Item context, String serverId) {
+        checkPermission(context);
         // Users can only demur in providing a server name if none are available to select
         if (bitbucketPluginConfiguration.getValidServerList().stream().noneMatch(server -> server.getId().equals(serverId))) {
             return FormValidation.error("Bitbucket instance is required");
@@ -130,29 +141,32 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
-    public FormValidation doTestConnection(String serverId, String credentialsId, String projectName,
+    public FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId, String projectName,
                                            String repositoryName, String mirrorName) {
-        FormValidation serverIdValidation = doCheckServerId(serverId);
+        checkPermission(context);
+        FormValidation serverIdValidation = doCheckServerId(context, serverId);
         if (serverIdValidation.kind == ERROR) {
             return serverIdValidation;
         }
 
-        FormValidation credentialsIdValidation = doCheckCredentialsId(credentialsId);
+        FormValidation credentialsIdValidation = doCheckCredentialsId(context, credentialsId);
         if (credentialsIdValidation.kind == ERROR) {
             return credentialsIdValidation;
         }
 
-        FormValidation projectNameValidation = doCheckProjectName(serverId, credentialsId, projectName);
+        FormValidation projectNameValidation = doCheckProjectName(context, serverId, credentialsId, projectName);
         if (projectNameValidation.kind == ERROR) {
             return projectNameValidation;
         }
 
-        FormValidation repositoryNameValidation = doCheckRepositoryName(serverId, credentialsId, projectName, repositoryName);
+        FormValidation repositoryNameValidation = doCheckRepositoryName(context, serverId, credentialsId, projectName,
+                repositoryName);
         if (repositoryNameValidation.kind == ERROR) {
             return repositoryNameValidation;
         }
 
-        FormValidation mirrorNameValidation = doCheckMirrorName(serverId, credentialsId, projectName, repositoryName, mirrorName);
+        FormValidation mirrorNameValidation = doCheckMirrorName(context, serverId, credentialsId, projectName,
+                repositoryName, mirrorName);
         if (mirrorNameValidation.kind == ERROR) {
             return mirrorNameValidation;
         }
@@ -164,8 +178,17 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
                 repositoryName, isBlank(mirrorName) ? "Primary Server" : mirrorName));
     }
 
-    private FormValidation doCheckMirrorName(String serverId, String credentialsId, String projectName,
+    private void checkPermission(@Nullable Item context) {
+        if (context != null) {
+            context.checkPermission(Item.EXTENDED_READ);
+        } else {
+            jenkinsProvider.get().checkPermission(Jenkins.ADMINISTER);
+        }
+    }
+
+    private FormValidation doCheckMirrorName(@Nullable Item context, String serverId, String credentialsId, String projectName,
                                              String repositoryName, String mirrorName) {
+        checkPermission(context);
         if (isBlank(serverId) || isBlank(projectName) || isBlank(repositoryName)) {
             return FormValidation.ok(); // Validation error would have been in one of the other fields
         }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketLinkActionFactoryTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketLinkActionFactoryTest.java
@@ -15,10 +15,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Collection;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketLinkActionFactoryTest {
@@ -47,8 +46,8 @@ public class BitbucketLinkActionFactoryTest {
         when(bitbucketSCM.getRepositoryName()).thenReturn(REPOSITORY_NAME);
         when(bitbucketSCM.getDescriptor()).thenReturn((SCMDescriptor) descriptor);
         when(descriptor.getConfiguration(SERVER_ID)).thenReturn(Optional.of(configuration));
-        when(descriptor.doCheckProjectName(SERVER_ID, CREDENTIALS_ID, PROJECT_NAME)).thenReturn(FormValidation.ok());
-        when(descriptor.doCheckRepositoryName(SERVER_ID, CREDENTIALS_ID, PROJECT_NAME, REPOSITORY_NAME)).thenReturn(FormValidation.ok());
+        when(descriptor.doCheckProjectName(target, SERVER_ID, CREDENTIALS_ID, PROJECT_NAME)).thenReturn(FormValidation.ok());
+        when(descriptor.doCheckRepositoryName(target, SERVER_ID, CREDENTIALS_ID, PROJECT_NAME, REPOSITORY_NAME)).thenReturn(FormValidation.ok());
         when(configuration.getBaseUrl()).thenReturn(BASE_URL);
         when(configuration.validate()).thenReturn(FormValidation.ok());
     }
@@ -74,7 +73,7 @@ public class BitbucketLinkActionFactoryTest {
 
     @Test
     public void testCreateProjectNameInvalid() {
-        when(descriptor.doCheckProjectName(SERVER_ID, CREDENTIALS_ID, PROJECT_NAME))
+        when(descriptor.doCheckProjectName(target, SERVER_ID, CREDENTIALS_ID, PROJECT_NAME))
                 .thenReturn(FormValidation.error("Bad project name"));
         Collection<? extends Action> actions = actionFactory.createFor(target);
 
@@ -83,7 +82,7 @@ public class BitbucketLinkActionFactoryTest {
 
     @Test
     public void testCreateRepoNameInvalid() {
-        when(descriptor.doCheckRepositoryName(SERVER_ID, CREDENTIALS_ID, PROJECT_NAME, REPOSITORY_NAME))
+        when(descriptor.doCheckRepositoryName(target, SERVER_ID, CREDENTIALS_ID, PROJECT_NAME, REPOSITORY_NAME))
                 .thenReturn(FormValidation.error("Bad repository name"));
         Collection<? extends Action> actions = actionFactory.createFor(target);
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
@@ -70,19 +70,19 @@ public class BitbucketSCMDescriptorTest {
 
     @Test
     public void testDoFillProjectNameItems() {
-        descriptor.doFillProjectNameItems("myServerId", "myCredentialsId", "myProjectName");
-        verify(formFill).doFillProjectNameItems("myServerId", "myCredentialsId", "myProjectName");
+        descriptor.doFillProjectNameItems(parent, "myServerId", "myCredentialsId", "myProjectName");
+        verify(formFill).doFillProjectNameItems(parent, "myServerId", "myCredentialsId", "myProjectName");
     }
 
     @Test
     public void testDoFillRepositoryNameItems() {
-        descriptor.doFillRepositoryNameItems("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
-        verify(formFill).doFillRepositoryNameItems("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        descriptor.doFillRepositoryNameItems(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        verify(formFill).doFillRepositoryNameItems(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
     }
 
     @Test
     public void testDoFillServerIdItems() {
-        descriptor.doFillServerIdItems("myServerId");
-        verify(formFill).doFillServerIdItems("myServerId");
+        descriptor.doFillServerIdItems(parent, "myServerId");
+        verify(formFill).doFillServerIdItems(parent, "myServerId");
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
@@ -36,36 +36,36 @@ public class BitbucketSCMDescriptorTest {
     @Mock
     private JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
     @Mock
-    private Item item;
+    private Item parent;
 
     @Test
     public void testDoCheckCredentialsId() {
-        descriptor.doCheckCredentialsId("myCredentialsId");
-        verify(formValidation).doCheckCredentialsId("myCredentialsId");
+        descriptor.doCheckCredentialsId(parent, "myCredentialsId");
+        verify(formValidation).doCheckCredentialsId(parent, "myCredentialsId");
     }
 
     @Test
     public void testDoCheckProjectName() {
-        descriptor.doCheckProjectName("myServerId", "myCredentialsId", "myProjectName");
-        verify(formValidation).doCheckProjectName("myServerId", "myCredentialsId", "myProjectName");
+        descriptor.doCheckProjectName(parent, "myServerId", "myCredentialsId", "myProjectName");
+        verify(formValidation).doCheckProjectName(parent, "myServerId", "myCredentialsId", "myProjectName");
     }
 
     @Test
     public void testDoCheckRepositoryName() {
-        descriptor.doCheckRepositoryName("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
-        verify(formValidation).doCheckRepositoryName("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        descriptor.doCheckRepositoryName(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        verify(formValidation).doCheckRepositoryName(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
     }
 
     @Test
     public void testDoCheckServerId() {
-        descriptor.doCheckServerId("myServerId");
-        verify(formValidation).doCheckServerId("myServerId");
+        descriptor.doCheckServerId(parent, "myServerId");
+        verify(formValidation).doCheckServerId(parent, "myServerId");
     }
 
     @Test
     public void testDoFillCredentialsIdItems() {
-        descriptor.doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
-        verify(formFill).doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
+        descriptor.doFillCredentialsIdItems(parent, "myBaseUrl", "myCredentialsId");
+        verify(formFill).doFillCredentialsIdItems(parent, "myBaseUrl", "myCredentialsId");
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
@@ -54,19 +54,19 @@ public class BitbucketSCMStepDescriptorTest {
 
     @Test
     public void testDoFillProjectNameItems() {
-        descriptor.doFillProjectNameItems("myServerId", "myCredentialsId", "myProjectName");
-        verify(formFill).doFillProjectNameItems("myServerId", "myCredentialsId", "myProjectName");
+        descriptor.doFillProjectNameItems(parent, "myServerId", "myCredentialsId", "myProjectName");
+        verify(formFill).doFillProjectNameItems(parent, "myServerId", "myCredentialsId", "myProjectName");
     }
 
     @Test
     public void testDoFillRepositoryNameItems() {
-        descriptor.doFillRepositoryNameItems("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
-        verify(formFill).doFillRepositoryNameItems("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        descriptor.doFillRepositoryNameItems(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        verify(formFill).doFillRepositoryNameItems(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
     }
 
     @Test
     public void testDoFillServerIdItems() {
-        descriptor.doFillServerIdItems("myServerId");
-        verify(formFill).doFillServerIdItems("myServerId");
+        descriptor.doFillServerIdItems(parent, "myServerId");
+        verify(formFill).doFillServerIdItems(parent, "myServerId");
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
@@ -20,36 +20,36 @@ public class BitbucketSCMStepDescriptorTest {
     @Mock
     private BitbucketScmFormValidationDelegate formValidation;
     @Mock
-    private Item item;
+    private Item parent;
 
     @Test
     public void testDoCheckCredentialsId() {
-        descriptor.doCheckCredentialsId("myCredentialsId");
-        verify(formValidation).doCheckCredentialsId("myCredentialsId");
+        descriptor.doCheckCredentialsId(parent, "myCredentialsId");
+        verify(formValidation).doCheckCredentialsId(parent, "myCredentialsId");
     }
 
     @Test
     public void testDoCheckProjectName() {
-        descriptor.doCheckProjectName("myServerId", "myCredentialsId", "myProjectName");
-        verify(formValidation).doCheckProjectName("myServerId", "myCredentialsId", "myProjectName");
+        descriptor.doCheckProjectName(parent, "myServerId", "myCredentialsId", "myProjectName");
+        verify(formValidation).doCheckProjectName(parent, "myServerId", "myCredentialsId", "myProjectName");
     }
 
     @Test
     public void testDoCheckRepositoryName() {
-        descriptor.doCheckRepositoryName("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
-        verify(formValidation).doCheckRepositoryName("myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        descriptor.doCheckRepositoryName(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
+        verify(formValidation).doCheckRepositoryName(parent, "myServerId", "myCredentialsId", "myProjectName", "myRepositoryName");
     }
 
     @Test
     public void testDoCheckServerId() {
-        descriptor.doCheckServerId("myServerId");
-        verify(formValidation).doCheckServerId("myServerId");
+        descriptor.doCheckServerId(parent, "myServerId");
+        verify(formValidation).doCheckServerId(parent, "myServerId");
     }
 
     @Test
     public void testDoFillCredentialsIdItems() {
-        descriptor.doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
-        verify(formFill).doFillCredentialsIdItems(item, "myBaseUrl", "myCredentialsId");
+        descriptor.doFillCredentialsIdItems(parent, "myBaseUrl", "myCredentialsId");
+        verify(formFill).doFillCredentialsIdItems(parent, "myBaseUrl", "myCredentialsId");
     }
 
     @Test


### PR DESCRIPTION
Addressing, once again, JENKINS-60116, as thoroughly as possible this time.

Every single validation and fill check on the SCM, SCMStep and SCMSource now has two permission checks:
- If done as part of a project form, we check to ensure the authenticated user has `Item.EXTENDED_READ` permissions. This is similar read instructions as necessary for the snippet generator etc. permitting the user to view configuration without changing it
- If done as part of a rest request accessing the descriptor by name from jenkins root (or otherwise providing no ancestor in context), the user must have `Jenkins.ADMINISTER` privileges. Our API will function fine from root, but it is not the intended case, hence the much stronger restrictions.

This also (finally) introduces permission checking into our unit tests :yayllama: