### PR TITLE
JENKINS-63815: Fix issue which matches all the jobs on head event

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -7,6 +7,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRefChangeType;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.security.ACL;
@@ -199,6 +200,15 @@ public class BitbucketWebhookConsumer {
         @Override
         public String getSourceName() {
             return getPayload().getRepository().getName();
+        }
+
+        @Override
+        public boolean isMatch(SCMSource source) {
+            if (source instanceof BitbucketSCMSource) {
+                BitbucketSCMSource bitbucketSCMSource = (BitbucketSCMSource) source;
+                return matchingRepo(getPayload().getRepository(), bitbucketSCMSource.getBitbucketSCMRepository());
+            }
+            return super.isMatch(source);
         }
 
         @Override


### PR DESCRIPTION
By default, the SCM API plugin considers a match if the `heads(SCMSource source)` returns a non-empty map (see [here](https://github.com/jenkinsci/scm-api-plugin/blob/041837a71e861a3cd7ade9269b2794b300c5ad47/src/main/java/jenkins/scm/api/SCMHeadEvent.java#L137)).
The way the `BitbucketSCMHeadEvent.heads` method is implemented is causing the `SCMHeadEvent.isMatch` method to return `true` in every single job in Jenkins, and because of that, the Branch API plugin is scanning all the jobs when any Multibranch Pipeline is triggered.