### PR TITLE
Remove all usages of Log4j API and ban it

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -53,6 +53,10 @@
         <module name="TypeName"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="IllegalImport">
+            <!--
+              Log4J and SLF4J are banned because anything logged with them doesn't show
+              up in the web console. Use java.util.logging instead.
+             -->
             <property name="illegalPkgs" value="clover,
                                                 com.google.common.collect,
                                                 junit.framework,

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -53,7 +53,12 @@
         <module name="TypeName"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="clover, junit.framework, org.apache.commons.lang, org.slf4j, com.google.common.collect"/>
+            <property name="illegalPkgs" value="clover,
+                                                com.google.common.collect,
+                                                junit.framework,
+                                                org.apache.commons.lang,
+                                                org.apache.log4j,
+                                                org.slf4j"/>
             <property name="illegalClasses" value="javax.annotation.Nonnull"/>
         </module>
         <module name="RedundantImport"/>

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/ModernBitbucketBuildStatusClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/ModernBitbucketBuildStatusClientImpl.java
@@ -6,7 +6,6 @@ import com.atlassian.bitbucket.jenkins.internal.provider.InstanceKeyPairProvider
 import com.google.common.annotations.VisibleForTesting;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
-import org.apache.log4j.Logger;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 import java.security.InvalidKeyException;
@@ -15,6 +14,8 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
@@ -92,7 +93,7 @@ public class ModernBitbucketBuildStatusClientImpl implements BitbucketBuildStatu
             headers.put(BUILD_STATUS_SIGNATURE_ID, Base64.getEncoder().encodeToString(sig.sign()));
             headers.put(BUILD_STATUS_SIGNATURE_ALGORITHM_ID, algorithm);
         } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException e) {
-            LOGGER.warn("Error signing build status, continuing without signature:", e);
+            LOGGER.log(Level.WARNING, "Error signing build status, continuing without signature:", e);
             return Headers.of(Collections.emptyMap());
         }
         return Headers.of(headers);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
@@ -148,7 +148,7 @@ public class HttpRequestExecutorImpl implements HttpRequestExecutor {
                     version = plugin.getWrapper().getVersion();
                 }
             } catch (IllegalStateException e) {
-                org.apache.log4j.Logger.getLogger(UserAgentInterceptor.class).warn("Jenkins not available", e);
+                Logger.getLogger(UserAgentInterceptor.class.getName()).log(Level.WARNING, "Jenkins not available", e);
             }
             bbJenkinsUserAgent = "bitbucket-jenkins-integration/" + version;
         }


### PR DESCRIPTION
The log4j API that Jenkins provides actually comes from SLF4J so this really doesn't do much but it stops customers who are nervous about the Log4Shell VULN from asking why we're using `org.apache.log4j` classes.