### PR TITLE
JENKINS-63009 do fill credential items now use item context not jenki…

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -80,13 +80,13 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
                 .includeEmptyValue()
                 .includeMatchingAs(
                         ACL.SYSTEM,
-                        jenkinsProvider.get(),
+                        context,
                         StringCredentials.class,
                         URIRequirementBuilder.fromUri(baseUrl).build(),
                         CredentialsMatchers.always())
                 .includeMatchingAs(
                         ACL.SYSTEM,
-                        jenkinsProvider.get(),
+                        context,
                         StandardUsernamePasswordCredentials.class,
                         URIRequirementBuilder.fromUri(baseUrl).build(),
                         CredentialsMatchers.always());
@@ -100,7 +100,7 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
                 .includeEmptyValue()
                 .includeMatchingAs(
                         ACL.SYSTEM,
-                        jenkinsProvider.get(),
+                        context,
                         BasicSSHUserPrivateKey.class,
                         URIRequirementBuilder.fromUri(baseUrl).build(),
                         CredentialsMatchers.always());


### PR DESCRIPTION
Addressing issue: JENKINS-63009

For prior art, see branch source plugins, BitbucketCredentials.java
No testing included- would need to be acceptance testing. Let me know if you think the work merits it.