### PR TITLE
Update capabilities checker to expect a map response

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClient.java
@@ -6,6 +6,8 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketCDCapabilities;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Client to get capabilities from the remote server.
  */
@@ -24,6 +26,7 @@ public interface BitbucketCapabilitiesClient {
      * @throws BitbucketClientException   for all errors not already captured
      * @since deployments
      */
+    @CheckForNull
     BitbucketCDCapabilities getCDCapabilities();
 
     /**

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities.*;
 import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertyUtils.parsePositiveLongFromSystemProperty;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static okhttp3.HttpUrl.parse;
 
@@ -61,7 +60,7 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
         if (events == null) {
             throw new BitbucketMissingCapabilityException(
                     "Remote Bitbucket Server does not support Webhooks. Make sure " +
-                    "Bitbucket server supports webhooks or correct version of it is installed.");
+                            "Bitbucket server supports webhooks or correct version of it is installed.");
         }
         return events;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
@@ -10,11 +10,13 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import okhttp3.HttpUrl;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities.*;
 import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertyUtils.parsePositiveLongFromSystemProperty;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static okhttp3.HttpUrl.parse;
 
@@ -33,13 +35,10 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
         capabilitiesCache = Suppliers.memoizeWithExpiration(supplier, CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS);
     }
 
+    @CheckForNull
     @Override
     public BitbucketCDCapabilities getCDCapabilities() {
-        BitbucketCDCapabilities capabilities = getCapabilitiesForKey(DEPLOYMENTS_CAPABILITY_KEY, BitbucketCDCapabilities.class);
-        if (capabilities == null) {
-            return new BitbucketCDCapabilities(emptySet());
-        }
-        return capabilities;
+        return getCapabilitiesForKey(DEPLOYMENTS_CAPABILITY_KEY, BitbucketCDCapabilities.class);
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeployedToEnvironmentNotifierStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeployedToEnvironmentNotifierStep.java
@@ -242,7 +242,7 @@ public class DeployedToEnvironmentNotifierStep extends Notifier implements Simpl
                 return FORM_VALIDATION_OK;
             }
             try {
-                URI uri = new URI(environmentUrl);// Try to coerce it into a URL
+                URI uri = new URI(environmentUrl); // Try to coerce it into a URL
                 if (!uri.isAbsolute()) {
                     return FormValidation.error(Messages.DeployedToEnvironmentNotifierStep_UriAbsolute());
                 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeploymentPosterImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeploymentPosterImpl.java
@@ -58,7 +58,7 @@ public class DeploymentPosterImpl implements DeploymentPoster {
         BitbucketClientFactory clientFactory =
                 bitbucketClientFactoryProvider.getClient(server.getBaseUrl(), credentials);
         BitbucketCDCapabilities cdCapabilities = clientFactory.getCapabilityClient().getCDCapabilities();
-        if (!cdCapabilities.supportsDeployments()) {
+        if (cdCapabilities == null) {
             // Bitbucket doesn't have deployments
             taskListener.error(format("Could not send deployment notification to %s: The Bitbucket version does not support deployments", server.getServerName()));
             return;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/deployment/BitbucketCDCapabilities.java
@@ -3,28 +3,22 @@ package com.atlassian.bitbucket.jenkins.internal.model.deployment;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import java.util.Set;
+import java.util.Map;
 
-import static java.util.Collections.unmodifiableSet;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketCDCapabilities {
 
-    public static final String DEPLOYMENTS_CAPABILITY_VALUE = "deployments";
-
-    private final Set<String> cdCapabilities;
+    private final Map<String, Object> cdCapabilities;
 
     @JsonCreator
-    public BitbucketCDCapabilities(Set<String> cdCapabilities) {
-        this.cdCapabilities = unmodifiableSet(requireNonNull(cdCapabilities, "cdCapabilities"));
+    public BitbucketCDCapabilities(Map<String, Object> cdCapabilities) {
+        this.cdCapabilities = unmodifiableMap(requireNonNull(cdCapabilities, "cdCapabilities"));
     }
 
-    public Set<String> getCdCapabilities() {
+    public Map<String, Object> getCdCapabilities() {
         return cdCapabilities;
-    }
-
-    public boolean supportsDeployments() {
-        return cdCapabilities.contains(DEPLOYMENTS_CAPABILITY_VALUE);
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeployedToEnvironmentNotifierStepTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeployedToEnvironmentNotifierStepTest.java
@@ -138,17 +138,15 @@ public class DeployedToEnvironmentNotifierStepTest {
         BitbucketDeployment deployment = createDeployment();
         Run<?, ?> run = mock(Run.class, Answers.RETURNS_DEEP_STUBS);
         when(run.getParent().getDisplayName()).thenReturn(parentName);
-        BitbucketRevisionAction revisionAction = mock(BitbucketRevisionAction.class);
         BitbucketSCMRepository repo = mock(BitbucketSCMRepository.class);
         when(repo.getServerId()).thenReturn(serverId);
         String projectKey = "myProj";
         when(repo.getProjectKey()).thenReturn(projectKey);
         String repoSlug = "myRepo";
         when(repo.getRepositorySlug()).thenReturn(repoSlug);
-        when(revisionAction.getBitbucketSCMRepo()).thenReturn(repo);
         String commit = "myCommit";
-        when(revisionAction.getRevisionSha1()).thenReturn(commit);
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(revisionAction);
+        when(run.getAction(argThat(actionClass -> actionClass.equals(BitbucketRevisionAction.class))))
+                .thenReturn(new BitbucketRevisionAction(repo, "my-branch", commit));
 
         when(bitbucketDeploymentFactory.createDeployment(run, expectedEnvironment)).thenReturn(deployment);
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeploymentPosterImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/deployments/DeploymentPosterImplTest.java
@@ -30,8 +30,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.PrintStream;
 
 import static java.lang.String.format;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
+import static java.util.Collections.*;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.mockito.Mockito.*;
@@ -86,7 +85,7 @@ public class DeploymentPosterImplTest {
         when(server.getBaseUrl()).thenReturn(BASE_URL);
         when(clientFactoryProvider.getClient(BASE_URL, bitbucketCredentials)).thenReturn(clientFactory);
         when(clientFactory.getCapabilityClient().getCDCapabilities())
-                .thenReturn(new BitbucketCDCapabilities(singleton("deployments")));
+                .thenReturn(new BitbucketCDCapabilities(emptyMap()));
         when(server.getServerName()).thenReturn(SERVER_NAME);
         when(taskListener.getLogger()).thenReturn(printStream);
     }
@@ -136,7 +135,7 @@ public class DeploymentPosterImplTest {
     @Test
     public void testPostDeploymentWithDeploymentsNotSupported() {
         when(clientFactory.getCapabilityClient().getCDCapabilities())
-                .thenReturn(new BitbucketCDCapabilities(emptySet()));
+                .thenReturn(null);
 
         poster.postDeployment(SERVER_ID, PROJECT_KEY, REPO_SLUG, REVISION_SHA, DEPLOYMENT, run, taskListener);
 


### PR DESCRIPTION
The capabilities endpoint was changed before the release in Bitbucket 7.16. The released version returns a map as the response.