### PR TITLE
Remove project and repo validation for bitbucket links

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketExternalLink.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketExternalLink.java
@@ -49,10 +49,6 @@ public class BitbucketExternalLink implements Action, IconSpec {
     @CheckForNull
     @Override
     public String getIconFileName() {
-        if (!owner.hasPermission(Item.CONFIGURE)) {
-            return null;
-        }
-
         JellyContext ctx = new JellyContext();
         ctx.setVariable("resURL", Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH);
         return IconSet.icons.getIconByClassSpec(iconName + " icon-md").getQualifiedUrl(ctx);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketJobLinkActionFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketJobLinkActionFactory.java
@@ -48,11 +48,8 @@ public class BitbucketJobLinkActionFactory extends TransientActionFactory<Job> {
         String credentialsId = Objects.toString(bitbucketRepository.getCredentialsId(), "");
 
         Optional<BitbucketServerConfiguration> maybeConfig = bitbucketPluginConfiguration.getServerById(serverId);
-        FormValidation configValid = FormValidation.aggregate(Arrays.asList(
-                maybeConfig.map(BitbucketServerConfiguration::validate).orElse(FormValidation.error("Config not present")),
-                formValidation.doCheckProjectName(target, serverId, credentialsId, bitbucketRepository.getProjectName()),
-                formValidation.doCheckRepositoryName(target, serverId, credentialsId, bitbucketRepository.getProjectName(), bitbucketRepository.getRepositoryName())
-        ));
+        FormValidation configValid = maybeConfig.map(BitbucketServerConfiguration::validate)
+                .orElse(FormValidation.error("Valid config is not present"));
 
         if (configValid.kind == FormValidation.Kind.ERROR) {
             return Collections.emptySet();

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketJobLinkActionFactoryTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketJobLinkActionFactoryTest.java
@@ -75,12 +75,8 @@ public class BitbucketJobLinkActionFactoryTest {
         when(multibranchProject.getSCMSources()).thenReturn(Arrays.asList(mockSCMSource));
         when(bitbucketRepository.getServerId()).thenReturn(SERVER_ID);
         when(bitbucketRepository.getCredentialsId()).thenReturn(CREDENTIALS_ID);
-        when(bitbucketRepository.getProjectName()).thenReturn(PROJECT_NAME);
-        when(bitbucketRepository.getRepositoryName()).thenReturn(REPOSITORY_NAME);
 
         when(pluginConfiguration.getServerById(SERVER_ID)).thenReturn(Optional.of(configuration));
-        when(formValidationDelegate.doCheckProjectName(any(), eq(SERVER_ID), eq(CREDENTIALS_ID), eq(PROJECT_NAME))).thenReturn(FormValidation.ok());
-        when(formValidationDelegate.doCheckRepositoryName(any(), eq(SERVER_ID), eq(CREDENTIALS_ID), eq(PROJECT_NAME), eq(REPOSITORY_NAME))).thenReturn(FormValidation.ok());
         when(configuration.getBaseUrl()).thenReturn(BASE_URL);
         when(configuration.validate()).thenReturn(FormValidation.ok());
 
@@ -135,24 +131,6 @@ public class BitbucketJobLinkActionFactoryTest {
     public void testCreateNotBitbucketSCMWorkflow() {
         workflowJob.setDefinition(new CpsScmFlowDefinition(mock(SCM.class), "Jenkinsfile"));
         Collection<? extends Action> actions = actionFactory.createFor(workflowJob);
-
-        assertThat(actions.size(), equalTo(0));
-    }
-
-    @Test
-    public void testCreateProjectNameInvalid() {
-        when(formValidationDelegate.doCheckProjectName(any(), eq(SERVER_ID), eq(CREDENTIALS_ID), eq(PROJECT_NAME)))
-                .thenReturn(FormValidation.error("Bad project name"));
-        Collection<? extends Action> actions = actionFactory.createFor(freeStyleProject);
-
-        assertThat(actions.size(), equalTo(0));
-    }
-
-    @Test
-    public void testCreateRepoNameInvalid() {
-        when(formValidationDelegate.doCheckRepositoryName(any(), eq(SERVER_ID), eq(CREDENTIALS_ID), eq(PROJECT_NAME), eq(REPOSITORY_NAME)))
-                .thenReturn(FormValidation.error("Bad repository name"));
-        Collection<? extends Action> actions = actionFactory.createFor(freeStyleProject);
 
         assertThat(actions.size(), equalTo(0));
     }


### PR DESCRIPTION
The BitbucketJobLinkActionFactory class is validating Bitbucket configurations the same way the form does, by checking project and repo via rest points. This is not a single call per action, and this method can be called 5 or 6 times per page load. Additionally, the validation _requires_ extended read permission for users- so a user without the ability to view job configuration will flood the logs with exceptions.

There are a few ways to solve this. The easiest is to simply remove the repo/project validation. This still performs the config validation, so it won't send you to an invalid URL, but does not verify the repo and project exist- so users will hit a dead link if it has been configured incorrectly rather than hiding it as was done previously.

I also removed the "CONFIG" restriction, so anyone that can read the job can hit the link.