### PR TITLE
Added project match check in validation and SCM constructor steps

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketSearchHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketSearchHelper.java
@@ -30,6 +30,8 @@ public final class BitbucketSearchHelper {
                                                                 BitbucketClientFactory clientFactory) throws BitbucketClientException {
         return findRepositories(repositoryNameOrSlug, projectNameOrKey, clientFactory)
                 .stream()
+                // The search endpoint matches partial project keys, so we filter to only include exact matches
+                .filter(r -> projectNameOrKey.equalsIgnoreCase(r.getProject().getName()))
                 .filter(r -> repositoryNameOrSlug.equalsIgnoreCase(r.getName()))
                 // Repo names are unique within a project
                 .findAny()


### PR DESCRIPTION
I think this is properly fixed now. I cannot replicate the behaviour in UI locally because of how `findAny()` works (it is non-deterministic, but on a local test instance behaves identically to `findFirst()`, which typically provides the correct answer). This can by creating a few test projects with subset project names/keys and identical repo names/slugs, and checking the length of the stream after both filter operations before and after this change.

This change impacts
- The validation of the repository field, not just the form fill
- The SCM, SCMSource and SCMStep when fetching the matching repository on config save. Both unmirrored and mirrored repos use the same helper method

Let me know if I missed anything 