### PR TITLE
Revert acceptance-test-harness version bump and ignore failing tests

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -14,7 +14,7 @@
         <plugin.build.dir>../target</plugin.build.dir>
         <!-- The name of the plugin being tested (i.e. the artifact name in the plugin's pom.xml) -->
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
-        <jenkins.acceptance-test-harness.version>1.111</jenkins.acceptance-test-harness.version>
+        <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jenkins.version>2.289.1</jenkins.version>

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
@@ -214,6 +214,11 @@ public class SmokeTest extends AbstractJUnitTest {
     }
 
     @Test
+    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
+    // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
+    // Jenkins version (v2.289.1) we are using or the LTS (v2.319.1). Jenkins version should be >= v2.323 for v1.109 of
+    // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
+    // acceptance-test-harness.
     public void testRunBuildActionWtihFreestlyeJob() throws Exception {
         // Log into Bitbucket
         LoginPage loginPage = new LoginPage(jenkins, BITBUCKET_BASE_URL);

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
@@ -16,6 +16,7 @@ import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.User;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.inject.Inject;
@@ -72,6 +73,11 @@ public class ThreeLeggedOAuthAcceptanceTest extends AbstractJUnitTest {
     }
 
     @Test
+    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
+    // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
+    // Jenkins version (v2.289.1) we are using or the LTS (v2.319.1). Jenkins version should be >= v2.323 for v1.109 of
+    // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
+    // acceptance-test-harness.
     public void testAuthorize() {
         OAuth1AccessToken user1AccessToken = getAccessToken(user1);
         OAuth1AccessToken user2AccessToken = getAccessToken(user2);


### PR DESCRIPTION
This PR reverts the acceptance-test-harness version version back to 1.97 from 1.111. This is done to fix all the acceptance tests that are failing in the setup with the following error - 

> org.openqa.selenium.TimeoutException: Expected condition failed: waiting for org.jenkinsci.test.acceptance.po.CodeMirror$$Lambda$252/1015545330@39c85c1a (tried for 120 second(s) with 500 milliseconds interval)
Caused by: org.openqa.selenium.NoSuchElementException:
no such element: Unable to locate element: {"method":"xpath","selector":"//*[@path='/script']"}
  (Session info: chrome=97.0.4692.71)
For documentation on this error, please visit: https://www.seleniumhq.org/exceptions/no_such_element.html
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'C02DQ1B2MD6V', ip: 'fe80:0:0:0:1c13:81f5:5830:b908%en0', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.16', java.version: '1.8.0_281'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: true, browserName: chrome, browserVersion: 97.0.4692.71, chrome: {chromedriverVersion: 97.0.4692.71 (adefa7837d02a..., userDataDir: /var/folders/90/hzkwp11s1nx...}, goog:chromeOptions: {debuggerAddress: localhost:60089}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: normal, platform: MAC, platformName: MAC, proxy: Proxy(manual, http=0.0.0.0:..., setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webauthn:extension:credBlob: true, webauthn:extension:largeBlob: true, webauthn:virtualAuthenticators: true}
Session ID: bd04df0d0a624a8b74f871716e49d832
*** Element info: {Using=xpath, value=//*[@path='/script']}

The reason being v1.111 of the test harness is not compatible with Jenkins v2.289.1 . It needs at least v2.323 of Jenkins which is not LTS.

Because of reverting back to 1.97 of the test harness, couple of tests need to be ignored which are failing because of https://github.com/jenkinsci/acceptance-test-harness/issues/721 