### PR TITLE
Fix checkstyle config, and update style to match the now enforeced style

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -53,7 +53,8 @@
         <module name="TypeName"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="clover, junit.framework, org.apache.commons.lang, org.slf4j, javax.annotation.Nonnull, com.google.common.collect"/>
+            <property name="illegalPkgs" value="clover, junit.framework, org.apache.commons.lang, org.slf4j, com.google.common.collect"/>
+            <property name="illegalClasses" value="javax.annotation.Nonnull"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/link/BitbucketJobLinkActionFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/link/BitbucketJobLinkActionFactory.java
@@ -15,7 +15,6 @@ import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.*;
 import java.util.stream.Stream;
@@ -32,9 +31,8 @@ public class BitbucketJobLinkActionFactory extends TransientActionFactory<Job> {
         this.externalLinkUtils = externalLinkUtils;
     }
 
-    @Nonnull
     @Override
-    public Collection<? extends Action> createFor(@Nonnull Job target) {
+    public Collection<? extends Action> createFor(Job target) {
         // Freestyle Job
         if (target instanceof FreeStyleProject) {
             FreeStyleProject freeStyleProject = (FreeStyleProject) target;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/link/BitbucketMultibranchLinkActionFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/link/BitbucketMultibranchLinkActionFactory.java
@@ -7,7 +7,6 @@ import hudson.model.Action;
 import jenkins.model.TransientActionFactory;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,9 +25,8 @@ public class BitbucketMultibranchLinkActionFactory extends TransientActionFactor
         this.externalLinkUtils = externalLinkUtils;
     }
 
-    @Nonnull
     @Override
-    public Collection<? extends Action> createFor(@Nonnull WorkflowMultiBranchProject workflowMultiBranchProject) {
+    public Collection<? extends Action> createFor(WorkflowMultiBranchProject workflowMultiBranchProject) {
         Optional<BitbucketSCMRepository> maybeSource = workflowMultiBranchProject.getSCMSources()
                 .stream().filter(source -> source instanceof BitbucketSCMSource)
                 .map(source -> ((BitbucketSCMSource) source).getBitbucketSCMRepository())

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -16,7 +16,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -56,7 +55,7 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
     }
 
     @Override
-    public void onCompleted(Run<?, ?> r, @Nonnull TaskListener listener) {
+    public void onCompleted(Run<?, ?> r, TaskListener listener) {
         BitbucketRevisionAction bitbucketRevisionAction = r.getAction(BitbucketRevisionAction.class);
         if (bitbucketRevisionAction != null) {
             postBuildStatus(bitbucketRevisionAction, r, listener);


### PR DESCRIPTION
Our checkstyle config _tried_ to prevent import of the `NonNull` annotation but it had put the config in the wrong place. This fixes that mistake.