### PR TITLE
Ignore a test that is very unstable

### DIFF
--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImplTest.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImplTest.java
@@ -17,10 +17,7 @@ import hudson.util.RunList;
 import it.com.atlassian.bitbucket.jenkins.internal.util.AsyncTestUtils;
 import it.com.atlassian.bitbucket.jenkins.internal.util.SingleExecutorRule;
 import it.com.atlassian.bitbucket.jenkins.internal.util.WaitConditionFailure;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -173,6 +170,7 @@ public class BitbucketWebhookTriggerImplTest {
         }
     }
 
+    @Ignore("Test is unstable, frequent failures for not reason, ignoring for now")
     @Test
     public void testTriggerPollingSubsequentBuildNow() {
         trigger.trigger(


### PR DESCRIPTION
This test is frequently red for no good reason. Adding `@Ignore` so it won't be so disruptive. We can then later either look at removing or fixing it.