### PR TITLE
changed form entry field name to still be consumer: fixes bug

### DIFF
--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerEntry/config.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerEntry/config.jelly
@@ -14,7 +14,7 @@
           </j:otherwise>
         </j:choose>
     </f:entry>
-    <f:entry field="sharedSecret" title="${%bitbucket.oauth.shared.secret}">
+    <f:entry field="consumerSecret" title="${%bitbucket.oauth.shared.secret}">
         <f:password value="${it.consumerSecret}"/>
     </f:entry>
     <f:entry field="callbackUrl" title="${%bitbucket.oauth.consumer.callback}">


### PR DESCRIPTION
bug: when creating bbs consumer, pressing 'save' produced an error with JSON fields. 
tried changing form entry field to sharedSecret but that didn't work. 
ended up changing form entry field name back to consumerSecret to match backend. 