### PR TITLE
Update pattern for gitignore Jenkins homedir to include any folder that is prefixed with 'work'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 *.iws
 out/
 .home*/
-work/
+work*/
 # maven stuff
 .mvn/maven.config
 target


### PR DESCRIPTION
This is useful to make backups of the work folder without it being noticed by git