### PR TITLE
JENKINS-65541 add owner to git scm, add func tests for folder credentials

### DIFF
--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
@@ -8,6 +8,8 @@ import io.restassured.response.ResponseBody;
 import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.model.OAuthConsumer;
 import it.com.atlassian.bitbucket.jenkins.internal.pageobjects.BitbucketScmConfig;
 import okhttp3.HttpUrl;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.jenkinsci.test.acceptance.SshKeyPair;
 import org.jenkinsci.test.acceptance.SshKeyPairGenerator;
 import org.jenkinsci.test.acceptance.po.Jenkins;
@@ -15,11 +17,19 @@ import org.jenkinsci.test.acceptance.po.Job;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import static it.com.atlassian.bitbucket.jenkins.internal.util.GitUtils.*;
+import static it.com.atlassian.bitbucket.jenkins.internal.util.GitUtils.ADMIN_CREDENTIALS_PROVIDER;
+import static it.com.atlassian.bitbucket.jenkins.internal.util.TestData.ECHO_ONLY_JENKINS_FILE_CONTENT;
+import static it.com.atlassian.bitbucket.jenkins.internal.util.TestData.JENKINS_FILE_NAME;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Copied from {@code it.com.atlassian.bitbucket.jenkins.internal.util.BitbucketUtils} in the main module (under
@@ -118,17 +128,18 @@ public class BitbucketUtils {
         return new BitbucketSshKeyPair(response.path("id"), keyPair.readPublicKey(), keyPair.readPrivateKey());
     }
 
-    public static Job createJobWithBitbucketScm(Jenkins jenkins, String bbsAdminCredsId, BitbucketSshKeyPair bbsSshCreds,
+    public static Job provideJobWithBitbucketScm(Job job, String bbsAdminCredsId, @Nullable BitbucketSshKeyPair bbsSshCreds,
                                                 String serverId, BitbucketRepository repository) {
-        Job job = jenkins.jobs.create();
         BitbucketScmConfig bitbucketScm = job.useScm(BitbucketScmConfig.class);
         bitbucketScm
                 .credentialsId(bbsAdminCredsId)
-                .sshCredentialsId(bbsSshCreds.getId())
                 .serverId(serverId)
                 .projectName(repository.getProject().getKey())
                 .repositoryName(repository.getSlug())
                 .anyBranch();
+        if (bbsSshCreds != null) {
+            bitbucketScm.sshCredentialsId(bbsSshCreds.getId());
+        }
         job.save();
 
         return job;

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
@@ -8,28 +8,18 @@ import io.restassured.response.ResponseBody;
 import it.com.atlassian.bitbucket.jenkins.internal.applink.oauth.model.OAuthConsumer;
 import it.com.atlassian.bitbucket.jenkins.internal.pageobjects.BitbucketScmConfig;
 import okhttp3.HttpUrl;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.revwalk.RevCommit;
 import org.jenkinsci.test.acceptance.SshKeyPair;
 import org.jenkinsci.test.acceptance.SshKeyPairGenerator;
-import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
-import static it.com.atlassian.bitbucket.jenkins.internal.util.GitUtils.*;
-import static it.com.atlassian.bitbucket.jenkins.internal.util.GitUtils.ADMIN_CREDENTIALS_PROVIDER;
-import static it.com.atlassian.bitbucket.jenkins.internal.util.TestData.ECHO_ONLY_JENKINS_FILE_CONTENT;
-import static it.com.atlassian.bitbucket.jenkins.internal.util.TestData.JENKINS_FILE_NAME;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Copied from {@code it.com.atlassian.bitbucket.jenkins.internal.util.BitbucketUtils} in the main module (under

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -259,6 +259,8 @@ public class BitbucketSCMSource extends SCMSource {
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria, SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event,
                             TaskListener listener) throws IOException, InterruptedException {
+        // The git scm needs an owner set to resolve non-global credentials
+        getGitSCMSource().setOwner(getOwner());
         if (getOwner() instanceof ComputedFolder && event != null) {
             ComputedFolder<?> owner = (ComputedFolder<?>) getOwner();
             Object payload = event.getPayload();
@@ -275,7 +277,6 @@ public class BitbucketSCMSource extends SCMSource {
                 return;
             }
         }
-        //
         getGitSCMSource().accessibleRetrieve(criteria, observer, event, listener);
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -155,6 +155,9 @@ public class BitbucketSCMSource extends SCMSource {
     @Override
     public void afterSave() {
         super.afterSave();
+        // The git scm needs an owner set to resolve non-global credentials
+        getGitSCMSource().setOwner(getOwner());
+
         if (!webhookRegistered && isValid()) {
             SCMSourceOwner owner = getOwner();
             if (owner instanceof ComputedFolder) {
@@ -259,8 +262,6 @@ public class BitbucketSCMSource extends SCMSource {
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria, SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event,
                             TaskListener listener) throws IOException, InterruptedException {
-        // The git scm needs an owner set to resolve non-global credentials
-        getGitSCMSource().setOwner(getOwner());
         if (getOwner() instanceof ComputedFolder && event != null) {
             ComputedFolder<?> owner = (ComputedFolder<?>) getOwner();
             Object payload = event.getPayload();


### PR DESCRIPTION
I believe the checkout was failing because the Git SCM is resolving the credentials by ID, which id does using it's parent (the SCM owner) as context. This is typically set by Stapler but as we wrap the SCM, it was set to null, which the credentials provider resolves as Jenkins.get(), so folder-scoped credentials were inaccessible.
I've added a manual SCM owner assignment to the `BitbucketSCMSource`, and acceptance tests for both freestyle and MBP jobs at the folder level.