### PR TITLE
RFC Refactor bitbucket revision action & add Bitbucket Repo to environment

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMEnvironmentContributor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMEnvironmentContributor.java
@@ -1,86 +1,23 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
-import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.model.*;
-import hudson.plugins.git.GitSCM;
-import hudson.scm.SCM;
-import jenkins.branch.BranchSource;
-import jenkins.branch.MultiBranchProject;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Objects;
 
 @Extension
 public class BitbucketSCMEnvironmentContributor extends EnvironmentContributor {
 
-    public void buildEnvironmentFor(@NonNull Job job, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
-        if (job instanceof AbstractProject) {
-            // Case 1 - Freestyle job
-            SCM scm = ((AbstractProject<?, ?>) job).getScm();
-            if (!(scm instanceof BitbucketSCM)) {
-                return;
-            }
-            ((BitbucketSCM) scm).getBitbucketSCMRepository().buildEnvironment(envs);
+    public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        BitbucketSCMRevisionAction revisionAction = run.getAction(BitbucketSCMRevisionAction.class);
+        if (revisionAction == null) {
+            // No environment to contribute yet
             return;
         }
-        if (job instanceof WorkflowJob) {
-            // Case 2 - Not a freestyle job. Proceed to inspect SCM on item
-            WorkflowJob workflowJob = (WorkflowJob) job;
-            SCM scm = workflowJob.getTypicalSCM();
-            if (!(scm instanceof GitSCM || scm instanceof BitbucketSCM)) {
-                return;
-            }
-            if (scm instanceof BitbucketSCM) {
-                //case 2 - bb_checkout step in the script (pipeline or groovy)
-                ((BitbucketSCM) scm).getBitbucketSCMRepository().buildEnvironment(envs);
-                return;
-            }
-            ItemGroup<?> parent = getJobParent(job);
-            GitSCM gitScm = (GitSCM) scm;
-            if (parent instanceof MultiBranchProject) { // Case 3.1 - Multi branch workflow job
-                MultiBranchProject<?, ?> multiBranchProject = (MultiBranchProject<?, ?>) parent;
-                multiBranchProject
-                        .getSources()
-                        .stream()
-                        .map(BranchSource::getSource)
-                        .filter(BitbucketSCMSource.class::isInstance)
-                        .map(BitbucketSCMSource.class::cast)
-                        .filter(bbsSource ->
-                                // The assumption is the remote URL specified in GitSCM should be same as remote URL
-                                // specified in Bitbucket Source.
-                                gitScm.getUserRemoteConfigs()
-                                        .stream()
-                                        .anyMatch(userRemoteConfig ->
-                                                Objects.equals(userRemoteConfig.getUrl(), bbsSource.getRemote())))
-                        .findFirst()
-                        .ifPresent(scmSource -> scmSource.getBitbucketSCMRepository().buildEnvironment(envs));
-            } else { // Case 3.2 - Part of pipeline run
-                // Handle only SCM jobs.
-                workflowJob.getSCMs()
-                        .stream()
-                        .filter(BitbucketSCM.class::isInstance)
-                        .map(BitbucketSCM.class::cast)
-                        .filter(bScm -> {
-                            GitSCM bGitScm = bScm.getGitSCM();
-                            return bGitScm != null &&
-                                    Objects.equals(bGitScm.getKey(), scm.getKey());
-                        })
-                        .findFirst()
-                        .ifPresent(bScm -> bScm.getBitbucketSCMRepository().buildEnvironment(envs));
-            }
-        }
-    }
-
-    /**
-     * {@link Job#getParent()} uses {@code @WithBridgeMethods(value=Jenkins.class,castRequired=true)} which is
-     * problematic when trying to mock the parent.
-     */
-    @VisibleForTesting
-    ItemGroup<?> getJobParent(Job<?, ?> job) {
-        return job.getParent();
+        revisionAction.getBitbucketSCMRepo().buildEnvironment(envs);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevisionAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevisionAction.java
@@ -1,0 +1,34 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.model.InvisibleAction;
+
+import javax.annotation.CheckForNull;
+
+public class BitbucketSCMRevisionAction extends InvisibleAction {
+
+    public static final String REF_PREFIX = "refs/heads/";
+
+    private final BitbucketSCMRepository bitbucketSCMRepository;
+    private final String branchName;
+    private final String revisionSha1;
+
+    public BitbucketSCMRevisionAction(BitbucketSCMRepository bitbucketSCMRepository, @CheckForNull String branchName,
+                                      String revisionSha1) {
+        this.bitbucketSCMRepository = bitbucketSCMRepository;
+        this.branchName = branchName;
+        this.revisionSha1 = revisionSha1;
+    }
+
+    public BitbucketSCMRepository getBitbucketSCMRepo() {
+        return bitbucketSCMRepository;
+    }
+
+    public String getRevisionSha1() {
+        return revisionSha1;
+    }
+
+    @CheckForNull
+    public String getBranchAsRefFormat() {
+        return branchName != null ? REF_PREFIX + branchName : null;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryExtension.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryExtension.java
@@ -1,0 +1,65 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+import javax.annotation.CheckForNull;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is an extension that is used only by {@link BitbucketSCM} and {@link BitbucketSCMSource} (through
+ * {@link InternalBitbucketRepositoryTrait}. The descriptors are hidden from the UI, and extension lists containing
+ * this are filtered before displaying in the UI.
+ * <p>
+ * In the {@link #beforeCheckout(GitSCM, Run, GitClient, TaskListener)} method, this class adds the
+ * {@link BitbucketSCMRepository} information to the run so that {@link hudson.model.listeners.SCMListener} classes
+ * have access to it.
+ */
+public class InternalBitbucketRepositoryExtension extends GitSCMExtension {
+
+    private final BitbucketSCMRepository bitbucketSCMRepository;
+
+    public InternalBitbucketRepositoryExtension(BitbucketSCMRepository bitbucketSCMRepository) {
+        this.bitbucketSCMRepository = bitbucketSCMRepository;
+    }
+
+    @Override
+    public void onCheckoutCompleted(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
+        Map<String, String> env = new HashMap<>();
+        scm.buildEnvironment(build, env);
+        String branch = env.get(GitSCM.GIT_BRANCH);
+        String refName = branch != null ? scm.deriveLocalBranchName(branch) : null;
+
+        build.addAction(new BitbucketSCMRevisionAction(bitbucketSCMRepository, refName, env.get(GitSCM.GIT_COMMIT)));
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Bitbucket revision information extension";
+        }
+    }
+
+    @Restricted({DoNotUse.class})
+    @Extension
+    public static class Hider extends DescriptorVisibilityFilter {
+
+        public boolean filter(@CheckForNull Object context, Descriptor descriptor) {
+            return !(descriptor instanceof DescriptorImpl);
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryTrait.java
@@ -1,28 +1,3 @@
-/*
- * The MIT License
- *
- * Copyright (c) 2017 CloudBees, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- */
-
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import hudson.Extension;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/InternalBitbucketRepositoryTrait.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import jenkins.plugins.git.traits.GitSCMExtensionTrait;
+import jenkins.plugins.git.traits.GitSCMExtensionTraitDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * This class is a trait that is used only by {@link BitbucketSCMSource}. The descriptors are hidden from the UI,
+ * and trait lists containing this are filtered before displaying in the UI.
+ *
+ * @see {@link InternalBitbucketRepositoryExtension}
+ */
+public class InternalBitbucketRepositoryTrait extends GitSCMExtensionTrait<InternalBitbucketRepositoryExtension> {
+
+    @DataBoundConstructor
+    public InternalBitbucketRepositoryTrait(InternalBitbucketRepositoryExtension extension) {
+        super(extension);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Bitbucket revision information trait";
+        }
+    }
+
+    @Restricted({DoNotUse.class})
+    @Extension
+    public static class Hider extends DescriptorVisibilityFilter {
+
+        public boolean filter(@CheckForNull Object context, Descriptor descriptor) {
+            return !(descriptor instanceof DescriptorImpl);
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.status;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
 import com.atlassian.bitbucket.jenkins.internal.model.TestResults;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
@@ -63,7 +64,7 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
                 .setDescription(state.getDescriptiveText(build.getDisplayName(), build.getDurationString()));
 
         if (isRich) {
-            BitbucketRevisionAction revisionAction = build.getAction(BitbucketRevisionAction.class);
+            BitbucketSCMRevisionAction revisionAction = build.getAction(BitbucketSCMRevisionAction.class);
 
             bbs.setBuildNumber(build.getId())
                     .setTestResults(getTestResults(build))

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketRevisionAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketRevisionAction.java
@@ -6,6 +6,10 @@ import hudson.model.Action;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
+/**
+ * @deprecated in 3.1.0 please use{@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction} instead.
+ */
+@Deprecated
 public class BitbucketRevisionAction implements Action {
 
     public static final String REF_PREFIX = "refs/heads/";

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusSCMListener.java
@@ -1,0 +1,40 @@
+package com.atlassian.bitbucket.jenkins.internal.status;
+
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.SCMListener;
+import hudson.scm.SCM;
+import hudson.scm.SCMRevisionState;
+
+import javax.annotation.CheckForNull;
+import javax.inject.Inject;
+import java.io.File;
+
+@Extension
+public class BuildStatusSCMListener extends SCMListener {
+
+    private BuildStatusPoster buildStatusPoster;
+
+    public BuildStatusSCMListener() {
+    }
+
+    @Inject
+    BuildStatusSCMListener(BuildStatusPoster buildStatusPoster) {
+        this.buildStatusPoster = buildStatusPoster;
+    }
+
+    @Override
+    public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener,
+                           @CheckForNull File changelogFile,
+                           @CheckForNull SCMRevisionState pollingBaseline) {
+        BitbucketSCMRevisionAction bitbucketRevisionAction = build.getAction(BitbucketSCMRevisionAction.class);
+        if (bitbucketRevisionAction == null) {
+            // Not a Bitbucket SCM (or a legacy build, which will be handled by LegacySCMListener)
+            return;
+        }
+        buildStatusPoster.postBuildStatus(bitbucketRevisionAction, build, listener);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/package-info.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/package-info.java
@@ -44,12 +44,24 @@
  *
  * Overall workflow of sending build status is as follows:
  * <ol>
- *     <li>We add SCM Listener {@link com.atlassian.bitbucket.jenkins.internal.status.LocalSCMListener} which listens for checkouts</li>
- *     <li>On a checkout completion, we check association with {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM} or {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource}</li>
- *     <li>We attach a {@link com.atlassian.bitbucket.jenkins.internal.status.BitbucketRevisionAction} for storing the checkout context.</li>
- *     <li>We send an In progress build status</li>
- *     <li>We add a Run listener {@link com.atlassian.bitbucket.jenkins.internal.status.BuildStatusPoster} which listens for builds</li>
- *     <li>On Build completion, we retrieve the {@code BitbucketRevisionAction} and send build status to Bitbucket.</li>
+ *     <li>
+ *         We associate the {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository} through
+ *         {@link com.atlassian.bitbucket.jenkins.internal.scm.InternalBitbucketRepositoryExtension}
+ *         (for users of {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM}), or
+ *         {@link com.atlassian.bitbucket.jenkins.internal.scm.InternalBitbucketRepositoryTrait} for users of
+ *         {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource}
+ *     </li>
+ *     <li>
+ *         In {@link com.atlassian.bitbucket.jenkins.internal.scm.InternalBitbucketRepositoryExtension#beforeCheckout(hudson.plugins.git.GitSCM, hudson.model.Run, org.jenkinsci.plugins.gitclient.GitClient, hudson.model.TaskListener)}
+ *         we add {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction} to the build for ease
+ *         of access to the {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository}
+ *     </li>
+ *     <li>
+ *         We send an in-progress build status in {@link com.atlassian.bitbucket.jenkins.internal.status.BuildStatusSCMListener}
+ *         and a completed build status in {@link com.atlassian.bitbucket.jenkins.internal.status.BuildStatusSCMListener#onCheckout(hudson.model.Run, hudson.scm.SCM, hudson.FilePath, hudson.model.TaskListener, java.io.File, hudson.scm.SCMRevisionState)}
+ *         both of which retrieves the {@link com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction}
+ *         and gets the Git commit and branch off the environment to send build status to Bitbucket
+ *     </li>
  * </ol>
  *
  *

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMEnvironmentContributorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMEnvironmentContributorTest.java
@@ -1,217 +1,31 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import hudson.EnvVars;
-import hudson.model.FreeStyleProject;
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.UserRemoteConfig;
-import hudson.scm.SCM;
-import jenkins.branch.BranchSource;
-import jenkins.branch.MultiBranchProject;
-import jenkins.scm.api.SCMSource;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import hudson.model.Run;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.annotation.CheckForNull;
-import java.util.UUID;
-
-import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class BitbucketSCMEnvironmentContributorTest {
 
-    private static final String REMOTE_URL = "http://localhost:7990/bitbucket/scm/project_1/rep_1.git";
-
-    @Mock
-    BitbucketSCMRepository repository;
-
     @Spy
     BitbucketSCMEnvironmentContributor contributor;
 
     @Test
-    public void testBuildEnvironmentForAbstractProjectWithoutBitbucketSCM() throws Exception {
-        FreeStyleProject job = mock(FreeStyleProject.class);
-        GitSCM scm = mockGitSCM();
-        when(job.getScm()).thenReturn(scm);
-        EnvVars envs = new EnvVars();
+    public void testBuildEnvironment() throws Exception {
+        Run run = mock(Run.class);
+        BitbucketSCMRevisionAction action = mock(BitbucketSCMRevisionAction.class);
+        when(run.getAction(BitbucketSCMRevisionAction.class)).thenReturn(action);
+        BitbucketSCMRepository repo = mock(BitbucketSCMRepository.class);
+        when(action.getBitbucketSCMRepo()).thenReturn(repo);
+        EnvVars env = new EnvVars();
 
-        contributor.buildEnvironmentFor(job, envs, null);
+        contributor.buildEnvironmentFor(run, env, null);
 
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForAbstractProjectWithBitbucketSCM() throws Exception {
-        FreeStyleProject job = mock(FreeStyleProject.class);
-        BitbucketSCM scm = mockBitbucketSCM();
-        when(job.getScm()).thenReturn(scm);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithoutSCM() throws Exception {
-        WorkflowJob job = mockWorkflowJob(null);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithDifferentSCM() throws Exception {
-        SCM scm = mock(SCM.class);
-        WorkflowJob job = mockWorkflowJob(scm);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithBitbucketSCM() throws Exception {
-        BitbucketSCM bitbucketSCM = mockBitbucketSCM();
-        WorkflowJob job = mockWorkflowJob(bitbucketSCM);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithMultibranchParent() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        BitbucketSCMSource bitbucketSCMSource = getBitbucketSCMSource();
-        MultiBranchProject parent = mock(MultiBranchProject.class);
-        when(parent.getSources()).thenReturn(singletonList(new BranchSource(bitbucketSCMSource)));
-        doReturn(parent).when(contributor).getJobParent(job);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithMultibranchParentButNotBitbucketSCMSource() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        MultiBranchProject parent = mock(MultiBranchProject.class);
-        SCMSource notBitbucketScmSource = mock(SCMSource.class);
-        when(parent.getSources()).thenReturn(singletonList(new BranchSource(notBitbucketScmSource)));
-        doReturn(parent).when(contributor).getJobParent(job);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForWorkflowJobWithMultibranchParentButRemotesDontMatch() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        BitbucketSCMSource bitbucketSCMSource = getBitbucketSCMSource();
-        when(bitbucketSCMSource.getRemote()).thenReturn("something else");
-        MultiBranchProject parent = mock(MultiBranchProject.class);
-        when(parent.getSources()).thenReturn(singletonList(new BranchSource(bitbucketSCMSource)));
-        doReturn(parent).when(contributor).getJobParent(job);
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForPipelineJobWithNotBitbucketSCM() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        doReturn(null).when(contributor).getJobParent(job);
-
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForPipelineJobWithDifferentSCM() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        BitbucketSCM bitbucketSCM = mockBitbucketSCM(); // Will generate a different git scm
-        doReturn(singletonList(bitbucketSCM)).when(job).getSCMs();
-        doReturn(null).when(contributor).getJobParent(job);
-
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository, never()).buildEnvironment(envs);
-    }
-
-    @Test
-    public void testBuildEnvironmentForPipelineJob() throws Exception {
-        GitSCM gitSCM = mockGitSCM();
-        WorkflowJob job = mockWorkflowJob(gitSCM);
-        BitbucketSCM bitbucketSCM = mockBitbucketSCM(gitSCM);
-        doReturn(singletonList(bitbucketSCM)).when(job).getSCMs();
-        doReturn(null).when(contributor).getJobParent(job);
-
-        EnvVars envs = new EnvVars();
-
-        contributor.buildEnvironmentFor(job, envs, null);
-
-        verify(repository).buildEnvironment(envs);
-    }
-
-    private BitbucketSCMSource getBitbucketSCMSource() {
-        BitbucketSCMSource bitbucketSCMSource = mock(BitbucketSCMSource.class);
-        when(bitbucketSCMSource.getRemote()).thenReturn(REMOTE_URL);
-        when(bitbucketSCMSource.getBitbucketSCMRepository()).thenReturn(repository);
-        return bitbucketSCMSource;
-    }
-
-    private WorkflowJob mockWorkflowJob(@CheckForNull SCM scm) {
-        WorkflowJob job = mock(WorkflowJob.class);
-        when(job.getTypicalSCM()).thenReturn(scm);
-        doReturn(singletonList(scm)).when(job).getSCMs();
-        return job;
-    }
-
-    private GitSCM mockGitSCM() {
-        return mockGitSCM(UUID.randomUUID().toString());
-    }
-
-    private GitSCM mockGitSCM(String gitScmKey) {
-        GitSCM gitSCM = mock(GitSCM.class);
-        UserRemoteConfig gitRemoteConfig = new UserRemoteConfig(REMOTE_URL, null, null, null);
-        when(gitSCM.getUserRemoteConfigs()).thenReturn(singletonList(gitRemoteConfig));
-        when(gitSCM.getKey()).thenReturn(gitScmKey);
-        return gitSCM;
-    }
-
-    private BitbucketSCM mockBitbucketSCM() {
-        GitSCM gitSCM = mockGitSCM();
-        return mockBitbucketSCM(gitSCM);
-    }
-
-    private BitbucketSCM mockBitbucketSCM(GitSCM gitSCM) {
-        BitbucketSCM bitbucketSCM = mock(BitbucketSCM.class);
-        when(bitbucketSCM.getBitbucketSCMRepository()).thenReturn(repository);
-        when(bitbucketSCM.getGitSCM()).thenReturn(gitSCM);
-        return bitbucketSCM;
+        verify(repo).buildEnvironment(env);
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusSCMListenerTest.java
@@ -1,0 +1,42 @@
+package com.atlassian.bitbucket.jenkins.internal.status;
+
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BuildStatusSCMListenerTest {
+
+    @Mock
+    Run<?, ?> build;
+    @InjectMocks
+    BuildStatusSCMListener buildStatusSCMListener;
+    @Mock
+    BuildStatusPoster poster;
+    @Mock
+    TaskListener taskListener;
+
+    @Test
+    public void testBuildStatusNotPostedOnCheckoutWhenNoRevision() {
+        buildStatusSCMListener.onCheckout(build, null, null, taskListener, null, null);
+        verifyZeroInteractions(poster);
+    }
+
+    @Test
+    public void testBuildStatusPostedOnCheckout() {
+        BitbucketSCMRevisionAction action = mock(BitbucketSCMRevisionAction.class);
+        when(build.getAction(BitbucketSCMRevisionAction.class)).thenReturn(action);
+
+        buildStatusSCMListener.onCheckout(build, null, null, taskListener, null, null);
+
+        verify(poster).postBuildStatus(action, build, taskListener);
+    }
+
+}

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMIT.java
@@ -1,7 +1,7 @@
 package it.com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
-import com.atlassian.bitbucket.jenkins.internal.status.BitbucketRevisionAction;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction;
 import com.atlassian.bitbucket.jenkins.internal.util.TestUtils;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -98,7 +98,7 @@ public class BitbucketSCMIT {
                         .append("/repos/")
                         .append(BitbucketUtils.repoForkSlug)
                         .append("/commits?since=")
-                        .append(build.getAction(BitbucketRevisionAction.class).getRevisionSha1())
+                        .append(build.getAction(BitbucketSCMRevisionAction.class).getRevisionSha1())
                         .toString());
     }
 
@@ -158,7 +158,7 @@ public class BitbucketSCMIT {
         project.save();
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
-        BitbucketRevisionAction revisionAction = build.getAction(BitbucketRevisionAction.class);
+        BitbucketSCMRevisionAction revisionAction = build.getAction(BitbucketSCMRevisionAction.class);
 
         RestAssured
                 .given()

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
@@ -2,7 +2,7 @@ package it.com.atlassian.bitbucket.jenkins.internal.status;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
-import com.atlassian.bitbucket.jenkins.internal.status.BitbucketRevisionAction;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevisionAction;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import hudson.model.*;
 import it.com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
@@ -247,7 +247,7 @@ public class BuildStatusPosterIT {
     private static RequestPatternBuilder requestBody(RequestPatternBuilder requestPatternBuilder, Run<?, ?> build,
                                                      URL jenkinsUrl, BuildState buildState, String refName) {
         Job<?, ?> job = build.getParent();
-        BitbucketRevisionAction bitbucketRevisionAction = build.getAction(BitbucketRevisionAction.class);
+        BitbucketSCMRevisionAction bitbucketRevisionAction = build.getAction(BitbucketSCMRevisionAction.class);
         assertNotNull(bitbucketRevisionAction);
         String jenkinsUrlAsString = jenkinsUrl.toExternalForm();
         ItemGroup<?> parentProject = job.getParent();


### PR DESCRIPTION
- Deprecates `BitbucketRevisionAction` and replaces it with `BitbucketSCMRevisionAction` and renames `LocalSCMListener` to `LegacySCMListener`
- Adds `InternalBitbucketRepositoryExtension` and `InternalBitbucketRepositoryTrait` which are hidden from the UI, but added to all builds using `BitbucketSCM` or `BitbucketSCMSource`
- `InternalBitbucketRepositoryExtension` adds repository information to the build in the form of `BitbucketSCMRevisionAction`, since it knows directly the repository being used (rather than doing a series of casts that can be seen in `LegacySCMListener`)
- Adds `BuildStatusSCMListener` which gets the `BitbucketSCMRepository` off the `BitbucketSCMRevisionAction` and posts the in-progress build status. `LegacySCMListener` still posts the in-progress build status for jobs that do not have `BitbucketSCMRevisionAction` added by the extension. `LegacySCMListener` will also add the `BitbucketSCMRevisionAction` to the build so that the final build status notification can be sent
- Adds `BitbucketSCMRepositoryEnvironmentContributor` which adds the repository details to the environment using the new `BitbucketSCMRevisionAction`

Reopened from https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/pull/279