### PR TITLE
Bump rest-assured to 4.4.0 to enable running tests on modern Java ver…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.0.0</version>
+            <version>4.4.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -293,6 +293,10 @@
                 <exclusion>
                     <groupId>com.sun.xml.bind</groupId>
                     <artifactId>jaxb-osgi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
This allows us to run our tests on Java versions beyond 11.