### PR TITLE
JENKINS-63815: Fix issue which matches all the jobs on head event

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -7,6 +7,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRefChangeType;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.security.ACL;
@@ -31,6 +32,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -203,6 +205,13 @@ public class BitbucketWebhookConsumer {
 
         @Override
         public Map<SCMHead, SCMRevision> heads(SCMSource source) {
+            if (!(source instanceof BitbucketSCMSource)) {
+                return emptyMap();
+            }
+            BitbucketSCMSource src = (BitbucketSCMSource) source;
+            if (!matchingRepo(getPayload().getRepository(), src.getBitbucketSCMRepository())) {
+                return emptyMap();
+            }
             return getPayload().getChanges().stream().collect(Collectors.toMap(change -> new GitBranchSCMHead(change.getRef().getDisplayId()), change -> new GitBranchSCMRevision(new GitBranchSCMHead(change.getRef().getDisplayId()), change.getToHash())));
         }
 


### PR DESCRIPTION
By default, the SCM API plugin considers a match if the `heads(SCMSource source)` returns a non-empty map (see [here](https://github.com/jenkinsci/scm-api-plugin/blob/041837a71e861a3cd7ade9269b2794b300c5ad47/src/main/java/jenkins/scm/api/SCMHeadEvent.java#L137)).
The way the `BitbucketSCMHeadEvent.heads` method is implemented is causing the `SCMHeadEvent.isMatch` method to return `true` in every single job in Jenkins, and because of that, the Branch API plugin is scanning all the jobs when any Multibranch Pipeline is triggered.

I've added some checks, as the Branch Source plugin [does](https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/cloudbees-bitbucket-branch-source-2.9.4/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java#L143), to guarantee only the heads a matching repository are returned.