### PR TITLE
JENKINS-63009 using global instead of system credentials for repo ret…

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/CredentialUtils.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/CredentialUtils.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.credentials;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import hudson.model.Item;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
@@ -23,6 +24,14 @@ public final class CredentialUtils {
     private CredentialUtils() {
         throw new UnsupportedOperationException(
                 CredentialUtils.class.getName() + " should not be instantiated");
+    }
+
+    public static Optional<Credentials> getCredentials(@Nullable String credentialsId, @Nullable Item context) {
+        return CREDENTIAL_TYPES.stream().map(type -> firstOrNull(
+                lookupCredentials(type, context, ACL.SYSTEM, Collections.emptyList()),
+                withId(trimToEmpty(credentialsId))))
+                .filter(Objects::nonNull)
+                .findAny();
     }
 
     public static Optional<Credentials> getCredentials(@Nullable String credentialsId) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
 import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsProvider;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
@@ -87,9 +88,9 @@ public class BitbucketSCMSource extends SCMSource {
                         projectName,
                         repositoryName,
                         mirrorName));
-        String baseUrl = serverConfiguration.getBaseUrl();
         BitbucketScmHelper scmHelper =
-                descriptor.getBitbucketScmHelper(baseUrl, credentialsId);
+                descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(),
+                        globalCredentialsProvider.getGlobalAdminCredentials().orElse(null));
         if (isBlank(projectName)) {
             LOGGER.info("Error creating the Bitbucket SCM: The project name is blank");
             setEmptyRepository(credentialsId, sshCredentialsId, projectName, repositoryName, serverId, mirrorName);
@@ -468,10 +469,10 @@ public class BitbucketSCMSource extends SCMSource {
         }
 
         BitbucketScmHelper getBitbucketScmHelper(String bitbucketUrl,
-                                                 @Nullable String credentialsId) {
+                                                 @Nullable BitbucketTokenCredentials tokenCredentials) {
             return new BitbucketScmHelper(bitbucketUrl,
                     bitbucketClientFactoryProvider,
-                    credentialsId, jenkinsToBitbucketCredentials);
+                    jenkinsToBitbucketCredentials.toBitbucketCredentials(tokenCredentials));
         }
 
         Optional<BitbucketServerConfiguration> getConfiguration(@Nullable String serverId) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
 import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsProvider;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentialsModule;
@@ -170,7 +171,8 @@ public class BitbucketSCMStep extends SCMStep {
                         repositoryName,
                         mirrorName));
         BitbucketScmHelper scmHelper =
-                descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(), credentialsId);
+                descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(),
+                        globalCredentialsProvider.getGlobalAdminCredentials().orElse(null));
         BitbucketRepository repository;
         if (!isBlank(mirrorName)) {
             try {
@@ -367,12 +369,11 @@ public class BitbucketSCMStep extends SCMStep {
                     (client, project, repo) -> helper.getRepository(project, repo));
         }
 
-        private BitbucketScmHelper getBitbucketScmHelper(String bitbucketUrl,
-                                                         @Nullable String credentialsId) {
-            injectJenkinsToBitbucketCredentials();
+        BitbucketScmHelper getBitbucketScmHelper(String bitbucketUrl,
+                                                 @Nullable BitbucketTokenCredentials tokenCredentials) {
             return new BitbucketScmHelper(bitbucketUrl,
                     bitbucketClientFactoryProvider,
-                    credentialsId, jenkinsToBitbucketCredentials);
+                    jenkinsToBitbucketCredentials.toBitbucketCredentials(tokenCredentials));
         }
 
         private Optional<BitbucketServerConfiguration> getConfiguration(@Nullable String serverId) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -119,7 +119,7 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
             return errorWithoutStack(HTTP_BAD_REQUEST, "The project name must be at least 2 characters long");
         }
 
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!isBlank(credentialsId) && !providedCredentials.isPresent()) {
             return errorWithoutStack(HTTP_BAD_REQUEST, "No credentials exist for the provided credentialsId");
         }
@@ -156,7 +156,7 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
             return errorWithoutStack(HTTP_BAD_REQUEST, "The projectName must be present");
         }
 
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!isBlank(credentialsId) && !providedCredentials.isPresent()) {
             return errorWithoutStack(HTTP_BAD_REQUEST, "No credentials exist for the provided credentialsId");
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -60,7 +60,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
             return FormValidation.warning(
                     "Without credentials, Jenkins can’t check out source code from non-public repositories. ");
         }
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
             return FormValidation.error("No credentials exist for the provided credentialsId");
         }
@@ -70,7 +70,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     @Override
     public FormValidation doCheckSshCredentialsId(@Nullable Item context, String sshCredentialsId) {
         checkPermission(context);
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(sshCredentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(sshCredentialsId, context);
         if (!isBlank(sshCredentialsId) && !providedCredentials.isPresent()) {
             return FormValidation.error("No credentials exist for the provided sshCredentialsId");
         }
@@ -86,7 +86,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         if (isBlank(credentialsId)) {
             return FormValidation.ok(); // There will be an error in the credentials field
         }
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
             return FormValidation.ok(); // There will be an error in the credentials field
         }
@@ -123,7 +123,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         if (isBlank(credentialsId)) {
             return FormValidation.ok(); // There will be an error in the credentials field
         }
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
             return FormValidation.ok(); // There will be an error in the credentials field
         }
