### PR TITLE
Expose git submodule configs on bitucket SCM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 *.swp
 *.DS_Store
 *.log
+.factorypath
 
 # Duplicated config files that are copied across during the build
 src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -20,6 +20,7 @@ import hudson.model.TaskListener;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitTool;
+import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.browser.Stash;
 import hudson.plugins.git.extensions.GitSCMExtension;
@@ -285,6 +286,13 @@ public class BitbucketSCM extends SCM {
     @CheckForNull
     public String getServerId() {
         return getBitbucketSCMRepository().getServerId();
+    }
+
+    public Collection<SubmoduleConfig> getSubmoduleCfg() {
+        if (gitSCM == null) {
+            return emptyList();
+        }
+        return gitSCM.getSubmoduleCfg();
     }
 
     public List<UserRemoteConfig> getUserRemoteConfigs() {


### PR DESCRIPTION
Hi!

We have some global-library accessing scm.userRemoteConfigs during checkout and would be nice to access directly submoduleCfg like the standard git SCM.

```
ERROR: groovy.lang.MissingPropertyException: No such property: submoduleCfg for class: com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM
```

It will also facilitate pipeline and jenkins library migration from GitSCM to BitbucketSCM.

Thanks!