### PR TITLE
Fix broken access token URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,8 @@ To configure the plugin:
 
 Bitbucket Server instances are added and configured at the system level. Once they’re added users can select them from the SCM when creating a Jenkins job. You must add at least one Bitbucket Server instance to Jenkins.
 
-When adding a Bitbucket Server instance you must add at least one Bitbucket Server [personal access token](https://confluence.atlassian.com/display/BitbucketServer/personal+access+tokens) that is configured with project admin permissions. Doing this allows users to automatically set up build triggers when creating a Jenkins job.
+When adding a Bitbucket Server instance you must add at least one Bitbucket Server [HTTP access 
+token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) that is configured with project admin permissions. Doing this allows users to automatically set up build triggers when creating a Jenkins job.
 
 Watch our [video](https://youtu.be/0-FugzVYJQU) to find out how to do this, or see below for written instructions. 
 
@@ -71,9 +72,9 @@ To add a Bitbucket Server instance:
 3. Enter these instance details:
    - Instance name - Enter a name to help users identify this instance. 
    - Instance URL - Enter the Bitbucket Server base URL. For example, http://localhost:7990/bitbucket. 
-   - Personal access token - Select a token from the list. Or to first add a token:
+   - HTTP access token - Select a token from the list. Or to first add a token:
       - Select **Add** > **Jenkins**.
-      - For **Kind**, select [Bitbucket personal access token](https://confluence.atlassian.com/display/BitbucketServer/personal+access+tokens).
+      - For **Kind**, select [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html).
       - Enter a Token (with at least **project admin permissions**), a unique token ID and a Description. 
       - Select **Add**. You should now be able to select the token from the list.
 4. Select **Test connection** to check your instance details. 
@@ -101,7 +102,8 @@ To register a consumer:
 
 After you save, you’ll be taken to a page called Application Link details. It’s a good idea to keep this page open when moving onto part 2 so you can copy the details across to Bitbucket Server. 
 
-You can also access the Application Link details page by going to **Jenkins** > **Manage Jenkins** > **Manage Bitbucket Server consumers**, and selecting the Application Link details for the consumer. 
+You can also 
+the Application Link details page by going to **Jenkins** > **Manage Jenkins** > **Manage Bitbucket Server consumers**, and selecting the Application Link details for the consumer. 
 
 #### 2. Create an Application Link to Jenkins
 

--- a/readme.md
+++ b/readme.md
@@ -102,8 +102,7 @@ To register a consumer:
 
 After you save, you’ll be taken to a page called Application Link details. It’s a good idea to keep this page open when moving onto part 2 so you can copy the details across to Bitbucket Server. 
 
-You can also 
-the Application Link details page by going to **Jenkins** > **Manage Jenkins** > **Manage Bitbucket Server consumers**, and selecting the Application Link details for the consumer. 
+You can also access the Application Link details page by going to **Jenkins** > **Manage Jenkins** > **Manage Bitbucket Server consumers**, and selecting the Application Link details for the consumer. 
 
 #### 2. Create an Application Link to Jenkins
 


### PR DESCRIPTION
Also rename 'personal' access tokens to 'HTTP' access tokens now that project/repo scoped tokens can be created in Bitbucket Server.

Thanks to @mikerossiter for [pointing this out](https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/pull/322)