@@ -220,7 +220,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         if (isBlank(serverId) || isBlank(projectName) || isBlank(repositoryName) || isBlank(credentialsId)) {
             return FormValidation.ok(); // Validation error would have been in one of the other fields
         }
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId);
+        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
             return FormValidation.ok(); // There will be an error in the credentials field
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
@@ -4,12 +4,11 @@ import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactory;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClientException;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
-import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
+import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.model.RepositoryState;
 
-import javax.annotation.Nullable;
 import java.util.logging.Logger;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getProjectByNameOrKey;
@@ -23,10 +22,8 @@ public class BitbucketScmHelper {
 
     public BitbucketScmHelper(String bitbucketBaseUrl,
                               BitbucketClientFactoryProvider bitbucketClientFactoryProvider,
-                              @Nullable String credentialsId,
-                              JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials) {
-        clientFactory = bitbucketClientFactoryProvider.getClient(bitbucketBaseUrl,
-                jenkinsToBitbucketCredentials.toBitbucketCredentials(credentialsId));
+                              BitbucketCredentials credentials) {
+        clientFactory = bitbucketClientFactoryProvider.getClient(bitbucketBaseUrl, credentials);
     }
 
     public BitbucketRepository getRepository(String projectName, String repositoryName) {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -1,6 +1,8 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
+import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsProvider;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
@@ -181,13 +183,15 @@ public class BitbucketSCMSourceTest {
                 BitbucketServerConfiguration bitbucketServerConfiguration = mock(BitbucketServerConfiguration.class);
                 BitbucketRepository repository = mock(BitbucketRepository.class);
 
+                doReturn(mock(GlobalCredentialsProvider.class))
+                        .when(bitbucketServerConfiguration).getGlobalCredentialsProvider(any(String.class));
                 when(descriptor.getConfiguration(argThat(serverId -> !isBlank(serverId))))
                         .thenReturn(Optional.of(bitbucketServerConfiguration));
                 when(descriptor.getConfiguration(argThat(StringUtils::isBlank)))
                         .thenReturn(Optional.empty());
                 when(descriptor.getBitbucketScmHelper(
                         nullable(String.class),
-                        nullable(String.class)))
+                        nullable(BitbucketTokenCredentials.class)))
                         .thenReturn(scmHelper);
                 when(descriptor.getRetryingWebhookHandler()).thenReturn(mock(RetryingWebhookHandler.class));
                 when(scmHelper.getRepository(nullable(String.class), nullable(String.class))).thenReturn(repository);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMTest.java
@@ -1,6 +1,8 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
+import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsProvider;
 import hudson.scm.SCMDescriptor;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
@@ -9,10 +11,10 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.*;
@@ -113,6 +115,8 @@ public class BitbucketSCMTest {
             @Override
             public SCMDescriptor<?> getDescriptor() {
                 BitbucketServerConfiguration bitbucketServerConfiguration = mock(BitbucketServerConfiguration.class);
+                doReturn(mock(GlobalCredentialsProvider.class))
+                        .when(bitbucketServerConfiguration).getGlobalCredentialsProvider(any(String.class));
                 DescriptorImpl descriptor = mock(DescriptorImpl.class);
                 when(descriptor.getConfiguration(argThat(serverId -> !isBlank(serverId))))
                         .thenReturn(Optional.of(bitbucketServerConfiguration));
@@ -120,7 +124,7 @@ public class BitbucketSCMTest {
                         .thenReturn(Optional.empty());
                 when(descriptor.getBitbucketScmHelper(
                         nullable(String.class),
-                        nullable(String.class)))
+                        nullable(BitbucketTokenCredentials.class)))
                         .thenReturn(mock(BitbucketScmHelper.class));
                 return descriptor;
             }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelperTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelperTest.java
@@ -58,8 +58,7 @@ public class BitbucketScmHelperTest {
         bitbucketScmHelper =
                 new BitbucketScmHelper("myBaseUrl",
                         bitbucketClientFactoryProvider,
-                        "",
-                        jenkinsToBitbucketCredentials);
+                        BitbucketCredentials.ANONYMOUS_CREDENTIALS);
     }
 
     @Test

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/ScmUtils.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/ScmUtils.java
@@ -40,7 +40,7 @@ public final class ScmUtils {
                 new BitbucketClientFactoryProvider(new HttpRequestExecutorImpl());
         BitbucketCredentials credentials =
                 new JenkinsToBitbucketCredentialsImpl().toBitbucketCredentials(
-                        getCredentials(bbJenkinsRule.getBbAdminUsernamePasswordCredentialsId()).orElse(null));
+                        getCredentials(bbJenkinsRule.getBbAdminUsernamePasswordCredentialsId(), null).orElse(null));
         BitbucketRepository repository =
                 bitbucketClientFactoryProvider.getClient(serverConfiguration.getBaseUrl(), credentials)
                         .getProjectClient(PROJECT_KEY)


### PR DESCRIPTION
This is one potential solution to the lack of context in evaluation credentials.

The alternative is to completely update our SCM constructor to leave a "skeleton repository", and defer the construction of the GitSCM to the `calculateRevisionsFor` method- this is consistent with how the git SCM itself evaluates credentials. If that method is preferred, let me know and I'll put up a PR for it.