### PR TITLE
Ensure test repos have unique names

### DIFF
--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/AbstractDeploymentStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/AbstractDeploymentStatusPosterIT.java
@@ -51,8 +51,7 @@ public abstract class AbstractDeploymentStatusPosterIT {
 
     @Before
     public void setUp() throws Exception {
-        String repoName = REPO_NAME + "-deployments-fork";
-        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG, repoName);
+        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG);
         repoSlug = repository.getSlug();
         String cloneUrl =
                 repository.getCloneUrls()

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
@@ -56,8 +56,7 @@ public class BuildStatusPosterIT {
 
     @Before
     public void setUp() throws Exception {
-        String repoName = REPO_NAME + "-fork";
-        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG, repoName);
+        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG);
         repoSlug = repository.getSlug();
         String cloneUrl =
                 repository.getCloneUrls()

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/TriggerWebhookCreationTest.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/trigger/TriggerWebhookCreationTest.java
@@ -52,8 +52,7 @@ public class TriggerWebhookCreationTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        String repoName = REPO_NAME + "-fork";
-        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG, repoName);
+        BitbucketRepository repository = forkRepository(PROJECT_KEY, REPO_SLUG);
         repoSlug = repository.getSlug();
         projectKey = repository.getProject().getKey();
         cloneUrl =

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/util/BitbucketUtils.java
@@ -11,7 +11,8 @@ import io.restassured.response.ResponseBody;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
+
+import static java.util.UUID.randomUUID;
 
 @SuppressWarnings("unchecked")
 public class BitbucketUtils {
@@ -55,7 +56,7 @@ public class BitbucketUtils {
 
     public static PersonalToken createPersonalToken(String... permissions) {
         HashMap<String, Object> createTokenRequest = new HashMap<>();
-        createTokenRequest.put("name", "BitbucketJenkinsRule-" + UUID.randomUUID());
+        createTokenRequest.put("name", "BitbucketJenkinsRule-" + randomUUID());
         createTokenRequest.put("permissions", permissions);
         ResponseBody<Response> tokenResponse =
                 RestAssured.given()
@@ -77,7 +78,7 @@ public class BitbucketUtils {
     public static void createRepoFork() {
         HashMap<String, Object> createForkRequest = new HashMap<>();
         HashMap<String, Object> projectProperties = new HashMap<>();
-        repoForkName = repoForkSlug = UUID.randomUUID().toString();
+        repoForkName = repoForkSlug = randomUUID().toString();
 
         projectProperties.put("key", PROJECT_KEY);
         createForkRequest.put("name", repoForkSlug);
@@ -181,6 +182,10 @@ public class BitbucketUtils {
                     .delete(BITBUCKET_BASE_URL + "/rest/api/1.0/projects/" + projectKey + "/repos/" + repoSlug +
                         "/webhooks/" + webhookId)
                 .getBody();
+    }
+
+    public static BitbucketRepository forkRepository(String projectKey, String repoSlug) throws IOException {
+        return forkRepository(projectKey, repoSlug, repoSlug + "-fork-" + randomUUID());
     }
 
     public static BitbucketRepository forkRepository(String projectKey, String repoSlug, String forkName) throws IOException {


### PR DESCRIPTION
If a test times out using the Timeout rule the `@After` and `@AfterClass` methods don't get called to clean up the repository. This can lead to failures in other tests if they are trying to create a fork with the same name. Instead, we will create a fork with a unique name so that if the cleanup fails to run it does not impact on other tests.