### PR TITLE
changed form entry field to still be consumer: bug fix

### DIFF
--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerEntry/config.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerEntry/config.jelly
@@ -14,7 +14,7 @@
           </j:otherwise>
         </j:choose>
     </f:entry>
-    <f:entry field="sharedSecret" title="${%bitbucket.oauth.shared.secret}">
+    <f:entry field="consumerSecret" title="${%bitbucket.oauth.shared.secret}">
         <f:password value="${it.consumerSecret}"/>
     </f:entry>
     <f:entry field="callbackUrl" title="${%bitbucket.oauth.consumer.callback}">


### PR DESCRIPTION
there was a bug with creating bbs consumer: clicking 'save' created error with JSON fields. 
tried to switch form entry field name to sharedSecret but there was still an error.
ended up switching form entry field name back to consumerSecret to match with backend. (so only the frontend text says sharedSecret, everything else still uses consumerSecret)