### PR TITLE
Add jenkinsUrl for use in BbS when generating jobs with DSL

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRepository.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRepository.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import javax.annotation.Nullable;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class BitbucketSCMRepository {
@@ -14,10 +15,11 @@ public class BitbucketSCMRepository {
     private final String repositorySlug;
     private final String serverId;
     private final String mirrorName;
+    private final String jenkinsUrl;
 
     public BitbucketSCMRepository(@Nullable String credentialsId, @Nullable String sshCredentialsId, String projectName, String projectKey,
                                   String repositoryName, String repositorySlug, @Nullable String serverId,
-                                  String mirrorName) {
+                                  String mirrorName, @Nullable String jenkinsUrl) {
         this.credentialsId = credentialsId;
         this.sshCredentialsId = sshCredentialsId;
         this.projectName = projectName;
@@ -26,6 +28,7 @@ public class BitbucketSCMRepository {
         this.repositorySlug = repositorySlug;
         this.serverId = serverId;
         this.mirrorName = mirrorName;
+        this.jenkinsUrl = jenkinsUrl;
     }
 
     @Nullable
@@ -62,8 +65,16 @@ public class BitbucketSCMRepository {
         return mirrorName;
     }
 
+    public String getJenkinsUrl() {
+        return jenkinsUrl;
+    }
+
     public boolean isMirrorConfigured() {
         return !isEmpty(mirrorName);
+    }
+
+    public boolean isJenkinsUrlConfigured() {
+        return !isBlank(jenkinsUrl);
     }
 
     public boolean isPersonal() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandler.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.trigger;
 
+import com.atlassian.bitbucket.jenkins.internal.applink.oauth.serviceprovider.consumer.PersistentServiceProviderConsumerStore;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketCapabilitiesClient;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactory;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
@@ -16,6 +17,7 @@ import com.atlassian.bitbucket.jenkins.internal.trigger.register.WebhookHandler;
 import com.atlassian.bitbucket.jenkins.internal.trigger.register.WebhookRegisterRequest;
 import com.atlassian.bitbucket.jenkins.internal.trigger.register.WebhookRegistrationFailed;
 
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,6 +34,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  */
 @Singleton
 public class RetryingWebhookHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketWebhookMultibranchTrigger.class.getName());
 
     private final InstanceBasedNameGenerator instanceBasedNameGenerator;
     private final JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
@@ -56,7 +60,9 @@ public class RetryingWebhookHandler {
         if (isBlank(bitbucketBaseUrl)) {
             throw new IllegalArgumentException("Invalid Bitbucket base URL. Input - " + bitbucketBaseUrl);
         }
-        String jenkinsUrl = jenkinsProvider.get().getRootUrl();
+
+        String jenkinsUrl = repository.isJenkinsUrlConfigured() ?
+            repository.getJenkinsUrl() : jenkinsProvider.get().getRootUrl();
         if (isBlank(jenkinsUrl)) {
             throw new IllegalArgumentException("Invalid Jenkins base url. Actual - " + jenkinsUrl);
         }

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/help-jenkinsUrl.html
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/help-jenkinsUrl.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Enter the root URL for your Jenkins instance, used as the webhook target; this is
+        only needed when creating a job using DSL, because it can't be auto-detected there.</p>
+</div>

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/help-jenkinsUrl.html
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/help-jenkinsUrl.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Enter the root URL for your Jenkins instance, used as the webhook target; this is
+        only needed when creating a job using DSL, because it can't be auto-detected there.</p>
+</div>

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -51,6 +51,20 @@ public class BitbucketSCMSourceTest {
     }
 
     @Test
+    public void testBuildHttpWithJenkinsUrl() {
+        BitbucketSCMSource scmSource = createInstance("credentialsId", "", "serverId", "project", "repo", "", "jenkins");
+        SCMHead scmHead = mock(SCMHead.class);
+        when(scmHead.getName()).thenReturn("myBranch");
+        SCM scm = scmSource.build(scmHead, null);
+        assertTrue(scm instanceof GitSCM);
+        GitSCM gitSCM = (GitSCM) scm;
+        List<UserRemoteConfig> userRemoteConfigs = gitSCM.getUserRemoteConfigs();
+        assertEquals(1, userRemoteConfigs.size());
+        assertEquals(httpCloneLink, userRemoteConfigs.get(0).getUrl());
+        assertEquals("jenkins", scmSource.getJenkinsUrl());
+    }
+
+    @Test
     public void testBuildSsh() {
         BitbucketSCMSource scmSource =
                 createInstance("credentialsId", "sshCredentialsId", "serverId", "project", "repo");
@@ -62,6 +76,21 @@ public class BitbucketSCMSourceTest {
         List<UserRemoteConfig> userRemoteConfigs = gitSCM.getUserRemoteConfigs();
         assertEquals(1, userRemoteConfigs.size());
         assertEquals(sshCloneLink, userRemoteConfigs.get(0).getUrl());
+    }
+
+    @Test
+    public void testBuildSshWithJenkinsUrl() {
+        BitbucketSCMSource scmSource =
+            createInstance("credentialsId", "sshCredentialsId", "serverId", "project", "repo", "", "jenkins");
+        SCMHead scmHead = mock(SCMHead.class);
+        when(scmHead.getName()).thenReturn("myBranch");
+        SCM scm = scmSource.build(scmHead, null);
+        assertTrue(scm instanceof GitSCM);
+        GitSCM gitSCM = (GitSCM) scm;
+        List<UserRemoteConfig> userRemoteConfigs = gitSCM.getUserRemoteConfigs();
+        assertEquals(1, userRemoteConfigs.size());
+        assertEquals(sshCloneLink, userRemoteConfigs.get(0).getUrl());
+        assertEquals("jenkins", scmSource.getJenkinsUrl());
     }
 
     @Test
@@ -164,7 +193,13 @@ public class BitbucketSCMSourceTest {
     }
 
     private BitbucketSCMSource createInstance(String credentialsId, String sshCredentialId, @Nullable String serverId,
-                                              @Nullable String projectName, @Nullable String repo) {
+        @Nullable String projectName, @Nullable String repo) {
+        return createInstance(credentialsId, sshCredentialId, serverId, projectName, repo, "", "");
+    }
+
+    private BitbucketSCMSource createInstance(String credentialsId, String sshCredentialId, @Nullable String serverId,
+                                              @Nullable String projectName, @Nullable String repo,
+                                              @Nullable String mirrorName, @Nullable String jenkinsUrl) {
         return new BitbucketSCMSource(
                 "1",
                 credentialsId,
@@ -173,7 +208,8 @@ public class BitbucketSCMSourceTest {
                 projectName,
                 repo,
                 serverId,
-                null) {
+                mirrorName,
+                jenkinsUrl) {
             @Override
             public SCMSourceDescriptor getDescriptor() {
                 DescriptorImpl descriptor = mock(DescriptorImpl.class);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.*;
@@ -59,7 +60,7 @@ public class BitbucketSCMTest {
         String projectKey = "~USER";
 
         BitbucketSCMRepository scmRepository =
-                new BitbucketSCMRepository(credentialsId, null, projectName, projectKey, "", "", serverId, "");
+                new BitbucketSCMRepository(credentialsId, null, projectName, projectKey, "", "", serverId, "", "");
         BitbucketSCM scm = spy(createInstance(credentialsId, serverId));
         doReturn(scmRepository).when(scm).getBitbucketSCMRepository();
 
@@ -74,11 +75,26 @@ public class BitbucketSCMTest {
         String projectKey = "PROJECT_1";
 
         BitbucketSCMRepository scmRepository =
-                new BitbucketSCMRepository(credentialsId, null, projectName, projectKey, "", "", serverId, "");
+                new BitbucketSCMRepository(credentialsId, null, projectName, projectKey, "", "", serverId, "", "");
         BitbucketSCM scm = spy(createInstance(credentialsId, serverId));
         doReturn(scmRepository).when(scm).getBitbucketSCMRepository();
 
         assertEquals(projectName, scm.getProjectName());
+    }
+
+    @Test
+    public void testJenkinsUrl() {
+        String credentialsId = "valid-credentials";
+        String serverId = "serverId1";
+        String jenkinsUrl = "jenkins";
+
+        BitbucketSCMRepository scmRepository =
+            new BitbucketSCMRepository(credentialsId, null, "", "", "", "", serverId, "", jenkinsUrl);
+        BitbucketSCM scm = spy(createInstance(credentialsId, serverId));
+        doReturn(scmRepository).when(scm).getBitbucketSCMRepository();
+
+        assertTrue(scmRepository.isJenkinsUrlConfigured());
+        assertEquals(jenkinsUrl, scm.getJenkinsUrl());
     }
 
     private BitbucketSCM createInstance(String credentialId) {
@@ -94,11 +110,11 @@ public class BitbucketSCMTest {
     }
 
     private BitbucketSCM createInstance(String credentialId, String serverId, String projectName, String repo) {
-        return createInstance(credentialId, serverId, projectName, repo, null);
+        return createInstance(credentialId, serverId, projectName, repo, null, null);
     }
 
     private BitbucketSCM createInstance(String credentialsId, String serverId, String project, String repo,
-                                        String mirror) {
+                                        String mirror, String jenkinsUrl) {
         return new BitbucketSCM(
                 "1",
                 Collections.emptyList(),
@@ -109,7 +125,8 @@ public class BitbucketSCMTest {
                 project,
                 repo,
                 serverId,
-                mirror) {
+                mirror,
+                jenkinsUrl) {
             @Override
             public SCMDescriptor<?> getDescriptor() {
                 BitbucketServerConfiguration bitbucketServerConfiguration = mock(BitbucketServerConfiguration.class);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -31,7 +31,7 @@ public class BuildStatusPosterTest {
     private static final String REVISION_SHA1 = "67d71c2133aab0e070fb8100e3e71220332c5af1";
     private static final String SERVER_URL = "http://www.example.com";
     private static final BitbucketSCMRepository scmRepository =
-            new BitbucketSCMRepository(null, null, PROJECT_NAME, PROJECT_NAME, REPO_SLUG, REPO_SLUG, SERVER_ID, "");
+            new BitbucketSCMRepository(null, null, PROJECT_NAME, PROJECT_NAME, REPO_SLUG, REPO_SLUG, SERVER_ID, "", "");
     private static final BitbucketRevisionAction action =
             new BitbucketRevisionAction(scmRepository, "master", REVISION_SHA1);
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
@@ -108,7 +108,7 @@ public class BitbucketWebhookConsumerTest {
                 BITBUCKET_USER, REPO_REF_CHANGE.getEventId(), new Date(), refChanges(), bitbucketRepository);
 
         BitbucketSCMRepository scmRepo = new BitbucketSCMRepository("credentialId", "", JENKINS_PROJECT_NAME,
-                JENKINS_PROJECT_KEY.toUpperCase(), JENKINS_REPO_NAME, JENKINS_REPO_SLUG.toUpperCase(), serverId, "");
+                JENKINS_PROJECT_KEY.toUpperCase(), JENKINS_REPO_NAME, JENKINS_REPO_SLUG.toUpperCase(), serverId, "", "");
         when(bitbucketSCM.getRepositories())
                 .thenReturn(singletonList(scmRepo));
         when(bitbucketSCM.getServerId()).thenReturn(serverId);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImplTest.java
@@ -334,10 +334,10 @@ public class BitbucketWebhookTriggerImplTest {
     }
 
     private BitbucketSCMRepository createSCMRepo() {
-        return createSCMRepo("serverId", "");
+        return createSCMRepo("serverId", "", "");
     }
 
-    private BitbucketSCMRepository createSCMRepo(String serverId, String mirrorName) {
+    private BitbucketSCMRepository createSCMRepo(String serverId, String mirrorName, String jenkinsUrl) {
         BitbucketServerConfiguration serverConfiguration = mock(BitbucketServerConfiguration.class);
         when(bitbucketPluginConfiguration.getServerById(serverId)).thenReturn(Optional.of(serverConfiguration));
         when(serverConfiguration.getGlobalCredentialsProvider(any(Item.class))).thenReturn(mock(GlobalCredentialsProvider.class));
@@ -350,15 +350,16 @@ public class BitbucketWebhookTriggerImplTest {
                 REPO,
                 REPO,
                 serverId,
-                mirrorName);
+                mirrorName,
+                jenkinsUrl);
     }
 
     private BitbucketSCMRepository createSCMRepoWithMirror(String mirrorName) {
-        return createSCMRepo("serverID", mirrorName);
+        return createSCMRepo("serverID", mirrorName, "");
     }
 
     private BitbucketSCMRepository createSCMRepoWithServerId(String serverId) {
-        return createSCMRepo(serverId, "");
+        return createSCMRepo(serverId, "", "");
     }
 
     private Job createWorkflowJob() {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandlerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandlerTest.java
@@ -110,7 +110,7 @@ public class RetryingWebhookHandlerTest {
     }
 
     private BitbucketSCMRepository createSCMRepository() {
-        return new BitbucketSCMRepository(JOB_CREDENTIALS, "", PROJECT, PROJECT, REPO, REPO, SERVER_ID, "");
+        return new BitbucketSCMRepository(JOB_CREDENTIALS, "", PROJECT, PROJECT, REPO, REPO, SERVER_ID, "", "");
     }
 
     private BitbucketWebhookClient mockWebhookClient(BitbucketClientFactory clientFactory) {

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/JenkinsProjectHandler.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/JenkinsProjectHandler.java
@@ -69,7 +69,7 @@ public class JenkinsProjectHandler {
 
         SCMSource scmSource =
                 new BitbucketSCMSource(id, credentialsId, "",
-                        new BitbucketSCMSource.DescriptorImpl().getTraitsDefaults(), project, repoSlug, serverId, null);
+                        new BitbucketSCMSource.DescriptorImpl().getTraitsDefaults(), project, repoSlug, serverId, null, "");
         WorkflowMultiBranchProject mbp = bbJenkinsRule.createProject(WorkflowMultiBranchProject.class, name);
         BranchSource branchSource = new BranchSource(scmSource);
 

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/TestSCM.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/TestSCM.java
@@ -9,7 +9,8 @@ public class TestSCM extends BitbucketSCM {
     public TestSCM(BitbucketSCM bitbucketSCM) {
         super(bitbucketSCM.getId(), bitbucketSCM.getBranches(), bitbucketSCM.getCredentialsId(), bitbucketSCM.getSshCredentialsId(),
                 bitbucketSCM.getExtensions(), bitbucketSCM.getGitTool(), bitbucketSCM.getProjectName(),
-                bitbucketSCM.getRepositoryName(), bitbucketSCM.getServerId(), bitbucketSCM.getMirrorName());
+                bitbucketSCM.getRepositoryName(), bitbucketSCM.getServerId(), bitbucketSCM.getMirrorName(),
+                bitbucketSCM.getJenkinsUrl());
     }
 
     @Override

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceIT.java
@@ -101,7 +101,7 @@ public class BitbucketSCMSourceIT {
         String id = randomUUID().toString();
         String serverId = serverConf.getId();
         BitbucketSCMSource scmSource =
-                new BitbucketSCMSource(id, credentialsId, "", null, PROJECT_NAME, forkRepoName, serverId, null);
+                new BitbucketSCMSource(id, credentialsId, "", null, PROJECT_NAME, forkRepoName, serverId, null, "");
         assertThat(scmSource.getTraits(), hasSize(0));
         assertThat(scmSource.getRemote(), containsStringIgnoringCase(forkCloneUrl));
         assertThat(scmSource.getCredentialsId(), equalTo(credentialsId));
@@ -140,7 +140,8 @@ public class BitbucketSCMSourceIT {
                 PROJECT_NAME,
                 forkRepoName,
                 serverId,
-                null);
+                null,
+                "");
 
         executeFullFlow(scmSource);
     }
@@ -158,7 +159,8 @@ public class BitbucketSCMSourceIT {
                 PROJECT_NAME,
                 forkRepoName,
                 serverId,
-                null);
+                null,
+                "");
 
         executeFullFlow(scmSource);
     }

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandlerIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/RetryingWebhookHandlerIT.java
@@ -62,7 +62,7 @@ public class RetryingWebhookHandlerIT {
         adminCredentials = JenkinsToBitbucketCredentialsImpl.getBearerCredentials(adminToken.getSecret());
         nonAdminCredentials = JenkinsToBitbucketCredentialsImpl.getBearerCredentials(nonAdminToken.getSecret());
         bitbucketSCMRepository =
-                new BitbucketSCMRepository(JOB_CREDENTIAL_ID, "", PROJECT_NAME, PROJECT_KEY, REPO_NAME, REPO_SLUG, SERVER_ID, "");
+                new BitbucketSCMRepository(JOB_CREDENTIAL_ID, "", PROJECT_NAME, PROJECT_KEY, REPO_NAME, REPO_SLUG, SERVER_ID, "", "");
         cleanWebhooks();
     }
 


### PR DESCRIPTION
## Problem

When configuring certain kinds of jobs that use a Bitbucket connection, the plugin needs to create a webhook on the Bitbucket repo.  The `RetryingWebhookHandler` class gets the webhook target URL from `jenkinsProvider.get().getRootUrl()`.

This code works fine when using the plugin from the UI, but the value from `jenkinsProvider` is not available when generating a job using DSL.  As a result, the webhook setup process fails.

## Solution

This PR adds a new `jenkinsUrl` parameter to the `BbS` DSL, to explicitly set the Jenkins callback URL.  This value, if set, takes precedence over the value from `jenkinsProvider`.    There is example DSL below that shows usage.   The new parameter is not exposed in the UI, since it is not needed there.

## Testing

I have added unit tests, following the pattern in the existing code.  I also generated an `.hpi` file, installed it into my existing Jenkins instance, and tested manually.

Creating a job in the UI works the same as before.  The new parameter does not change the UI behavior.  

When creating a job using DSL, the resulting job has the expected contents in `config.xml` and works as expected.   The new `jenkinsUrl` parameter is required when using the DSL.

## Alternatives

I had hoped to find another source for the root URL that works when using DSL, but as of this writing I haven't found one.  (See this [StackOverflow](https://stackoverflow.com/questions/65947423/why-is-jenkins-get-getrooturl-not-available-when-generating-dsl) question.)   For instance, static references like `Jenkins.get().getRootUrl()` and `JenkinsLocationConfiguration.get().getUrl()` also do not work.  So, I do not think there is an alternative to what I have implemented.

Arguably, the `jenkinsUrl` parameter could be optional when used in a place where a webhook doesn't need to be created.  I don't see a way to detect that situation or to mark the parameter as optional.  If there is some mechanism that I'm not aware of, let me know and I'll rework the PR.  

## Example DSL

Below is example DSL using the new `jenkinsUrl` parameter.

```groovy
multibranchPipelineJob("myrepo-pr-build") {
   branchSources {
      branchSource {
         source {
            BbS {
               id("myrepo-pr")
               serverId("ff658f08-0ac6-409b-9129-30cb47034b14")
               credentialsId("47bd62f3-3cff-41dc-bfbe-c069c718cd2e")
               sshCredentialsId("")
               mirrorName("")
               jenkinsUrl("https://my.jenkins/")
               projectName("myproject")
               repositoryName("myrepo")
               traits {
                  gitBranchDiscovery()
                  headWildcardFilter {
                     includes("*")
                     excludes("master")
                  }
               }
            }
         }
      }
   }

   triggers {
      BitbucketWebhookMultibranchTriggerImpl()
   }

   orphanedItemStrategy {
      discardOldItems {
         daysToKeep(30)
      }
   }
}
```