### PR TITLE
JENKINS-66372 changed oauth date to use month instead of minutes

### DIFF
--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration/index.properties
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration/index.properties
@@ -2,5 +2,5 @@ bitbucket.oauth.token.consumer.name=Consumer Name
 bitbucket.oauth.token.creation.date=Creation Date
 bitbucket.oauth.token.status=Token Status
 bitbucket.oauth.token.action.button=Action
-bitbucket.oauth.token.creation.date.value={0,date,yyyy-mm-dd hh:mm}
+bitbucket.oauth.token.creation.date.value={0,date,yyyy-MM-dd hh:mm}
 bitbucket.oauth.token.header=Authorized tokens


### PR DESCRIPTION
Tracking ticket: https://issues.jenkins.io/browse/JENKINS-66372
See below screenshot before and after:

![Screenshot_20210816_103433](https://user-images.githubusercontent.com/53157896/129497618-cd661b8f-1c3d-4250-b894-7070a90a1146.png)
![Screenshot_20210816_103301](https://user-images.githubusercontent.com/53157896/129497624-7f65c2e9-2256-42dd-be87-76307cb7e5ef.png)
