### PR TITLE
Set bitbucket version to 6.10.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <bitbucket.version>6.10.0</bitbucket.version>
+        <bitbucket.version>6.10.17</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <bitbucket.version>6.10.17</bitbucket.version>
+        <bitbucket.version>6.10.15</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The plugin streamlines the entire configuration process and removes the need for
 - Jenkins 2.289.1+
 - Bitbucket Server 7.4+
 
-Note: Bitbucket Server 6.10.17 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
+Note: Bitbucket Server 6.10.15 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
 
 ## In this document
 1. [Install the plugin](#install-the-plugin)

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The plugin streamlines the entire configuration process and removes the need for
 - Jenkins 2.289.1+
 - Bitbucket Server 7.4+
 
-Note: Bitbucket Server 6.10 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
+Note: Bitbucket Server 6.10.17 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
 
 ## In this document
 1. [Install the plugin](#install-the-plugin)

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/register/BitbucketWebhookHandler.java
@@ -5,7 +5,6 @@ import com.atlassian.bitbucket.jenkins.internal.client.BitbucketWebhookClient;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketMissingCapabilityException;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhook;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookRequest;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketWebhookSupportedEvents;
 import com.atlassian.bitbucket.jenkins.internal.trigger.events.BitbucketWebhookEvent;
 
 import javax.annotation.Nullable;


### PR DESCRIPTION
Windows build doesn't pass with bitbucket version 6.10.0 and hence this PR bumps the version to 6.10.15. Also an unused import is removed to fix checkstyle build.

Regarding failing builds, it seems the windows build needs at least 6.10.15 which has [SSH related change](https://jira.atlassian.com/browse/BSERV-13013?jql=project%20%3D%20BSERV%20AND%20resolution%20in%20(Fixed%2C%20Done)%20AND%20fixVersion%20%3D%206.10.15%20ORDER%20BY%20votes%20DESC). This is verified by running the builds on 6.10.14 and 6.10.15 -

