### PR TITLE
Dk/fix build by bumping jenkins minor

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -14,7 +14,7 @@
         <plugin.build.dir>../target</plugin.build.dir>
         <!-- The name of the plugin being tested (i.e. the artifact name in the plugin's pom.xml) -->
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
-        <jenkins.acceptance-test-harness.version>1.74</jenkins.acceptance-test-harness.version>
+        <jenkins.acceptance-test-harness.version>1.82</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.10</httpclient.version>
         <jenkins.version>2.190.3</jenkins.version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.74</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.10</httpclient.version>
-        <jenkins.version>2.190.1</jenkins.version>
+        <jenkins.version>2.190.3</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.82</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.10</httpclient.version>
-        <jenkins.version>2.190.3</jenkins.version>
+        <jenkins.version>2.204.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>
@@ -45,7 +45,7 @@
             <groupId>org.jenkins-ci</groupId>
             <artifactId>acceptance-test-harness</artifactId>
             <version>${jenkins.acceptance-test-harness.version}</version>
-            <!-- This exlcusion is to prevent a log4j delegation loop (http://www.slf4j.org/codes.html#log4jDelegationLoop)
+            <!-- This exclusion is to prevent a log4j delegation loop (http://www.slf4j.org/codes.html#log4jDelegationLoop)
             The acceptance test harness pulls in sl4j-log4j as a dependency which redirects calls made to an SLF4J logger to log4j.
             com.atlassian.bitbucket.server:bitbucket-page-objects pulls in log4j-over-slf4j which does the opposite. This delegation
             loop immediately results in a stackoverflow error if left untreated.-->

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-14</version>
+            <version>build-217-jenkins-27</version>
         </dependency>
         <dependency>
             <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.11.2</jackson.version>
-        <jenkins.version>2.190.1</jenkins.version>
+        <jenkins.version>2.190.3</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <surefireTestExclusions>nothing-to-exclude</surefireTestExclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.11.2</jackson.version>
-        <jenkins.version>2.190.3</jenkins.version>
+        <jenkins.version>2.204.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <surefireTestExclusions>nothing-to-exclude</surefireTestExclusions>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.190.1+
+- Jenkins 2.204.1+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 5.6 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.4+ you can set up an Application Link to have access to all plugin features.

--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,9 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 2.1.2 (XX January 2021)
+- The minimum version of Jenkins changed to be **2.204.1**
+
 ### 2.1.1 (24 November 2020)
 - Revoke access tokens now a user action
 - JENKINS-63070 - links supports Pipeline and Multibranch Pipeline


### PR DESCRIPTION
Bumps a number of versions to make the builds work again. 
Notably this increases the minimum version we support from 2.190.1 to 2.204.1 (next LTS).