### PR TITLE
Bugfix: fix anonymous user oauth handling

### DIFF
--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/applink/oauth/serviceprovider/auth/OAuth1aRequestFilterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/applink/oauth/serviceprovider/auth/OAuth1aRequestFilterTest.java
@@ -263,10 +263,10 @@ public class OAuth1aRequestFilterTest {
     public void testNotAuthorizingAnonymousUsers() throws IOException, ServletException {
         setupRequestWithParameters(rsaConsumerParameterMap);
         when(securityChecker.isSecurityEnabled()).thenReturn(false);
-        when(store.get(TOKEN)).thenReturn(Optional.of(ACCESS_TOKEN));
 
         filter.doFilter(request, response, chain);
         verifyNoMoreInteractions(trustedUnderlyingSystemAuthorizerFilter);
+        verify(chain).doFilter(isA(HttpServletRequest.class), isA(HttpServletResponse.class));
     }
 
     private void setupRequestWithParameters(Map<String, String[]> params) {


### PR DESCRIPTION
1. Redirect unauthenticated users to the login screen when viewing the AuthorizeConfirmationConfig screen.

    Previously, unauthenticated users with read access to Jenkins would not be prompted to log in. This would cause an
    exception and show the user a stack trace when we tried to store the token. As a workaround, we will redirect
    unauthenticated users to the login screen if security is enabled.

2. Update OAuth1aRequestFilter so that if security is not enabled we continue the filter chain.

    Previously, the check for whether security was enabled or not was embedded deep in the authentication logic
    and the fact that we didn't continue the filter chain was hard to spot. This commit refactors the logic so
    that the check for whether security is enabled or not happens at the start of the method.