### PR TITLE
Revert minimum supported version to 5.5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The plugin streamlines the entire configuration process and removes the need for
 - Jenkins 2.289.1+
 - Bitbucket Server 7.4+
 
-Note: Bitbucket Server 6.10.15 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
+Note: Bitbucket Server 5.5 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
 
 ## In this document
 1. [Install the plugin](#install-the-plugin)

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,6 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ### 3.2.0 (Unreleased)
 - The minimum version of Jenkins changed to be **2.289.1**
-- The minimum **Bitbucket** version changed to be **6.10.15** while earlier versions may continue to work we do recommend upgrading to ensure the plugin continues to function as expected.
 
 ### 3.1.0 (5 November 2021)
 - [Sending notifications to Bitbucket Data Center's deployment status API](./docs/deployment_notifications.md) are now


### PR DESCRIPTION
We can still test successfully against 5.5 so I don't think it's correct to say we don't support it. Even if the feature set is much smaller, the plugin works as intended and our capability endpoint gives info to users attempting to use unavailable features.

The change related to our windows builds- because we're testing jenkins rather than Bitbucket, I don't think it's necessary for Bitbucket 5.5 to work on Windows for us to say the plugin is compatible with Bitbucket 5.5 on Windows.