### PR TITLE
Bumped to 2.1.0

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -6,7 +6,7 @@
     <name>Bitbucket Server Integration Plugin Acceptance Tests</name>
     <description>Includes the integration/acceptance tests for the Bitbucket Server Jenkins integration plugin</description>
     <packaging>jar</packaging>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <properties>
         <!-- The Maven build directory of the plugin, where the '.hpi' file is packaged (by default it's '../target').

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>atlassian-bitbucket-server-integration</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <bitbucket.version>5.5.9</bitbucket.version>


### PR DESCRIPTION
Given we're releasing SSH, which is a relatively large feature, this release probably merits a minor version number.