### PR TITLE
Minimum jenkins version updated to 2.249.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.235.5+
+- Jenkins 2.249.1+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 5.6 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
@@ -209,7 +209,7 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
-### 3.0.2 (XX 2021)
+### 3.0.2 (19 October 2021)
 - The minimum version of Jenkins changed to be **2.249.1**
 - Fix issue JENKINS-66789 (incoming webhooks unexpectedly disabling pipeline branches)
 


### PR DESCRIPTION
The acceptance harness minimum version has broken our tests again, so we are bumping to their minimum supported version. 