### PR TITLE
JENKINS-61182 repo form fill now only matches whole project names

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findProjects;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.findRepositories;
@@ -167,7 +168,10 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
                                     providedCredentials.orElse(null));
                     try {
                         Collection<BitbucketRepository> repositories = findRepositories(repositoryName, projectName,
-                                bitbucketClientFactoryProvider.getClient(serverConf.getBaseUrl(), credentials));
+                                bitbucketClientFactoryProvider.getClient(serverConf.getBaseUrl(), credentials))
+                                .stream()
+                                .filter(repository -> repository.getProject().getName().equals(projectName))
+                                .collect(Collectors.toList());
                         return okJSON(JSONArray.fromObject(repositories));
                     } catch (BitbucketClientException e) {
                         // Something went wrong with the request to Bitbucket


### PR DESCRIPTION
Linked Issue: https://issues.jenkins.io/browse/JENKINS-61182

This involves a change in UI behaviour- previously, a partial project key could be entered (validation would complain), but then all repos matching the partial key would be matched and displayed. 

I argue this is not desirable behaviour- the form is intended to be completed in order, a partial project name is NEVER valid (in fact if you change it to a valid one, the repository field clears), and user can always visit bitbucket directly if they're unsure of the exact project key or name.