### PR TITLE
Upgrade Jenkins min version

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.235.5</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.11.2</jackson.version>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.235.5</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.222.4+
+- Jenkins 2.235.5+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 5.6 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.4+ you can set up an Application Link to have access to all plugin features.
@@ -210,7 +210,7 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ## Changelog
 
 ### 3.0.0 (XX XXX 2021)
-- The minimum version of Jenkins changed to be **2.204.6**
+- The minimum version of Jenkins changed to be **2.235.5**
 - JENKINS-60342 added support for Pull Request triggers
 - JENKINS-63033 added support for lightweight checkout with pipeline and mutlibranch pipeline jobs
 - JENKINS-63070 added multibranch project bitbucket links


### PR DESCRIPTION
It seems in order to get all the tests green we need to lift the minimum version we support. This PR moves us from  2.222.4 released 2020-05-24
to 2.235.5 released 2020-08-17.

We are moving from 2.222 to 2.235 which is the next lts version, so we're only dropping support for one LTS version, despite the big jump in version number.