### PR TITLE
ref trigger checked default & help text for select branch trait

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait.java
@@ -52,7 +52,7 @@ public class SelectBranchTrait extends SCMSourceTrait {
 
         @Override
         public String getDisplayName() {
-            return "Only build branches with open pull requests";
+            return "Only build pull request source branches";
         }
     }
 }

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait/help.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait/help.groovy
@@ -1,0 +1,3 @@
+package com.atlassian.bitbucket.jenkins.internal.scm.SelectBranchTrait
+
+p(_("select.branch.trait.help"))

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait/help.properties
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/SelectBranchTrait/help.properties
@@ -1,0 +1,1 @@
+select.branch.trait.help=Jenkins will only build branches that are the source branches of open pull requests. 

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookMultibranchTrigger/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookMultibranchTrigger/config.groovy
@@ -6,7 +6,7 @@ f.section() {
     f.entry(title: _("bitbucket.trigger.warning"), name: "warning", inline: "true") {}
 
     f.entry(title: _("bitbucket.trigger.refTrigger"), field: "refTrigger", name: "refTrigger", inline: "true") {
-        f.checkbox()
+        f.checkbox(checked:"true")
     }
 
     f.entry(title: _("bitbucket.trigger.pullRequestTrigger"), field: "pullRequestTrigger",  name: "pullRequestTrigger", inline: "true") {


### PR DESCRIPTION
FEATURES: 
- push trigger checkbox is default selected 
- help dialogue to pull request filter behaviour (checked with @ctan-atlassian)