### PR TITLE
Bump bitbucket version to 6.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,9 +522,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skipTests>true</skipTests>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <bitbucket.version>5.5.9</bitbucket.version>
+        <bitbucket.version>6.10.17</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
@@ -522,6 +522,9 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <bitbucket.version>6.10.17</bitbucket.version>
+        <bitbucket.version>6.10.0</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The plugin streamlines the entire configuration process and removes the need for
 - Jenkins 2.289.1+
 - Bitbucket Server 7.4+
 
-Note: Bitbucket Server 5.6 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
+Note: Bitbucket Server 6.10 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
 
 ## In this document
 1. [Install the plugin](#install-the-plugin)

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
@@ -93,14 +93,12 @@ public class BitbucketWebhookHandler implements WebhookHandler {
      */
     private Collection<BitbucketWebhookEvent> getEvents(WebhookRegisterRequest request) {
         Set<BitbucketWebhookEvent> supportedEvents = new HashSet<>();
-        Set<BitbucketWebhookEvent> forbiddenEvents = new HashSet<>();
-        Set<String> hooks = new HashSet<>();
+        Set<String> hooks;
         try {
-            BitbucketWebhookSupportedEvents events = serverCapabilities.getWebhookSupportedEvents();
-            hooks.addAll(events.getApplicationWebHooks());
+            hooks = serverCapabilities.getWebhookSupportedEvents().getApplicationWebHooks();
         } catch (BitbucketMissingCapabilityException e) {
-            forbiddenEvents.add(MIRROR_SYNCHRONIZED);
-            forbiddenEvents.add(PULL_REQUEST_FROM_REF_UPDATED);
+            // For Bitbucket < 6.5
+            hooks = new HashSet<>();
         }
 
         if (request.isMirror() && hooks.contains(MIRROR_SYNCHRONIZED.getEventId())) {
@@ -109,10 +107,10 @@ public class BitbucketWebhookHandler implements WebhookHandler {
             supportedEvents.add(REPO_REF_CHANGE);
         }
         if (request.isTriggerOnPullRequest()) {
+            // For Bitbucket starting 6.5, supported events should be checked for presence in the hooks set.
             supportedEvents.add(PULL_REQUEST_DECLINED);
             supportedEvents.add(PULL_REQUEST_DELETED);
-            if (!forbiddenEvents.contains(PULL_REQUEST_FROM_REF_UPDATED) && !request.isMirror() &&
-                    hooks.contains(PULL_REQUEST_FROM_REF_UPDATED.getEventId())) {
+            if (!request.isMirror() && hooks.contains(PULL_REQUEST_FROM_REF_UPDATED.getEventId())) {
                 supportedEvents.add(PULL_REQUEST_FROM_REF_UPDATED);
             }
             supportedEvents.add(PULL_REQUEST_MERGED);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
@@ -111,7 +111,8 @@ public class BitbucketWebhookHandler implements WebhookHandler {
         if (request.isTriggerOnPullRequest()) {
             supportedEvents.add(PULL_REQUEST_DECLINED);
             supportedEvents.add(PULL_REQUEST_DELETED);
-            if (!forbiddenEvents.contains(PULL_REQUEST_FROM_REF_UPDATED) && !request.isMirror()) {
+            if (!forbiddenEvents.contains(PULL_REQUEST_FROM_REF_UPDATED) && !request.isMirror() &&
+                    hooks.contains(PULL_REQUEST_FROM_REF_UPDATED.getEventId())) {
                 supportedEvents.add(PULL_REQUEST_FROM_REF_UPDATED);
             }
             supportedEvents.add(PULL_REQUEST_MERGED);


### PR DESCRIPTION
- Changed the value of `bitbucket.version` to 6.10.0 in `pom.xml`
- Fix `BitbucketWebhookHandler` to not send "pr:from_ref_updated" in the webhooks request for Bitbucket < 7.0