### PR TITLE
Bump Jenkins to 2.289.1

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
@@ -23,36 +23,47 @@ public class BitbucketScmConfig extends Scm {
     }
 
     public BitbucketScmConfig credentialsId(String credentialsId) {
+        scrollIntoView(this.credentialsId);
         new Select(this.credentialsId.resolve()).selectByValue(credentialsId);
         return this;
     }
 
     public BitbucketScmConfig sshCredentialsId(String sshCredentialsId) {
+        this.scrollIntoView(this.sshCredentialsId);
         new Select(this.sshCredentialsId.resolve()).selectByValue(sshCredentialsId);
         return this;
     }
 
     public BitbucketScmConfig serverId(String serverId) {
+        scrollIntoView(this.serverId);
         new Select(this.serverId.resolve()).selectByVisibleText(serverId);
         return this;
     }
 
     public BitbucketScmConfig projectName(String projectName) {
-        this.projectName.set(projectName);
-        return this;
+        return scrollIntoViewAndSet(projectName, this.projectName);
     }
 
     public BitbucketScmConfig repositoryName(String repositoryName) {
-        this.repositoryName.set(repositoryName);
-        return this;
+        return scrollIntoViewAndSet(repositoryName, this.repositoryName);
     }
 
     public BitbucketScmConfig branchName(String branchName) {
-        this.branchName.set(branchName);
-        return this;
+        return scrollIntoViewAndSet(branchName, this.branchName);
     }
 
     public BitbucketScmConfig anyBranch() {
         return branchName("");
+    }
+
+    private BitbucketScmConfig scrollIntoViewAndSet(String repositoryName, Control element) {
+        scrollIntoView(element);
+        element.set(repositoryName);
+        return this;
+    }
+
+    private Object scrollIntoView(Control element) {
+        // Scrolls the element to the top of the page, and then scrolls back down by 150px to offset the breadcrumbs
+        return element.executeScript("arguments[0].scrollIntoView(true);window.scrollBy(0, -150);", element.resolve());
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/test/acceptance/ProjectBasedMatrixSecurityHelper.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/test/acceptance/ProjectBasedMatrixSecurityHelper.java
@@ -109,7 +109,11 @@ public class ProjectBasedMatrixSecurityHelper {
         if (Objects.equals(user, jenkins.getCurrentUser())) {
             return;
         }
-        assertThat(new LoginPage(jenkins).load().login(user), isSuccessfulLogin());
+        LoginPage.LoginResult loginResult = new LoginPage(jenkins).load().login(user);
+        // For some reason, for non-admin users, the login page redirects to /me/api/json after successful login.
+        // This makes sure we're on the home page before proceeding.
+        jenkins.visit("/");
+        assertThat(loginResult, isSuccessfulLogin());
     }
 
     public void cleanUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
         <jackson.version>2.13.0</jackson.version>
+        <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
         <jenkins.version>2.289.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>atlassian-bitbucket-server-integration</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <bitbucket.version>5.5.9</bitbucket.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
         <java.level>8</java.level>
-        <jackson.version>2.11.2</jackson.version>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jackson.version>2.13.0</jackson.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -36,6 +36,18 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1013.vf8058992a042</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -61,12 +73,12 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.13</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
             <scope>provided
             </scope> <!-- Should really be test scope but that scope does not work due to transitive dependencies -->
         </dependency>
@@ -96,35 +108,30 @@
             <version>4.4.14</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-27</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.2</version>
+            <!--<version>managed by bom</version>-->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.13-1.0</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.5.9</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.14</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.11</version>
+            <!--<version>managed by bom</version>-->
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -135,7 +142,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>4.4.5</version>
+            <!--<version>managed by bom</version>-->
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -146,22 +153,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.20</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.32.1</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
-            <version>2.13</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.12</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -171,27 +178,27 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.8.4</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.5</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.7</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.6.4</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.76</version>
+            <!--<version>managed by bom</version>-->
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -202,32 +209,32 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.41</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.21</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.83</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.40</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.22</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.7</version>
+            <!--<version>managed by bom</version>-->
         </dependency>
         <dependency>
             <groupId>org.jfree</groupId>

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,9 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 3.2.0 (Unreleased)
+- The minimum version of Jenkins changed to be **2.289.1**
+
 ### 3.1.0 (5 November 2021)
 - [Sending notifications to Bitbucket Data Center's deployment status API](./docs/deployment_notifications.md) are now
   supported. For Freestyle jobs, this is implemented as a post-build action. For Pipeline and Multibranch Pipeline jobs,

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.249.1+
+- Jenkins 2.289.1+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 5.6 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/JenkinsProjectHandler.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/JenkinsProjectHandler.java
@@ -16,15 +16,20 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static it.com.atlassian.bitbucket.jenkins.internal.fixture.ScmUtils.createScm;
+import static java.lang.String.format;
 
 public class JenkinsProjectHandler {
+
+    private static final Logger log = Logger.getLogger(JenkinsProjectHandler.class.getName());
 
     public static final String MASTER_BRANCH_PATTERN = "**/master";
     public static final int DEFAULT_WAIT_TIME = 100;
@@ -93,7 +98,7 @@ public class JenkinsProjectHandler {
         }
         PseudoRun<WorkflowJob> lastSuccessfulBuild = mbp.getLastSuccessfulBuild();
         while (lastSuccessfulBuild.equals(mbp.getLastSuccessfulBuild())) {
-            System.out.println("Waiting for branch detection to run");
+            log.info("Waiting for branch detection to run");
             Thread.sleep(DEFAULT_WAIT_TIME);
         }
     }
@@ -104,10 +109,11 @@ public class JenkinsProjectHandler {
 
         performBranchScanning(mbp);
 
-        while (mbp.getItem(branch) == null || mbp.getItem(branch).getLastSuccessfulBuild() == lastSuccessfulBuild) {
-            System.out.println("Waiting for workflow run after scan to finish");
+        while (mbp.getItem(branch) == null || mbp.getItem(branch).getLastCompletedBuild() == lastSuccessfulBuild) {
+            log.info("Waiting for workflow run after scan to finish");
             Thread.sleep(DEFAULT_WAIT_TIME);
         }
+        checkLatestRunIsSuccessful(mbp.getItem(branch));
     }
 
     public void runWorkflowJobForBranch(WorkflowMultiBranchProject mbp, String branch) throws Exception {
@@ -121,10 +127,11 @@ public class JenkinsProjectHandler {
         Future<WorkflowRun> startCondition = item.scheduleBuild2(0).getStartCondition();
         WorkflowRun workflowRun = startCondition.get(1, TimeUnit.MINUTES);
 
-        while (!workflowRun.equals(item.getLastSuccessfulBuild())) {
-            System.out.println("Waiting for workflow run to finish");
+        while (!workflowRun.equals(item.getLastCompletedBuild())) {
+            log.info("Waiting for workflow run to finish");
             Thread.sleep(DEFAULT_WAIT_TIME);
         }
+        checkLatestRunIsSuccessful(item);
 
         onBuildCompletion.accept(workflowRun);
     }
@@ -138,10 +145,11 @@ public class JenkinsProjectHandler {
         Future<WorkflowRun> startCondition = workflowJob.scheduleBuild2(0).getStartCondition();
         WorkflowRun workflowRun = startCondition.get(1, TimeUnit.MINUTES);
 
-        while (!workflowRun.equals(workflowJob.getLastSuccessfulBuild())) {
-            System.out.println("Waiting for workflow run to finish");
+        while (!workflowRun.equals(workflowJob.getLastCompletedBuild())) {
+            log.info("Waiting for workflow run to finish");
             Thread.sleep(DEFAULT_WAIT_TIME);
         }
+        checkLatestRunIsSuccessful(workflowJob);
 
         onBuildCompletion.accept(workflowRun);
     }
@@ -150,11 +158,11 @@ public class JenkinsProjectHandler {
         items.stream().forEach(this::deleteQuietly);
     }
 
-    private void deleteQuietly(Item item) {
-        try {
-            item.delete();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    private void checkLatestRunIsSuccessful(WorkflowJob item) throws IOException {
+        if (item.getLastCompletedBuild() != item.getLastSuccessfulBuild()) {
+            // The build completed, but it wasn't successful
+            log.severe(format("Build completed unsuccessfully: %s", item.getLastCompletedBuild().getLog()));
+            throw new AssertionError("Expected the build to pass, but it didn't.");
         }
     }
 
@@ -163,5 +171,13 @@ public class JenkinsProjectHandler {
                 .map(BranchSpec::new)
                 .collect(Collectors.toList());
         return createScm(bbJenkinsRule, projectKey, repoSlug, branchSpecs);
+    }
+
+    private void deleteQuietly(Item item) {
+        try {
+            item.delete();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
* Add dependency management on bom and remove versions that are managed by that
* Harden acceptance tests
* Remove dependency on trilead-ssh2 (it seems to not be needed)