### PR TITLE
Categorize oauth consumer global config as Security rather than Uncategorized

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.jenkins.oauth.consumer;
 import com.atlassian.bitbucket.jenkins.internal.applink.oauth.serviceprovider.consumer.ServiceProviderConsumerStore;
 import com.atlassian.bitbucket.jenkins.internal.applink.oauth.serviceprovider.token.ServiceProviderTokenStore;
 import com.atlassian.bitbucket.jenkins.internal.jenkins.oauth.servlet.AuthorizeConfirmationConfig.AuthorizeConfirmationConfigDescriptor;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Describable;
@@ -59,6 +60,12 @@ public class OAuthGlobalConfiguration extends ManagementLink implements Describa
     @SuppressWarnings("unused") // Stapler
     public Action getAuthorize(StaplerRequest req) throws FormException {
         return authorizeConfirmationConfigDescriptor.createInstance(req);
+    }
+
+    @NonNull
+    @Override
+    public Category getCategory() {
+        return Category.SECURITY;
     }
 
     @Override


### PR DESCRIPTION
![Screenshot_20211005_110922](https://user-images.githubusercontent.com/53157896/135940927-b7bbe77b-3d44-496a-955d-a3d6a73eb264.png)

I chose security given this is auth configuration, but I'm happy to change it to System Config if anyone feels strongly about it.