### PR TITLE
RFC: Bump minimum bitbucket version to 7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <bitbucket.version>5.5.9</bitbucket.version>
+        <bitbucket.version>7.4.2</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Our default Bitbucket version right now is 5.5.9, which is too low for even source branch updated events. We can still customize the property, and perhaps should continue to include 5.5.9 integration tests, but they should be the exception rather than the rule. I'm suggesting we use 7.4 to be consistent with our minimum recommended version- it also means we can test real source branch updated webhooks and the build page during acceptance tests _by default_.