### PR TITLE
Acceptance test fix

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
@@ -33,7 +33,9 @@ public class BitbucketScmWorkflowMultiBranchJob extends WorkflowMultiBranchJob {
             super.reIndex();
         } catch (NoSuchElementException e) {
             // JENKINS-63044
-            find(by.xpath("//div[@class=\"task\"]//*[text()=\"Scan Multibranch Pipeline Now\"]")).click();
+            // This selector is out of date as of Jenkins 2.249.1
+            // find(by.xpath("//div[@class=\"task\"]//*[text()=\"Scan Multibranch Pipeline Now\"]")).click();
+            find(by.xpath("//a[@title=\"Scan Multibranch Pipeline Now\"]")).click();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.11.2</jackson.version>
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->

--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,10 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 3.0.2 (XX 2021)
+- The minimum version of Jenkins changed to be **2.249.1**
+- Fix issue JENKINS-66789 (incoming webhooks unexpectedly disabling pipeline branches)
+
 ### 3.0.1 (8 October 2021)
 - Fix issue JENKINS-66802 (Builds failing with Jenkinsfiles longer than 500 lines)
 - OAuth consumer settings category set to Security


### PR DESCRIPTION
A dependency change in our acceptance test framework means we need to bump our latest Jenkins up to 2.2491, which had a CSS change that broke our func tests. This PR addresses both- for release in 3.0.2.