### PR TITLE
Bump acceptance-test-harness version to fix Smoke tests

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -14,7 +14,7 @@
         <plugin.build.dir>../target</plugin.build.dir>
         <!-- The name of the plugin being tested (i.e. the artifact name in the plugin's pom.xml) -->
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
-        <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
+        <jenkins.acceptance-test-harness.version>1.111</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jenkins.version>2.289.1</jenkins.version>


### PR DESCRIPTION
This PR fixes this [test](https://server-syd-bamboo.internal.atlassian.com/browse/BSERVTOOLS-BBSJEN-ST-532/test/case/4155528789) which is failing because of a change in button with label "Add user or group...". The corresponding fix in the acceptance-test-harness library is done in [this PR](https://github.com/jenkinsci/acceptance-test-harness/pull/720) and hence we need a version bump in that library which is done in this PR.