### PR TITLE
Add ID to gitSCMSource so that it is persisted in the XML and not generated to be a random UUID each time

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -134,6 +134,7 @@ public class BitbucketSCMSource extends SCMSource {
         //self link contains `/browse` which we must trim off.
         String repositoryUrl = selfLink.substring(0, max(selfLink.lastIndexOf("/browse"), 0));
         gitSCMSource.setBrowser(new Stash(repositoryUrl));
+        gitSCMSource.setId(getId() + "-git-scm");
     }
 
     /**


### PR DESCRIPTION
On restart, the job config is read into memory. However because the SCM Source does not contain an ID, it gets auto-generated each time. This means that on a scan, Jenkins detects that the SCM has 'changed' and therefor a build should be run for all branches (causing a 'build storm').

This change sets a static ID so that it is saved in the XML and on scanning after restarts does not trigger a build storm.