### PR TITLE
Empty build credentials dropdown value on BB SCM config form load

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -160,7 +160,7 @@ public class BitbucketSCMSource extends SCMSource {
 
     @CheckForNull
     public String getCredentialsId() {
-        return gitSCMSource.getCredentialsId();
+        return getBitbucketSCMRepository().getCredentialsId();
     }
 
     public String getMirrorName() {


### PR DESCRIPTION
When loading the BB SCM config form (e.g. as part of a multi-branch project), if the ssh credentials have been set, the non-ssh credentials (the "Credentials (for build auth)") dropdown is loaded as blank, even if a build credentials was selected and persisted.
That's because on loading the form, we get the current value for the `credentialsId` from the `CustomGitSCMSource` field of the `BitbucketSCMSource` entity, but that field is set to the ssh `credentialsId` if the ssh credentials are set (in `BitbucketSCMSource.initialize()`):

```
private void initialize(String cloneUrl, BitbucketSCMRepository bitbucketSCMRepository) {
        repository = bitbucketSCMRepository;
        String credentialsId = isBlank(bitbucketSCMRepository.getSshCredentialsId()) ?
                bitbucketSCMRepository.getCredentialsId() : bitbucketSCMRepository.getSshCredentialsId();
        UserRemoteConfig remoteConfig =
                new UserRemoteConfig(cloneUrl, bitbucketSCMRepository.getRepositorySlug(), null, credentialsId);
        gitSCMSource = new CustomGitSCMSource(remoteConfig.getUrl());
        gitSCMSource.setTraits(traits);
        gitSCMSource.setCredentialsId(credentialsId);
    }
```
This PR fixes the problem by fetching the `credentialsId` value from the `BitbucketSCMRepository` entity instead.