### PR TITLE
Add client for interacting with Bitbucket DC's upcoming deployment status API

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
@@ -4,11 +4,26 @@ import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
 import com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketCDCapabilities;
 
 /**
  * Client to get capabilities from the remote server.
  */
 public interface BitbucketCapabilitiesClient {
+
+    /**
+     * Get the supported deployment capabilities of the linked Bitbucket Server.
+     *
+     * @return the supported capabilities
+     * @throws AuthorizationException     if the credentials did not allow access to the given url
+     * @throws NoContentException         if the server did not respond with a body
+     * @throws ConnectionFailureException if the server did not respond
+     * @throws NotFoundException          if the requested url does not exist
+     * @throws BadRequestException        if the request was malformed and thus rejected by the server
+     * @throws ServerErrorException       if the server failed to process the request
+     * @throws BitbucketClientException   for all errors not already captured
+     */
+    BitbucketCDCapabilities getCDCapabilities();
 
     /**
      * Get the supported ci capabilities of the linked Bitbucket Server.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
@@ -22,6 +22,7 @@ public interface BitbucketCapabilitiesClient {
      * @throws BadRequestException        if the request was malformed and thus rejected by the server
      * @throws ServerErrorException       if the server failed to process the request
      * @throws BitbucketClientException   for all errors not already captured
+     * @since deployments
      */
     BitbucketCDCapabilities getCDCapabilities();
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
@@ -5,6 +5,7 @@ import com.atlassian.bitbucket.jenkins.internal.client.supply.BitbucketCapabilit
 import com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketCDCapabilities;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import okhttp3.HttpUrl;
@@ -12,8 +13,7 @@ import okhttp3.HttpUrl;
 import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
-import static com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities.RICH_BUILDSTATUS_CAPABILITY_KEY;
-import static com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities.WEBHOOK_CAPABILITY_KEY;
+import static com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities.*;
 import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertyUtils.parsePositiveLongFromSystemProperty;
 import static java.util.Collections.emptySet;
 import static okhttp3.HttpUrl.parse;
@@ -31,6 +31,15 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
     BitbucketCapabilitiesClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, BitbucketCapabilitiesSupplier supplier) {
         this.bitbucketRequestExecutor = bitbucketRequestExecutor;
         capabilitiesCache = Suppliers.memoizeWithExpiration(supplier, CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public BitbucketCDCapabilities getCDCapabilities() {
+        BitbucketCDCapabilities capabilities = getCapabilitiesForKey(DEPLOYMENTS_CAPABILITY_KEY, BitbucketCDCapabilities.class);
+        if (capabilities == null) {
+            return new BitbucketCDCapabilities(emptySet());
+        }
+        return capabilities;
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -37,7 +37,7 @@ public interface BitbucketClientFactory {
     /**
      * Return a client that can post deployment information to Bitbucket.
      *
-     * @param revisionSha      the revision for the build status
+     * @param revisionSha      the revision for the deployment
      * @param bitbucketSCMRepo the (Bitbucket) SCM Repo
      * @return a client that can post deployment information
      */

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -1,8 +1,5 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
-
 /**
  * Factory for Bitbucket Clients.
  */
@@ -22,26 +19,6 @@ public interface BitbucketClientFactory {
      * @return a client that is ready to use
      */
     BitbucketCapabilitiesClient getCapabilityClient();
-
-    /**
-     * Return a client that can post the current status of a build to Bitbucket.
-     *
-     * @param revisionSha      the revision for the build status
-     * @param bitbucketSCMRepo the (Bitbucket) SCM Repo
-     * @param ciCapabilities   CI capabilities of the remote server
-     * @return a client that can post a build status
-     */
-    BitbucketBuildStatusClient getBuildStatusClient(String revisionSha, BitbucketSCMRepository bitbucketSCMRepo,
-                                                    BitbucketCICapabilities ciCapabilities);
-
-    /**
-     * Return a client that can post deployment information to Bitbucket.
-     *
-     * @param revisionSha      the revision for the deployment
-     * @param bitbucketSCMRepo the (Bitbucket) SCM Repo
-     * @return a client that can post deployment information
-     */
-    BitbucketDeploymentClient getDeploymentClient(String revisionSha, BitbucketSCMRepository bitbucketSCMRepo);
 
     /**
      * Construct a client that can retrieve the list of mirrored repositories for a given {@code repoId} from Bitbucket.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactory.java
@@ -35,6 +35,15 @@ public interface BitbucketClientFactory {
                                                     BitbucketCICapabilities ciCapabilities);
 
     /**
+     * Return a client that can post deployment information to Bitbucket.
+     *
+     * @param revisionSha      the revision for the build status
+     * @param bitbucketSCMRepo the (Bitbucket) SCM Repo
+     * @return a client that can post deployment information
+     */
+    BitbucketDeploymentClient getDeploymentClient(String revisionSha, BitbucketSCMRepository bitbucketSCMRepo);
+
+    /**
      * Construct a client that can retrieve the list of mirrored repositories for a given {@code repoId} from Bitbucket.
      *
      * @param repositoryId the repositoryId

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -56,6 +56,12 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     }
 
     @Override
+    public BitbucketDeploymentClient getDeploymentClient(String revisionSha, BitbucketSCMRepository bitbucketSCMRepo) {
+        return new BitbucketDeploymentClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
+                bitbucketSCMRepo.getRepositorySlug(), revisionSha);
+    }
+
+    @Override
     public BitbucketMirrorClient getMirroredRepositoriesClient(int repositoryId) {
         return new BitbucketMirrorClientImpl(bitbucketRequestExecutor, repositoryId);
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -2,12 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.client.supply.BitbucketCapabilitiesSupplier;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
-import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
@@ -29,36 +24,6 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     @Override
     public BitbucketCapabilitiesClient getCapabilityClient() {
         return new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor, capabilitiesSupplier);
-    }
-
-    @VisibleForTesting
-    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha,
-                                                           BitbucketSCMRepository bitbucketSCMRepo,
-                                                           BitbucketCICapabilities ciCapabilities,
-                                                           InstanceKeyPairProvider instanceKeyPairProvider,
-                                                           DisplayURLProvider displayURLProvider) {
-        if (ciCapabilities.supportsRichBuildStatus()) {
-            return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
-                    bitbucketSCMRepo.getRepositorySlug(), revisionSha, instanceKeyPairProvider, displayURLProvider);
-        }
-        return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
-    }
-
-    @Override
-    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha,
-                                                           BitbucketSCMRepository bitbucketSCMRepo,
-                                                           BitbucketCICapabilities ciCapabilities) {
-        if (ciCapabilities.supportsRichBuildStatus()) {
-            return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
-                    bitbucketSCMRepo.getRepositorySlug(), revisionSha);
-        }
-        return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
-    }
-
-    @Override
-    public BitbucketDeploymentClient getDeploymentClient(String revisionSha, BitbucketSCMRepository bitbucketSCMRepo) {
-        return new BitbucketDeploymentClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
-                bitbucketSCMRepo.getRepositorySlug(), revisionSha);
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
@@ -1,0 +1,18 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+
+/**
+ * Client for interacting with Bitbucket Server's deployments API.
+ *
+ * @since deployments
+ */
+public interface BitbucketDeploymentClient {
+
+    /**
+     * Send notification of the deployment to Bitbucket Server
+     *
+     * @param deployment the deployment to send
+     */
+    void post(BitbucketDeployment deployment);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
+import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 
 /**
@@ -13,6 +14,12 @@ public interface BitbucketDeploymentClient {
      * Send notification of a deployment to Bitbucket Server
      *
      * @param deployment the deployment to send
+     * @throws AuthorizationException     if the credentials did not allow access to the given url
+     * @throws ConnectionFailureException if the server did not respond
+     * @throws NotFoundException          if the requested url does not exist
+     * @throws BadRequestException        if the request was malformed and thus rejected by the server
+     * @throws ServerErrorException       if the server failed to process the request
+     * @throws BitbucketClientException   for all errors not already captured
      */
     void post(BitbucketDeployment deployment);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClient.java
@@ -10,7 +10,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploy
 public interface BitbucketDeploymentClient {
 
     /**
-     * Send notification of the deployment to Bitbucket Server
+     * Send notification of a deployment to Bitbucket Server
      *
      * @param deployment the deployment to send
      */

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImpl.java
@@ -1,0 +1,42 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.stripToNull;
+
+public class BitbucketDeploymentClientImpl implements BitbucketDeploymentClient {
+
+    private final BitbucketRequestExecutor bitbucketRequestExecutor;
+    private final String projectKey;
+    private final String repoSlug;
+    private final String revisionSha;
+
+    public BitbucketDeploymentClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey,
+                                         String repoSlug, String revisionSha) {
+        this.bitbucketRequestExecutor = requireNonNull(bitbucketRequestExecutor, "bitbucketRequestExecutor");
+        this.revisionSha = requireNonNull(stripToNull(revisionSha), "revisionSha");
+        this.projectKey = requireNonNull(stripToNull(projectKey), "projectKey");
+        this.repoSlug = requireNonNull(stripToNull(repoSlug), "repoSlug");
+    }
+
+    @Override
+    public void post(BitbucketDeployment deployment) {
+        HttpUrl url = bitbucketRequestExecutor.getBaseUrl().newBuilder()
+                .addPathSegment("rest")
+                .addPathSegment("api")
+                .addPathSegment("1.0")
+                .addPathSegment("projects")
+                .addPathSegment(projectKey)
+                .addPathSegment("repos")
+                .addPathSegment(repoSlug)
+                .addPathSegment("commits")
+                .addPathSegment(revisionSha)
+                .addPathSegment("deployments")
+                .build();
+
+        bitbucketRequestExecutor.makePostRequest(url, deployment, Headers.of());
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImpl.java
@@ -17,9 +17,9 @@ public class BitbucketDeploymentClientImpl implements BitbucketDeploymentClient 
     public BitbucketDeploymentClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey,
                                          String repoSlug, String revisionSha) {
         this.bitbucketRequestExecutor = requireNonNull(bitbucketRequestExecutor, "bitbucketRequestExecutor");
-        this.revisionSha = requireNonNull(stripToNull(revisionSha), "revisionSha");
         this.projectKey = requireNonNull(stripToNull(projectKey), "projectKey");
         this.repoSlug = requireNonNull(stripToNull(repoSlug), "repoSlug");
+        this.revisionSha = requireNonNull(stripToNull(revisionSha), "revisionSha");
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
@@ -1,6 +1,7 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 
 /**
@@ -37,4 +38,23 @@ public interface BitbucketRepositoryClient {
      * @return a client that is ready to use
      */
     BitbucketWebhookClient getWebhookClient();
+
+    /**
+     * Return a client that can post the current status of a build to Bitbucket.
+     *
+     * @param revisionSha      the revision for the build status
+     * @param ciCapabilities   CI capabilities of the remote server
+     * @return a client that can post a build status
+     * @since deployments
+     */
+    BitbucketBuildStatusClient getBuildStatusClient(String revisionSha, BitbucketCICapabilities ciCapabilities);
+
+    /**
+     * Return a client that can post deployment information to Bitbucket.
+     *
+     * @param revisionSha      the revision for the deployment
+     * @return a client that can post deployment information
+     * @since deployments
+     */
+    BitbucketDeploymentClient getDeploymentClient(String revisionSha);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
@@ -1,7 +1,12 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
+import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+import com.google.common.annotations.VisibleForTesting;
 import okhttp3.HttpUrl;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
@@ -12,10 +17,43 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
     private final String projectKey;
     private final String repositorySlug;
 
-    BitbucketRepositoryClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey, String repositorySlug) {
+    BitbucketRepositoryClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey,
+                                  String repositorySlug) {
         this.bitbucketRequestExecutor = requireNonNull(bitbucketRequestExecutor, "bitbucketRequestExecutor");
         this.projectKey = requireNonNull(stripToNull(projectKey), "projectKey");
         this.repositorySlug = requireNonNull(stripToNull(repositorySlug), "repositorySlug");
+    }
+
+    @VisibleForTesting
+    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha,
+                                                           BitbucketSCMRepository bitbucketSCMRepo,
+                                                           BitbucketCICapabilities ciCapabilities,
+                                                           InstanceKeyPairProvider instanceKeyPairProvider,
+                                                           DisplayURLProvider displayURLProvider) {
+        if (ciCapabilities.supportsRichBuildStatus()) {
+            return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
+                    bitbucketSCMRepo.getRepositorySlug(), revisionSha, instanceKeyPairProvider, displayURLProvider);
+        }
+        return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
+    }
+
+    @Override
+    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha, BitbucketCICapabilities ciCapabilities) {
+        if (ciCapabilities.supportsRichBuildStatus()) {
+            return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug,
+                    revisionSha);
+        }
+        return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
+    }
+
+    @Override
+    public BitbucketDeploymentClient getDeploymentClient(String revisionSha) {
+        return new BitbucketDeploymentClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug, revisionSha);
+    }
+
+    @Override
+    public BitbucketFilePathClient getFilePathClient() {
+        return new BitbucketFilePathClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug);
     }
 
     @Override
@@ -32,9 +70,5 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
     @Override
     public BitbucketWebhookClient getWebhookClient() {
         return new BitbucketWebhookClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug);
-    }
-
-    public BitbucketFilePathClient getFilePathClient() {
-        return new BitbucketFilePathClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactory.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.deployments;
 
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
 import com.google.inject.ImplementedBy;
 import hudson.model.Run;
 
@@ -29,7 +30,7 @@ public interface BitbucketDeploymentFactory {
 
     /**
      * Create a deployment from the provided {@link Run}, {@link BitbucketDeploymentEnvironment} and
-     * {@link BitbucketDeployment.DeploymentState}.
+     * {@link DeploymentState}.
      *
      * The value of {@link Run#getResult()} will be ignored and the {@link BitbucketDeployment#getState()} will be
      * populated based on the provided {@code state}
@@ -41,5 +42,5 @@ public interface BitbucketDeploymentFactory {
      */
     BitbucketDeployment createDeployment(Run<?, ?> run,
                                          BitbucketDeploymentEnvironment environment,
-                                         @CheckForNull BitbucketDeployment.DeploymentState state);
+                                         @CheckForNull DeploymentState state);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactory.java
@@ -1,0 +1,45 @@
+package com.atlassian.bitbucket.jenkins.internal.deployments;
+
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.google.inject.ImplementedBy;
+import hudson.model.Run;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * A factory for creating instances of {@link BitbucketDeployment} from job information.
+ *
+ * @since deployments
+ */
+@ImplementedBy(BitbucketDeploymentFactoryImpl.class)
+public interface BitbucketDeploymentFactory {
+
+    /**
+     * Create a deployment from the provided {@link Run} and {@link BitbucketDeploymentEnvironment}.
+     *
+     * The value of {@link BitbucketDeployment#getState()} will be populated based on the {@link Run#getResult()}.
+     *
+     * @param run the run that deployed to the environment
+     * @param environment the environment that was deployed to
+     * @return a {@link BitbucketDeployment} matching the provided information
+     */
+    BitbucketDeployment createDeployment(Run<?, ?> run,
+                                         BitbucketDeploymentEnvironment environment);
+
+    /**
+     * Create a deployment from the provided {@link Run}, {@link BitbucketDeploymentEnvironment} and
+     * {@link BitbucketDeployment.DeploymentState}.
+     *
+     * The value of {@link Run#getResult()} will be ignored and the {@link BitbucketDeployment#getState()} will be
+     * populated based on the provided {@code state}
+     *
+     * @param run the run that deployed to the environment
+     * @param environment the environment that was deployed to
+     * @param state the result of the deployment
+     * @return a {@link BitbucketDeployment} matching the provided information
+     */
+    BitbucketDeployment createDeployment(Run<?, ?> run,
+                                         BitbucketDeploymentEnvironment environment,
+                                         @CheckForNull BitbucketDeployment.DeploymentState state);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
@@ -1,0 +1,75 @@
+package com.atlassian.bitbucket.jenkins.internal.deployments;
+
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.google.common.annotations.VisibleForTesting;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import jenkins.branch.MultiBranchProject;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+
+import javax.annotation.CheckForNull;
+import java.util.Arrays;
+import java.util.Collection;
+
+public final class BitbucketDeploymentFactoryImpl implements BitbucketDeploymentFactory {
+
+    private static final Collection<Result> successfulResults = Arrays.asList(Result.SUCCESS, Result.UNSTABLE);
+
+    private final DisplayURLProvider displayURLProvider;
+
+    public BitbucketDeploymentFactoryImpl() {
+        this(DisplayURLProvider.get());
+    }
+
+    @VisibleForTesting
+    BitbucketDeploymentFactoryImpl(DisplayURLProvider displayURLProvider) {
+        this.displayURLProvider = displayURLProvider;
+    }
+
+    @Override
+    public BitbucketDeployment createDeployment(Run<?, ?> run, BitbucketDeploymentEnvironment environment) {
+        return createDeployment(run, environment, null);
+    }
+
+    @Override
+    public BitbucketDeployment createDeployment(Run<?, ?> run,
+                                                BitbucketDeploymentEnvironment environment,
+                                                @CheckForNull BitbucketDeployment.DeploymentState state) {
+        Job<?, ?> job = run.getParent();
+        String description = getDescription(run);
+        String key = job.getFullName();
+        String name = getName(job);
+        state = state == null ? getStateFromRun(run) : state;
+        String url = displayURLProvider.getRunURL(run);
+
+        return new BitbucketDeployment(run.getNumber(), description, name, environment, key, state, url);
+    }
+
+    private String getDescription(Run<?, ?> run) {
+        String description = run.getDescription();
+        if (description != null) {
+            return description;
+        }
+        return run.getDisplayName();
+    }
+
+    private String getName(Job<?, ?> job) {
+        if (job.getParent() instanceof MultiBranchProject) {
+            return job.getParent().getDisplayName() + " » " + job.getDisplayName();
+        }
+        return job.getDisplayName();
+    }
+
+    private BitbucketDeployment.DeploymentState getStateFromRun(Run<?, ?> run) {
+        Result result = run.getResult();
+        if (result == null) {
+            return BitbucketDeployment.DeploymentState.IN_PROGRESS;
+        }
+        if (successfulResults.contains(result)) {
+            return BitbucketDeployment.DeploymentState.SUCCESSFUL;
+        }
+        return BitbucketDeployment.DeploymentState.FAILED;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.deployments;
 
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.model.Job;
 import hudson.model.Result;
@@ -36,7 +37,7 @@ public final class BitbucketDeploymentFactoryImpl implements BitbucketDeployment
     @Override
     public BitbucketDeployment createDeployment(Run<?, ?> run,
                                                 BitbucketDeploymentEnvironment environment,
-                                                @CheckForNull BitbucketDeployment.DeploymentState state) {
+                                                @CheckForNull DeploymentState state) {
         Job<?, ?> job = run.getParent();
         String description = getDescription(run);
         String key = job.getFullName();
@@ -62,14 +63,14 @@ public final class BitbucketDeploymentFactoryImpl implements BitbucketDeployment
         return job.getDisplayName();
     }
 
-    private BitbucketDeployment.DeploymentState getStateFromRun(Run<?, ?> run) {
+    private DeploymentState getStateFromRun(Run<?, ?> run) {
         Result result = run.getResult();
         if (result == null) {
-            return BitbucketDeployment.DeploymentState.IN_PROGRESS;
+            return DeploymentState.IN_PROGRESS;
         }
         if (successfulResults.contains(result)) {
-            return BitbucketDeployment.DeploymentState.SUCCESSFUL;
+            return DeploymentState.SUCCESSFUL;
         }
-        return BitbucketDeployment.DeploymentState.FAILED;
+        return DeploymentState.FAILED;
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImpl.java
@@ -14,7 +14,7 @@ import javax.annotation.CheckForNull;
 import java.util.Arrays;
 import java.util.Collection;
 
-public final class BitbucketDeploymentFactoryImpl implements BitbucketDeploymentFactory {
+public class BitbucketDeploymentFactoryImpl implements BitbucketDeploymentFactory {
 
     private static final Collection<Result> successfulResults = Arrays.asList(Result.SUCCESS, Result.UNSTABLE);
 
@@ -39,21 +39,13 @@ public final class BitbucketDeploymentFactoryImpl implements BitbucketDeployment
                                                 BitbucketDeploymentEnvironment environment,
                                                 @CheckForNull DeploymentState state) {
         Job<?, ?> job = run.getParent();
-        String description = getDescription(run);
         String key = job.getFullName();
         String name = getName(job);
         state = state == null ? getStateFromRun(run) : state;
+        String description = state.getDescriptiveTest(name, environment.getName());
         String url = displayURLProvider.getRunURL(run);
 
         return new BitbucketDeployment(run.getNumber(), description, name, environment, key, state, url);
-    }
-
-    private String getDescription(Run<?, ?> run) {
-        String description = run.getDescription();
-        if (description != null) {
-            return description;
-        }
-        return run.getDisplayName();
     }
 
     private String getName(Job<?, ?> job) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/package-info.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Add package level annotations to indicate everything is non-null by default.
+ */
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.atlassian.bitbucket.jenkins.internal.deployments;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/AtlassianServerCapabilities.java
@@ -16,6 +16,7 @@ public class AtlassianServerCapabilities {
 
     public static final String WEBHOOK_CAPABILITY_KEY = "webhooks";
     public static final String RICH_BUILDSTATUS_CAPABILITY_KEY = "build";
+    public static final String DEPLOYMENTS_CAPABILITY_KEY = "deployment";
 
     private final String application;
     private final Map<String, String> capabilities;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketCDCapabilities {
 
-    public static final String DEPLOYMENTS = "deployments";
+    public static final String DEPLOYMENTS_CAPABILITY_VALUE = "deployments";
 
     private final Set<String> cdCapabilities;
 
@@ -25,6 +25,6 @@ public class BitbucketCDCapabilities {
     }
 
     public boolean supportsDeployments() {
-        return cdCapabilities.contains(DEPLOYMENTS);
+        return cdCapabilities.contains(DEPLOYMENTS_CAPABILITY_VALUE);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
@@ -1,0 +1,30 @@
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Objects.requireNonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCDCapabilities {
+
+    public static final String DEPLOYMENTS = "deployments";
+
+    private final Set<String> cdCapabilities;
+
+    @JsonCreator
+    public BitbucketCDCapabilities(Set<String> cdCapabilities) {
+        this.cdCapabilities = unmodifiableSet(requireNonNull(cdCapabilities, "cdCapabilities"));
+    }
+
+    public Set<String> getCdCapabilities() {
+        return cdCapabilities;
+    }
+
+    public boolean supportsDeployments() {
+        return cdCapabilities.contains(DEPLOYMENTS);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeployment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeployment.java
@@ -9,6 +9,11 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * The details of a deployment.
+ *
+ * @since deployments
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BitbucketDeployment {
@@ -113,15 +118,5 @@ public class BitbucketDeployment {
                ", state=" + state +
                ", url='" + url + '\'' +
                '}';
-    }
-
-    public enum DeploymentState {
-        PENDING,
-        IN_PROGRESS,
-        CANCELLED,
-        FAILED,
-        ROLLED_BACK,
-        SUCCESSFUL,
-        UNKNOWN
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeployment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeployment.java
@@ -1,0 +1,127 @@
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BitbucketDeployment {
+
+    private static final String DEPLOYMENT_SEQUENCE_NUMBER = "deploymentSequenceNumber";
+    private static final String DESCRIPTION = "description";
+    private static final String DISPLAY_NAME = "displayName";
+    private static final String ENVIRONMENT = "environment";
+    private static final String KEY = "key";
+    private static final String STATE = "state";
+    private static final String URL = "url";
+
+    private final long deploymentSequenceNumber;
+    private final String description;
+    private final String displayName;
+    private final BitbucketDeploymentEnvironment environment;
+    private final String key;
+    private final DeploymentState state;
+    private final String url;
+
+    @JsonCreator
+    public BitbucketDeployment(@JsonProperty(DEPLOYMENT_SEQUENCE_NUMBER) long deploymentSequenceNumber,
+                               @JsonProperty(DESCRIPTION) String description,
+                               @JsonProperty(DISPLAY_NAME) String displayName,
+                               @JsonProperty(ENVIRONMENT) BitbucketDeploymentEnvironment environment,
+                               @JsonProperty(KEY) String key,
+                               @JsonProperty(STATE) DeploymentState state,
+                               @JsonProperty(URL) String url) {
+        this.deploymentSequenceNumber = deploymentSequenceNumber;
+        this.description = requireNonNull(description, "description");
+        this.displayName = requireNonNull(displayName, "displayName");
+        this.environment = requireNonNull(environment, "environment");
+        this.key = requireNonNull(key, "key");
+        this.state = requireNonNull(state, "state");
+        this.url = requireNonNull(url, "url");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BitbucketDeployment that = (BitbucketDeployment) o;
+        return deploymentSequenceNumber == that.deploymentSequenceNumber &&
+               Objects.equals(description, that.description) &&
+               Objects.equals(displayName, that.displayName) &&
+               Objects.equals(environment, that.environment) && Objects.equals(key, that.key) &&
+               state == that.state && Objects.equals(url, that.url);
+    }
+
+    @JsonProperty(DEPLOYMENT_SEQUENCE_NUMBER)
+    public long getDeploymentSequenceNumber() {
+        return deploymentSequenceNumber;
+    }
+
+    @JsonProperty(DESCRIPTION)
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty(DISPLAY_NAME)
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonProperty(ENVIRONMENT)
+    public BitbucketDeploymentEnvironment getEnvironment() {
+        return environment;
+    }
+
+    @JsonProperty(KEY)
+    public String getKey() {
+        return key;
+    }
+
+    @JsonProperty(STATE)
+    public DeploymentState getState() {
+        return state;
+    }
+
+    @JsonProperty(URL)
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deploymentSequenceNumber, description, displayName, environment, key, state, url);
+    }
+
+    @Override
+    public String toString() {
+        return "BitbucketDeployment{" +
+               "deploymentSequenceNumber=" + deploymentSequenceNumber +
+               ", description='" + description + '\'' +
+               ", displayName='" + displayName + '\'' +
+               ", environment=" + environment +
+               ", key='" + key + '\'' +
+               ", state=" + state +
+               ", url='" + url + '\'' +
+               '}';
+    }
+
+    public enum DeploymentState {
+        PENDING,
+        IN_PROGRESS,
+        CANCELLED,
+        FAILED,
+        ROLLED_BACK,
+        SUCCESSFUL,
+        UNKNOWN
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
@@ -1,0 +1,154 @@
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.stripToNull;
+
+/**
+ * The details of an environment that was deployed to.
+ *
+ * @since deployments
+ */
+public final class BitbucketDeploymentEnvironment {
+
+    private static final String DISPLAY_NAME = "displayName";
+    private static final String KEY = "key";
+    private static final String TYPE = "type";
+    private static final String URL = "url";
+
+    private final String key;
+    private final String name;
+    private final String type;
+    private final String url;
+
+    private BitbucketDeploymentEnvironment(Builder builder) {
+        key = builder.key;
+        name = builder.name;
+        type = builder.type == null ? null : builder.type.name();
+        url = builder.url;
+    }
+
+    @JsonCreator
+    public BitbucketDeploymentEnvironment(@JsonProperty(KEY) String key,
+                                          @JsonProperty(DISPLAY_NAME) String name,
+                                          @JsonProperty(TYPE) String type,
+                                          @JsonProperty(URL) String url) {
+        this.key = key;
+        this.name = name;
+        this.type = type;
+        this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BitbucketDeploymentEnvironment that = (BitbucketDeploymentEnvironment) o;
+        return Objects.equals(key, that.key) && Objects.equals(name, that.name) &&
+               Objects.equals(type, that.type) && Objects.equals(url, that.url);
+    }
+
+    /**
+     * @return a unique identifier for this environment
+     */
+    @JsonProperty(DISPLAY_NAME)
+    @Nonnull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return a human-readable name for this environment
+     */
+    @JsonProperty(KEY)
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the {@link Type} of environment, or {@code null} to indicate no type
+     */
+    @JsonProperty(TYPE)
+    @Nullable
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the URL of the environment, or {@code null} to indicate no URL
+     */
+    @JsonProperty(URL)
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, name, type, url);
+    }
+
+    @Override
+    public String toString() {
+        return "BitbucketDeploymentEnvironment{" +
+               "key='" + key + '\'' +
+               ", name='" + name + '\'' +
+               ", type='" + type + '\'' +
+               ", url='" + url + '\'' +
+               '}';
+    }
+
+    /**
+     * The types of environments available via the Bitbucket Server API.
+     */
+    public enum Type {
+        DEVELOPMENT,
+        TESTING,
+        STAGING,
+        PRODUCTION;
+    }
+
+    public static class Builder {
+
+        private final String key;
+        private final String name;
+
+        private Type type;
+        private String url;
+
+        public Builder(@Nonnull String key, @Nonnull String name) {
+            this.key = requireNonNull(stripToNull(key), "key");
+            this.name = requireNonNull(stripToNull(name), "name");
+        }
+
+        @Nonnull
+        public BitbucketDeploymentEnvironment build() {
+            return new BitbucketDeploymentEnvironment(this);
+        }
+
+        @Nonnull
+        public Builder type(@Nullable Type value) {
+            type = value;
+
+            return this;
+        }
+
+        @Nonnull
+        public Builder url(@Nullable String value) {
+            url = stripToNull(value);
+
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
@@ -77,7 +77,7 @@ public final class BitbucketDeploymentEnvironment {
     }
 
     /**
-     * @return the {@link Type} of environment, or {@code null} to indicate no type
+     * @return the {@link BitbucketDeploymentEnvironmentType} of environment, or {@code null} to indicate no type
      */
     @JsonProperty(TYPE)
     @Nullable
@@ -109,22 +109,12 @@ public final class BitbucketDeploymentEnvironment {
                '}';
     }
 
-    /**
-     * The types of environments available via the Bitbucket Server API.
-     */
-    public enum Type {
-        DEVELOPMENT,
-        TESTING,
-        STAGING,
-        PRODUCTION;
-    }
-
     public static class Builder {
 
         private final String key;
         private final String name;
 
-        private Type type;
+        private BitbucketDeploymentEnvironmentType type;
         private String url;
 
         public Builder(@Nonnull String key, @Nonnull String name) {
@@ -138,7 +128,7 @@ public final class BitbucketDeploymentEnvironment {
         }
 
         @Nonnull
-        public Builder type(@Nullable Type value) {
+        public Builder type(@Nullable BitbucketDeploymentEnvironmentType value) {
             type = value;
 
             return this;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
@@ -61,7 +61,7 @@ public final class BitbucketDeploymentEnvironment {
     /**
      * @return a unique identifier for this environment
      */
-    @JsonProperty(DISPLAY_NAME)
+    @JsonProperty(KEY)
     @Nonnull
     public String getKey() {
         return key;
@@ -70,7 +70,7 @@ public final class BitbucketDeploymentEnvironment {
     /**
      * @return a human-readable name for this environment
      */
-    @JsonProperty(KEY)
+    @JsonProperty(DISPLAY_NAME)
     @Nonnull
     public String getName() {
         return name;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironment.java
@@ -1,8 +1,11 @@
 package com.atlassian.bitbucket.jenkins.internal.model.deployment;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -15,7 +18,9 @@ import static org.apache.commons.lang3.StringUtils.stripToNull;
  *
  * @since deployments
  */
-public final class BitbucketDeploymentEnvironment {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BitbucketDeploymentEnvironment {
 
     private static final String DISPLAY_NAME = "displayName";
     private static final String KEY = "key";
@@ -28,17 +33,14 @@ public final class BitbucketDeploymentEnvironment {
     private final String url;
 
     private BitbucketDeploymentEnvironment(Builder builder) {
-        key = builder.key;
-        name = builder.name;
-        type = builder.type == null ? null : builder.type.name();
-        url = builder.url;
+        this(builder.key, builder.name, builder.type == null ? null : builder.type.name(), builder.url);
     }
 
     @JsonCreator
     public BitbucketDeploymentEnvironment(@JsonProperty(KEY) String key,
                                           @JsonProperty(DISPLAY_NAME) String name,
-                                          @JsonProperty(TYPE) String type,
-                                          @JsonProperty(URL) String url) {
+                                          @CheckForNull @JsonProperty(TYPE) String type,
+                                          @CheckForNull @JsonProperty(URL) String url) {
         this.key = key;
         this.name = name;
         this.type = type;
@@ -62,7 +64,6 @@ public final class BitbucketDeploymentEnvironment {
      * @return a unique identifier for this environment
      */
     @JsonProperty(KEY)
-    @Nonnull
     public String getKey() {
         return key;
     }
@@ -71,7 +72,6 @@ public final class BitbucketDeploymentEnvironment {
      * @return a human-readable name for this environment
      */
     @JsonProperty(DISPLAY_NAME)
-    @Nonnull
     public String getName() {
         return name;
     }
@@ -80,7 +80,7 @@ public final class BitbucketDeploymentEnvironment {
      * @return the {@link BitbucketDeploymentEnvironmentType} of environment, or {@code null} to indicate no type
      */
     @JsonProperty(TYPE)
-    @Nullable
+    @CheckForNull
     public String getType() {
         return type;
     }
@@ -89,7 +89,7 @@ public final class BitbucketDeploymentEnvironment {
      * @return the URL of the environment, or {@code null} to indicate no URL
      */
     @JsonProperty(URL)
-    @Nullable
+    @CheckForNull
     public String getUrl() {
         return url;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironmentType.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketDeploymentEnvironmentType.java
@@ -1,0 +1,14 @@
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+/**
+ * The types of environments available via the Bitbucket Server API.
+ *
+ * @since deployments
+ */
+public enum BitbucketDeploymentEnvironmentType {
+
+    DEVELOPMENT,
+    TESTING,
+    STAGING,
+    PRODUCTION;
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
@@ -43,6 +43,6 @@ public enum DeploymentState {
     }
 
     public String getDescriptiveTest(String jobName, String environmentName) {
-        return null;
+        return String.format(formatString, jobName, environmentName);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
@@ -7,11 +7,42 @@ package com.atlassian.bitbucket.jenkins.internal.model.deployment;
  */
 public enum DeploymentState {
 
-    PENDING,
-    IN_PROGRESS,
-    CANCELLED,
-    FAILED,
-    ROLLED_BACK,
-    SUCCESSFUL,
-    UNKNOWN
+    /**
+     * The deployment has been scheduled, but has not started.
+     */
+    PENDING("%s is waiting to deploy to %s."),
+    /**
+     * The deployment is currently in progress.
+     */
+    IN_PROGRESS("%s is deploying to %s."),
+    /**
+     * The deployment started, but was stopped part way through.
+     */
+    CANCELLED("%s deployment to %s cancelled."),
+    /**
+     * The deployment failed to complete.
+     */
+    FAILED("%s failed to deploy to %s."),
+    /**
+     * The commit is no longer deployed to the the environment.
+     */
+    ROLLED_BACK("%s deployment to %s was rolled back."),
+    /**
+     * The deployment was successful.
+     */
+    SUCCESSFUL("%s successfully deployed to %s"),
+    /**
+     * The state of the deployment is not known.
+     */
+    UNKNOWN("State of %s deploying to %s is unknown.");
+
+    private final String formatString;
+
+    DeploymentState(String formatString) {
+        this.formatString = formatString;
+    }
+
+    public String getDescriptiveTest(String jobName, String environmentName) {
+        return null;
+    }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/DeploymentState.java
@@ -1,0 +1,17 @@
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+/**
+ * The possible states of a deployment.
+ *
+ * @since deployments
+ */
+public enum DeploymentState {
+
+    PENDING,
+    IN_PROGRESS,
+    CANCELLED,
+    FAILED,
+    ROLLED_BACK,
+    SUCCESSFUL,
+    UNKNOWN
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/package-info.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Add package level annotations to indicate everything is non-null by default.
+ */
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.atlassian.bitbucket.jenkins.internal.model.deployment;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -8,6 +8,7 @@ import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsPro
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
@@ -90,7 +91,10 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
                     buildStatus.getState(), server.getServerName(), revisionAction.getRevisionSha1(),
                     buildStatus.getRef()));
 
-            bbsClient.getBuildStatusClient(revisionAction.getRevisionSha1(), revisionAction.getBitbucketSCMRepo(), ciCapabilities)
+            BitbucketSCMRepository bitbucketSCMRepo = revisionAction.getBitbucketSCMRepo();
+            bbsClient.getProjectClient(bitbucketSCMRepo.getProjectKey())
+                    .getRepositoryClient(bitbucketSCMRepo.getRepositorySlug())
+                    .getBuildStatusClient(revisionAction.getRevisionSha1(), ciCapabilities)
                     .post(buildStatus);
         } catch (RuntimeException e) {
             String errorMsg = BUILD_STATUS_ERROR_MSG + ' ' + e.getMessage();

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
@@ -7,6 +7,8 @@ import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.model.*;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironmentType;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
 import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.util.TestUtils;
@@ -327,11 +329,11 @@ public class BitbucketClientFactoryImplTest {
     @Test
     public void testPostDeployment() throws IOException {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
-                .type(BitbucketDeploymentEnvironment.Type.DEVELOPMENT)
+                .type(BitbucketDeploymentEnvironmentType.DEVELOPMENT)
                 .url("http://url.to.env")
                 .build();
         BitbucketDeployment deployment = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.FAILED, "http://url.to.job");
+                "my-key", DeploymentState.FAILED, "http://url.to.job");
         String projectKey = "myProject";
         String repoSlug = "myRepo";
         when(bitbucketSCMRepo.getProjectKey()).thenReturn(projectKey);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImplTest.java
@@ -5,25 +5,11 @@ import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials
 import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
 import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.model.*;
-import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
-import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
-import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironmentType;
-import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
-import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
-import com.atlassian.bitbucket.jenkins.internal.util.TestUtils;
-import okhttp3.Request;
-import okio.Buffer;
-import org.apache.commons.lang3.StringUtils;
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.IOException;
-import java.security.interfaces.RSAPrivateKey;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,28 +21,20 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketClientFactoryImplTest {
 
-    private static final String REVISION = "bc891c29e289e373fbf8daff411480e8da6d5252";
     private static final String MIRROR_SELF_LINK = "https://us-east.bitbucket.example.com/rest/mirroring/1.0/repos/1?" +
                                                    "jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9" +
                                                    ".TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
 
     private BitbucketClientFactoryImpl anonymousClientFactory;
     private final FakeRemoteHttpServer mockExecutor = new FakeRemoteHttpServer();
-    @Mock
-    private BitbucketCICapabilities ciCapabilities;
-    @Mock
-    private BitbucketSCMRepository bitbucketSCMRepo;
 
     @Before
     public void setup() {
         anonymousClientFactory = getClientFactory(BITBUCKET_BASE_URL, BitbucketCredentials.ANONYMOUS_CREDENTIALS);
-        when(ciCapabilities.supportsRichBuildStatus()).thenReturn(false);
     }
 
     @Test
@@ -67,63 +45,6 @@ public class BitbucketClientFactoryImplTest {
         assertTrue(response.isBitbucketServer());
         assertEquals("stash", response.getApplication());
         assertThat(response.getCapabilities(), hasKey("webhooks"));
-    }
-
-    @Test
-    public void testPostBuildStatus() throws IOException {
-        String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
-        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
-                .setName("Local BBS Project")
-                .setDescription("#15 in progress")
-                .build();
-
-        String url = BITBUCKET_BASE_URL + "/rest/build-status/1.0/commits/" + REVISION;
-        String requestString = readFileToString("/build-status-request.json");
-        mockExecutor.mapPostRequestToResult(url, requestString, "");
-        Buffer b = new Buffer();
-
-        BitbucketBuildStatusClient client =
-                anonymousClientFactory.getBuildStatusClient(REVISION, bitbucketSCMRepo, ciCapabilities);
-        client.post(buildStatus);
-
-        Request clientRequest = mockExecutor.getRequest(url);
-        clientRequest.body().writeTo(b);
-        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
-    }
-
-    @Test
-    public void testPostBuildStatusModenClient() throws IOException {
-        String projectKey = "myProject";
-        String repoSlug = "myRepo";
-        String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
-
-        InstanceKeyPairProvider keyPairProvider = mock(InstanceKeyPairProvider.class);
-        when(keyPairProvider.getPrivate()).thenReturn((RSAPrivateKey) TestUtils.createTestKeyPair().getPrivate());
-        DisplayURLProvider displayURLProvider = mock(DisplayURLProvider.class);
-        when(displayURLProvider.getRoot()).thenReturn("http://localhost:8080/jenkins");
-
-        when(ciCapabilities.supportsRichBuildStatus()).thenReturn(true);
-        when(bitbucketSCMRepo.getProjectKey()).thenReturn(projectKey);
-        when(bitbucketSCMRepo.getRepositorySlug()).thenReturn(repoSlug);
-
-        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
-                .setName("Local BBS Project")
-                .setDescription("#15 in progress")
-                .build();
-
-        String url = String.format("%s/rest/api/1.0/projects/%s/repos/%s/commits/%s/builds", BITBUCKET_BASE_URL,
-                projectKey, repoSlug, REVISION);
-        String requestString = readFileToString("/build-status-request.json");
-        mockExecutor.mapPostRequestToResult(url, requestString, "");
-        Buffer b = new Buffer();
-
-        BitbucketBuildStatusClient client =
-                anonymousClientFactory.getBuildStatusClient(REVISION, bitbucketSCMRepo, ciCapabilities, keyPairProvider, displayURLProvider);
-        client.post(buildStatus);
-
-        Request clientRequest = mockExecutor.getRequest(url);
-        clientRequest.body().writeTo(b);
-        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
     }
 
     @Test
@@ -324,33 +245,6 @@ public class BitbucketClientFactoryImplTest {
         BitbucketWebhookSupportedEvents hookSupportedEvents =
                 anonymousClientFactory.getCapabilityClient().getWebhookSupportedEvents();
         assertThat(hookSupportedEvents.getApplicationWebHooks(), hasItem(REPO_REF_CHANGE.getEventId()));
-    }
-
-    @Test
-    public void testPostDeployment() throws IOException {
-        BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
-                .type(BitbucketDeploymentEnvironmentType.DEVELOPMENT)
-                .url("http://url.to.env")
-                .build();
-        BitbucketDeployment deployment = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.FAILED, "http://url.to.job");
-        String projectKey = "myProject";
-        String repoSlug = "myRepo";
-        when(bitbucketSCMRepo.getProjectKey()).thenReturn(projectKey);
-        when(bitbucketSCMRepo.getRepositorySlug()).thenReturn(repoSlug);
-
-        String url = String.format("%s/rest/api/1.0/projects/%s/repos/%s/commits/%s/deployments", BITBUCKET_BASE_URL,
-                projectKey, repoSlug, REVISION);
-        String requestString = readFileToString("/deployments/send_deployment_request.json");
-        mockExecutor.mapPostRequestToResult(url, requestString, "");
-        Buffer b = new Buffer();
-
-        BitbucketDeploymentClient client = anonymousClientFactory.getDeploymentClient(REVISION, bitbucketSCMRepo);
-        client.post(deployment);
-
-        Request clientRequest = mockExecutor.getRequest(url);
-        clientRequest.body().writeTo(b);
-        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
     }
 
     @Test(expected = BitbucketMissingCapabilityException.class)

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImplTest.java
@@ -1,0 +1,54 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import okhttp3.Request;
+import okio.Buffer;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials.ANONYMOUS_CREDENTIALS;
+import static com.atlassian.bitbucket.jenkins.internal.util.TestUtils.*;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
+import static org.apache.commons.lang3.StringUtils.normalizeSpace;
+import static org.junit.Assert.assertEquals;
+
+public class BitbucketDeploymentClientImplTest {
+
+    private static final String DEPLOYMENTS_URL = "%s/rest/api/1.0/projects/%s/repos/%s/commits/%s/deployments";
+    private static final String projectKey = "proj";
+    private static final String repoSlug = "repo";
+    private static final String revisionSha = "deadbeef";
+
+    private final FakeRemoteHttpServer fakeRemoteHttpServer = new FakeRemoteHttpServer();
+    private final HttpRequestExecutor requestExecutor = new HttpRequestExecutorImpl(fakeRemoteHttpServer);
+    private final BitbucketRequestExecutor bitbucketRequestExecutor = new BitbucketRequestExecutor(BITBUCKET_BASE_URL,
+            requestExecutor, OBJECT_MAPPER, ANONYMOUS_CREDENTIALS);
+    private BitbucketDeploymentClient client = new BitbucketDeploymentClientImpl(bitbucketRequestExecutor, projectKey,
+            repoSlug, revisionSha);
+
+    @Test
+    public void testSendDeployment() throws IOException {
+        String response = readFileToString("/deployments/send_deployment_result.json");
+        String requestBody = readFileToString("/deployments/send_deployment_request.json");
+        String deploymentsUrl = format(DEPLOYMENTS_URL, BITBUCKET_BASE_URL, projectKey, repoSlug, revisionSha);
+        fakeRemoteHttpServer.mapPostRequestToResult(deploymentsUrl, requestBody, response);
+
+        BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
+                .type(BitbucketDeploymentEnvironment.Type.DEVELOPMENT)
+                .url("http://url.to.env")
+                .build();
+        BitbucketDeployment deployment = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
+                "my-key", BitbucketDeployment.DeploymentState.FAILED, "http://url.to.job");
+        client.post(deployment);
+
+        Request recordedRequest = fakeRemoteHttpServer.getRequest(deploymentsUrl);
+        Buffer b = new Buffer();
+        recordedRequest.body().writeTo(b);
+        assertEquals("Request body not same as expected.", deleteWhitespace(normalizeSpace(requestBody)), new String(b.readByteArray()));
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketDeploymentClientImplTest.java
@@ -4,6 +4,8 @@ import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
 import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironmentType;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
 import okhttp3.Request;
 import okio.Buffer;
 import org.junit.Test;
@@ -39,11 +41,11 @@ public class BitbucketDeploymentClientImplTest {
         fakeRemoteHttpServer.mapPostRequestToResult(deploymentsUrl, requestBody, response);
 
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
-                .type(BitbucketDeploymentEnvironment.Type.DEVELOPMENT)
+                .type(BitbucketDeploymentEnvironmentType.DEVELOPMENT)
                 .url("http://url.to.env")
                 .build();
         BitbucketDeployment deployment = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.FAILED, "http://url.to.job");
+                "my-key", DeploymentState.FAILED, "http://url.to.job");
         client.post(deployment);
 
         Request recordedRequest = fakeRemoteHttpServer.getRequest(deploymentsUrl);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
@@ -1,0 +1,132 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
+import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
+import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironmentType;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
+import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+import com.atlassian.bitbucket.jenkins.internal.util.TestUtils;
+import okhttp3.Request;
+import okio.Buffer;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.security.interfaces.RSAPrivateKey;
+
+import static com.atlassian.bitbucket.jenkins.internal.util.TestUtils.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketRepositoryClientImplTest {
+
+    private static final String PROJECT_KEY = "PROJECT_1";
+    private static final String REPO_SLUG = "rep_1";
+    private static final String REVISION = "bc891c29e289e373fbf8daff411480e8da6d5252";
+
+    private final FakeRemoteHttpServer mockExecutor = new FakeRemoteHttpServer();
+    @Mock
+    private BitbucketSCMRepository bitbucketSCMRepo;
+    @Mock
+    private BitbucketCICapabilities ciCapabilities;
+    private BitbucketRepositoryClientImpl repositoryClient;
+
+    @Before
+    public void setup() {
+        BitbucketRequestExecutor executor = new BitbucketRequestExecutor(BITBUCKET_BASE_URL,
+                new HttpRequestExecutorImpl(mockExecutor), OBJECT_MAPPER, BitbucketCredentials.ANONYMOUS_CREDENTIALS);
+        repositoryClient = new BitbucketRepositoryClientImpl(executor, PROJECT_KEY, REPO_SLUG);
+        when(ciCapabilities.supportsRichBuildStatus()).thenReturn(false);
+        when(bitbucketSCMRepo.getProjectKey()).thenReturn(PROJECT_KEY);
+        when(bitbucketSCMRepo.getRepositorySlug()).thenReturn(REPO_SLUG);
+    }
+
+    @Test
+    public void testPostBuildStatus() throws IOException {
+        String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
+        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
+                .setName("Local BBS Project")
+                .setDescription("#15 in progress")
+                .build();
+
+        String url = BITBUCKET_BASE_URL + "/rest/build-status/1.0/commits/" + REVISION;
+        String requestString = readFileToString("/build-status-request.json");
+        mockExecutor.mapPostRequestToResult(url, requestString, "");
+        Buffer b = new Buffer();
+
+        BitbucketBuildStatusClient client = repositoryClient.getBuildStatusClient(REVISION, ciCapabilities);
+        client.post(buildStatus);
+
+        Request clientRequest = mockExecutor.getRequest(url);
+        clientRequest.body().writeTo(b);
+        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
+    }
+
+    @Test
+    public void testPostBuildStatusModernClient() throws IOException {
+        String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
+
+        InstanceKeyPairProvider keyPairProvider = mock(InstanceKeyPairProvider.class);
+        when(keyPairProvider.getPrivate()).thenReturn((RSAPrivateKey) TestUtils.createTestKeyPair().getPrivate());
+        DisplayURLProvider displayURLProvider = mock(DisplayURLProvider.class);
+        when(displayURLProvider.getRoot()).thenReturn("http://localhost:8080/jenkins");
+
+        when(ciCapabilities.supportsRichBuildStatus()).thenReturn(true);
+
+        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
+                .setName("Local BBS Project")
+                .setDescription("#15 in progress")
+                .build();
+
+        String url = String.format("%s/rest/api/1.0/projects/%s/repos/%s/commits/%s/builds", BITBUCKET_BASE_URL,
+                PROJECT_KEY, REPO_SLUG, REVISION);
+        String requestString = readFileToString("/build-status-request.json");
+        mockExecutor.mapPostRequestToResult(url, requestString, "");
+        Buffer b = new Buffer();
+
+        BitbucketBuildStatusClient client =
+                repositoryClient.getBuildStatusClient(REVISION, bitbucketSCMRepo, ciCapabilities, keyPairProvider, displayURLProvider);
+        client.post(buildStatus);
+
+        Request clientRequest = mockExecutor.getRequest(url);
+        clientRequest.body().writeTo(b);
+        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
+    }
+
+    @Test
+    public void testPostDeployment() throws IOException {
+        BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
+                .type(BitbucketDeploymentEnvironmentType.DEVELOPMENT)
+                .url("http://url.to.env")
+                .build();
+        BitbucketDeployment deployment = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
+                "my-key", DeploymentState.FAILED, "http://url.to.job");
+
+        String url = String.format("%s/rest/api/1.0/projects/%s/repos/%s/commits/%s/deployments", BITBUCKET_BASE_URL,
+                PROJECT_KEY, REPO_SLUG, REVISION);
+        String requestString = readFileToString("/deployments/send_deployment_request.json");
+        mockExecutor.mapPostRequestToResult(url, requestString, "");
+        Buffer b = new Buffer();
+
+        BitbucketDeploymentClient client = repositoryClient.getDeploymentClient(REVISION);
+        client.post(deployment);
+
+        Request clientRequest = mockExecutor.getRequest(url);
+        clientRequest.body().writeTo(b);
+        assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(new String(b.readByteArray())));
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImplTest.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.deployments;
 
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeployment;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironment;
+import com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -43,7 +44,7 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.FAILED, RUN_URL);
+                "my-key", DeploymentState.FAILED, RUN_URL);
         Result result = Result.FAILURE;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -57,7 +58,7 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.SUCCESSFUL, RUN_URL);
+                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
         Result result = Result.SUCCESS;
         FreeStyleBuild run = mockRun(expected, result);
         // Force the run to have no description
@@ -74,7 +75,7 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.IN_PROGRESS, RUN_URL);
+                "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
         Result result = null;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -88,7 +89,7 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my description", "my display name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.SUCCESSFUL, RUN_URL);
+                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
         Result result = Result.SUCCESS;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -102,7 +103,7 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.SUCCESSFUL, RUN_URL);
+                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
         Result result = Result.UNSTABLE;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -116,12 +117,12 @@ public class BitbucketDeploymentFactoryImplTest {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
         BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", BitbucketDeployment.DeploymentState.IN_PROGRESS, RUN_URL);
+                "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
         Result result = Result.SUCCESS; // Something different to expected to make sure we're using that instead
         FreeStyleBuild run = mockRun(expected, result);
 
         BitbucketDeployment actual = deploymentFactory.createDeployment(run, environment,
-                BitbucketDeployment.DeploymentState.IN_PROGRESS);
+                DeploymentState.IN_PROGRESS);
 
         assertThat(actual, equalTo(expected));
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/BitbucketDeploymentFactoryImplTest.java
@@ -43,27 +43,10 @@ public class BitbucketDeploymentFactoryImplTest {
     public void testCreateDeploymentFailed() {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.FAILED, RUN_URL);
+        BitbucketDeployment expected = new BitbucketDeployment(42, "my-display-name failed to deploy to My-env.",
+                "my-display-name", environment, "my-key", DeploymentState.FAILED, RUN_URL);
         Result result = Result.FAILURE;
         FreeStyleBuild run = mockRun(expected, result);
-
-        BitbucketDeployment actual = deploymentFactory.createDeployment(run, environment);
-
-        assertThat(actual, equalTo(expected));
-    }
-
-    @Test
-    public void testCreateDeploymentFallsBackOnDisplayNameWhenNoDescription() {
-        BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
-                .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
-        Result result = Result.SUCCESS;
-        FreeStyleBuild run = mockRun(expected, result);
-        // Force the run to have no description
-        when(run.getDescription()).thenReturn(null);
-        when(run.getDisplayName()).thenReturn(expected.getDescription());
 
         BitbucketDeployment actual = deploymentFactory.createDeployment(run, environment);
 
@@ -74,8 +57,8 @@ public class BitbucketDeploymentFactoryImplTest {
     public void testCreateDeploymentInProgress() {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
+        BitbucketDeployment expected = new BitbucketDeployment(42, "my-display-name is deploying to My-env.",
+                "my-display-name", environment, "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
         Result result = null;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -88,8 +71,8 @@ public class BitbucketDeploymentFactoryImplTest {
     public void testCreateDeploymentSuccessful() {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my description", "my display name", environment,
-                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
+        BitbucketDeployment expected = new BitbucketDeployment(42, "my display name successfully deployed to My-env",
+                "my display name", environment, "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
         Result result = Result.SUCCESS;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -102,8 +85,8 @@ public class BitbucketDeploymentFactoryImplTest {
     public void testCreateDeploymentUnstable() {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
+        BitbucketDeployment expected = new BitbucketDeployment(42, "my-display-name successfully deployed to My-env",
+                "my-display-name", environment, "my-key", DeploymentState.SUCCESSFUL, RUN_URL);
         Result result = Result.UNSTABLE;
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -116,8 +99,8 @@ public class BitbucketDeploymentFactoryImplTest {
     public void testCreateDeploymentWithSpecificState() {
         BitbucketDeploymentEnvironment environment = new BitbucketDeploymentEnvironment.Builder("MY-ENV", "My-env")
                 .build();
-        BitbucketDeployment expected = new BitbucketDeployment(42, "my-description", "my-display-name", environment,
-                "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
+        BitbucketDeployment expected = new BitbucketDeployment(42, "my-display-name is deploying to My-env.",
+                "my-display-name", environment, "my-key", DeploymentState.IN_PROGRESS, RUN_URL);
         Result result = Result.SUCCESS; // Something different to expected to make sure we're using that instead
         FreeStyleBuild run = mockRun(expected, result);
 
@@ -132,7 +115,6 @@ public class BitbucketDeploymentFactoryImplTest {
         FreeStyleProject job = mock(FreeStyleProject.class);
         when(run.getParent()).thenReturn(job);
         when(job.getParent()).thenReturn(jenkins);
-        when(run.getDescription()).thenReturn(expected.getDescription());
         when(run.getNumber()).thenReturn((int) expected.getDeploymentSequenceNumber());
         when(run.getResult()).thenReturn(result);
         when(job.getDisplayName()).thenReturn(expected.getDisplayName());

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/mocks/TestBitbucketClientFactoryHandler.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/mocks/TestBitbucketClientFactoryHandler.java
@@ -8,6 +8,7 @@ import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfigurat
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+import org.mockito.Answers;
 
 import java.util.HashSet;
 
@@ -19,7 +20,7 @@ public class TestBitbucketClientFactoryHandler {
 
     private final BitbucketClientFactoryProvider clientFactoryProvider =
             mock(BitbucketClientFactoryProvider.class);
-    private final BitbucketClientFactory clientFactory = mock(BitbucketClientFactory.class);
+    private final BitbucketClientFactory clientFactory = mock(BitbucketClientFactory.class, Answers.RETURNS_DEEP_STUBS);
     private final BitbucketCapabilitiesClient capabilitiesClient = mock(BitbucketCapabilitiesClient.class);
     private final BitbucketCICapabilities ciCapabilities = mock(BitbucketCICapabilities.class);
     private final BitbucketBuildStatusClient buildStatusClient = mock(BitbucketBuildStatusClient.class);
@@ -50,7 +51,11 @@ public class TestBitbucketClientFactoryHandler {
     }
 
     public TestBitbucketClientFactoryHandler withBuildStatusClient(String revision, BitbucketSCMRepository scmRepo) {
-        when(clientFactory.getBuildStatusClient(revision, scmRepo, ciCapabilities)).thenReturn(buildStatusClient);
+        when(clientFactory
+                .getProjectClient(scmRepo.getProjectKey())
+                .getRepositoryClient(scmRepo.getRepositorySlug())
+                .getBuildStatusClient(revision, ciCapabilities))
+                .thenReturn(buildStatusClient);
         return this;
     }
 

--- a/src/test/resources/deployments/send_deployment_request.json
+++ b/src/test/resources/deployments/send_deployment_request.json
@@ -3,8 +3,8 @@
   "description": "my-description",
   "displayName": "my-display-name",
   "environment": {
-    "key": "My-env",
-    "displayName": "MY-ENV",
+    "key": "MY-ENV",
+    "displayName": "My-env",
     "type": "DEVELOPMENT",
     "url": "http://url.to.env"
   },

--- a/src/test/resources/deployments/send_deployment_request.json
+++ b/src/test/resources/deployments/send_deployment_request.json
@@ -1,0 +1,14 @@
+{
+  "deploymentSequenceNumber": 42,
+  "description": "my-description",
+  "displayName": "my-display-name",
+  "environment": {
+    "key": "My-env",
+    "displayName": "MY-ENV",
+    "type": "DEVELOPMENT",
+    "url": "http://url.to.env"
+  },
+  "key": "my-key",
+  "state": "FAILED",
+  "url": "http://url.to.job"
+}

--- a/src/test/resources/deployments/send_deployment_result.json
+++ b/src/test/resources/deployments/send_deployment_result.json
@@ -1,0 +1,3 @@
+{
+  // It actually doesn't matter what the response is because we never read it. We only check status code.
+}

--- a/src/test/resources/deployments/send_deployment_result.json
+++ b/src/test/resources/deployments/send_deployment_result.json
@@ -1,3 +1,80 @@
 {
-  // It actually doesn't matter what the response is because we never read it. We only check status code.
+  "deploymentSequenceNumber": 42,
+  "description": "my-description",
+  "displayName": "my-display-name",
+  "environment": {
+    "displayName": "MY-ENV",
+    "key": "My-env",
+    "type": "DEVELOPMENT",
+    "url": "http://url.to.env"
+  },
+  "fromCommit": null,
+  "key": "my-key",
+  "lastUpdated": 1626321456781,
+  "repository": {
+    "slug": "rep_1",
+    "id": 1,
+    "name": "rep_1",
+    "hierarchyId": "a5e17facbaafeb5b908d",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "PROJECT_1",
+      "id": 1,
+      "name": "Project 1",
+      "description": "Default configuration project #1",
+      "public": false,
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "http://localhost:7990/bitbucket/projects/PROJECT_1"
+          }
+        ]
+      }
+    },
+    "public": true,
+    "links": {
+      "clone": [
+        {
+          "href": "http://localhost:7990/bitbucket/scm/project_1/rep_1.git",
+          "name": "http"
+        },
+        {
+          "href": "ssh://git@localhost:7999/project_1/rep_1.git",
+          "name": "ssh"
+        }
+      ],
+      "self": [
+        {
+          "href": "http://localhost:7990/bitbucket/projects/PROJECT_1/repos/rep_1/browse"
+        }
+      ]
+    }
+  },
+  "state": "FAILED",
+  "toCommit": {
+    "id": "3004c112867819fc8d40d850e01ddd160496a6ba",
+    "displayId": "3004c112867",
+    "author": {
+      "name": "Administrator",
+      "emailAddress": "admin@example.com"
+    },
+    "authorTimestamp": 1626320844000,
+    "committer": {
+      "name": "Administrator",
+      "emailAddress": "admin@example.com"
+    },
+    "committerTimestamp": 1626320844000,
+    "message": null,
+    "parents": [
+      {
+        "id": "9d05a60df06da81b332daa63f35bbee43a5b7c12",
+        "displayId": "9d05a60df06"
+      }
+    ]
+  },
+  "url": "http://url.to.job"
 }


### PR DESCRIPTION
Bitbucket Server is looking into showing deployment status on pull requests and commits. This is the first PR to the feature branch `feature/deployment-notifications` with the client code to:
* Create a deployment status object that aligns with Bitbucket's unreleased REST API
* Send that object to Bitbucket Server

Future PRs will handle recognising when a deployment has happened. They will most likely be in the form of a `Notifier` step that consumers can use for freestyle jobs and a `BuildWrapper` that consumers can use to wrap the deployment steps on a pipelines job