### PR TITLE
JENKINS-66498 add server name resolution for BitbucketSCMStep

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ### 3.2.0 (Unreleased)
 - The minimum version of Jenkins changed to be **2.289.1**
 - Fix JENKINS-66539 we now handle rate limiting for posting build statuses
+- JENKINS-66498 BitbucketSCMStep can now use serverName instead of serverId to specify a Bitbucket instance
 
 ### 3.1.0 (5 November 2021)
 - [Sending notifications to Bitbucket Data Center's deployment status API](./docs/deployment_notifications.md) are now

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfiguration.java
@@ -24,6 +24,7 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
@@ -93,8 +94,18 @@ public class BitbucketPluginConfiguration extends GlobalConfiguration {
      * @return a list of all valid configured servers
      */
     public List<BitbucketServerConfiguration> getValidServerList() {
-        return serverList.stream()
-                .filter(server -> server.validate().kind != Kind.ERROR)
+        return getValidServerStream().collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of all servers configured by the user matching the provided name, and also passing the process()
+     * function with no errors.
+     * @param serverName the name to search for
+     * @return a list of all valid configured servers with a matching serverName
+     */
+    public List<BitbucketServerConfiguration> getValidServerListByName(String serverName) {
+        return getValidServerStream()
+                .filter(server -> serverName.equals(server.getServerName()))
                 .collect(Collectors.toList());
     }
 
@@ -107,6 +118,11 @@ public class BitbucketPluginConfiguration extends GlobalConfiguration {
         return serverList.stream().anyMatch(server -> server.validate().kind == Kind.ERROR);
     }
 
+    private Stream<BitbucketServerConfiguration> getValidServerStream() {
+        return serverList.stream()
+                .filter(server -> server.validate().kind != Kind.ERROR);
+    }
+    
     private void updateJobs(Map<String, String> oldBaseUrls) {
         Set<String> changedServerIds = serverList.stream()
                 .filter(serverConfig -> !serverConfig.getBaseUrl().equalsIgnoreCase(oldBaseUrls.get(serverConfig.getId())))

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import com.atlassian.bitbucket.jenkins.internal.annotations.UpgradeHandled;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.google.common.annotations.VisibleForTesting;
@@ -34,6 +35,7 @@ public class BitbucketSCMStep extends SCMStep {
     private final String projectName;
     private final String repositoryName;
     private String serverId;
+    @UpgradeHandled(handledBy = "Optional field, existing SCMSteps will be created as normal", removeAnnotationInVersion = "3.2.1")
     private String serverName;
     private String mirrorName;
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -1,12 +1,8 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
-import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
-import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
-import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentialsModule;
-import com.google.inject.Guice;
+import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.plugins.git.BranchSpec;
@@ -23,6 +19,7 @@ import org.kohsuke.stapler.verb.POST;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -37,18 +34,14 @@ public class BitbucketSCMStep extends SCMStep {
     private String id;
     private final String projectName;
     private final String repositoryName;
-    private final String serverId;
+    private String serverId;
+    private String serverName;
     private String mirrorName;
 
     @DataBoundConstructor
-    public BitbucketSCMStep(String projectName, String repositoryName, String serverId) {
+    public BitbucketSCMStep(String projectName, String repositoryName) {
         this.id = UUID.randomUUID().toString();
         this.branches = Collections.singletonList(new BranchSpec("**"));
-
-        if (isBlank(serverId)) {
-            throw new BitbucketSCMException("Error creating Bitbucket SCM: No server configuration provided");
-        }
-        this.serverId = serverId;
 
         if (isBlank(projectName)) {
             throw new BitbucketSCMException("Error creating the Bitbucket SCM: The project name is blank");
@@ -62,8 +55,8 @@ public class BitbucketSCMStep extends SCMStep {
     }
 
     @DataBoundSetter
-    public void setId(String id) {
-        this.id = requireNonNull(id, "id");
+    public void setBranches(List<BranchSpec> branches) {
+        this.branches = requireNonNull(branches, "branches");
     }
 
     @DataBoundSetter
@@ -72,8 +65,8 @@ public class BitbucketSCMStep extends SCMStep {
     }
 
     @DataBoundSetter
-    public void setSshCredentialsId(@Nullable String sshCredentialsId) {
-        this.sshCredentialsId = stripToNull(sshCredentialsId);
+    public void setId(String id) {
+        this.id = requireNonNull(id, "id");
     }
 
     @DataBoundSetter
@@ -82,10 +75,20 @@ public class BitbucketSCMStep extends SCMStep {
     }
 
     @DataBoundSetter
-    public void setBranches(List<BranchSpec> branches) {
-        this.branches = requireNonNull(branches, "branches");
+    public void setServerId(String serverId) {
+        this.serverId = requireNonNull(serverId, "serverId");
+    }
+    
+    @DataBoundSetter
+    public void setServerName(String serverName) {
+        this.serverName = requireNonNull(serverName, "serverName");
     }
 
+    @DataBoundSetter
+    public void setSshCredentialsId(@Nullable String sshCredentialsId) {
+        this.sshCredentialsId = stripToNull(sshCredentialsId);
+    }
+    
     public List<BranchSpec> getBranches() {
         return branches;
     }
@@ -120,25 +123,48 @@ public class BitbucketSCMStep extends SCMStep {
     public String getServerId() {
         return serverId;
     }
+    
+    @Nullable
+    public String getServerName() {
+        return serverName;
+    }
 
     @Override
     protected SCM createSCM() {
+        resolveServerId();
         return new BitbucketSCM(id, branches, credentialsId, sshCredentialsId, null, null, projectName, repositoryName, serverId, mirrorName);
+    }
+    
+    // If the server ID was not set but the server name was, this finds the matching config and resolves the ID
+    private void resolveServerId() {
+        if (serverId != null) {
+            // Id already exists, nothing to do
+            return;
+        }
+        if (serverName != null) {
+            List<BitbucketServerConfiguration> serverList = ((DescriptorImpl) getDescriptor()).getConfigurationByName(serverName);
+            if (serverList.isEmpty()) {
+                throw new BitbucketSCMException("Error creating Bitbucket SCM: No server configuration matches provided name");
+            } else if (serverList.size() > 1) {
+                throw new BitbucketSCMException("Error creating Bitbucket SCM: Multiple server configurations match " +
+                                                "provided service name. Use serverId to disambiguate");
+            }
+            serverId = serverList.get(0).getId();
+        } else {
+            throw new BitbucketSCMException("Error creating Bitbucket SCM: No server name or ID provided");
+        }
     }
 
     @Symbol("BitbucketSCMStep")
     @Extension
-    public static final class DescriptorImpl extends SCMStepDescriptor implements BitbucketScmFormValidation, BitbucketScmFormFill {
+    public static class DescriptorImpl extends SCMStepDescriptor implements BitbucketScmFormValidation, BitbucketScmFormFill {
 
-        @Inject
-        private BitbucketClientFactoryProvider bitbucketClientFactoryProvider;
         @Inject
         private BitbucketPluginConfiguration bitbucketPluginConfiguration;
         @Inject
         private BitbucketScmFormFillDelegate formFill;
         @Inject
         private BitbucketScmFormValidationDelegate formValidation;
-        private transient JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
 
         @Override
         @POST
@@ -261,35 +287,11 @@ public class BitbucketSCMStep extends SCMStep {
             return false;
         }
 
-        @Inject
-        public void setJenkinsToBitbucketCredentials(
-                JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials) {
-            this.jenkinsToBitbucketCredentials = jenkinsToBitbucketCredentials;
-        }
-
-        private BitbucketMirrorHandler createMirrorHandler(BitbucketScmHelper helper) {
-            injectJenkinsToBitbucketCredentials();
-            return new BitbucketMirrorHandler(
-                    bitbucketClientFactoryProvider,
-                    jenkinsToBitbucketCredentials,
-                    (client, project, repo) -> helper.getRepository(project, repo));
-        }
-
-        BitbucketScmHelper getBitbucketScmHelper(String bitbucketUrl,
-                                                 @Nullable BitbucketTokenCredentials tokenCredentials) {
-            return new BitbucketScmHelper(bitbucketUrl,
-                    bitbucketClientFactoryProvider,
-                    jenkinsToBitbucketCredentials.toBitbucketCredentials(tokenCredentials));
-        }
-
-        private Optional<BitbucketServerConfiguration> getConfiguration(@Nullable String serverId) {
-            return bitbucketPluginConfiguration.getServerById(serverId);
-        }
-
-        private void injectJenkinsToBitbucketCredentials() {
-            if (jenkinsToBitbucketCredentials == null) {
-                Guice.createInjector(new JenkinsToBitbucketCredentialsModule()).injectMembers(this);
-            }
+        @VisibleForTesting
+        List<BitbucketServerConfiguration> getConfigurationByName(String serverName) {
+             return bitbucketPluginConfiguration.getServerList()
+                    .stream().filter(server -> serverName.equals(server.getServerName()))
+                    .collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -19,7 +19,6 @@ import org.kohsuke.stapler.verb.POST;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -142,7 +141,7 @@ public class BitbucketSCMStep extends SCMStep {
             return;
         }
         if (serverName != null) {
-            List<BitbucketServerConfiguration> serverList = ((DescriptorImpl) getDescriptor()).getConfigurationByName(serverName);
+            List<BitbucketServerConfiguration> serverList = ((DescriptorImpl) getDescriptor()).getServerListByName(serverName);
             if (serverList.isEmpty()) {
                 throw new BitbucketSCMException("Error creating Bitbucket SCM: No server configuration matches provided name");
             } else if (serverList.size() > 1) {
@@ -288,10 +287,8 @@ public class BitbucketSCMStep extends SCMStep {
         }
 
         @VisibleForTesting
-        List<BitbucketServerConfiguration> getConfigurationByName(String serverName) {
-             return bitbucketPluginConfiguration.getServerList()
-                    .stream().filter(server -> serverName.equals(server.getServerName()))
-                    .collect(Collectors.toList());
+        List<BitbucketServerConfiguration> getServerListByName(String serverName) {
+             return bitbucketPluginConfiguration.getValidServerListByName(serverName);
         }
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfigurationTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfigurationTest.java
@@ -26,10 +26,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -59,6 +59,7 @@ public class BitbucketPluginConfigurationTest {
     @Before
     public void setup() {
         pluginConfiguration = new BitbucketPluginConfiguration();
+        when(validServerConfiguration.getServerName()).thenReturn("serverName");
         when(validServerConfiguration.validate()).thenReturn(FormValidation.ok());
         when(validServerConfiguration.getId()).thenReturn("0");
         when(validServerConfiguration.getBaseUrl()).thenReturn("http://localhost:5990/bitbucket");
@@ -141,6 +142,30 @@ public class BitbucketPluginConfigurationTest {
     public void testGetValidServerListEmpty() {
         pluginConfiguration.setServerList(Collections.emptyList());
         assertThat(pluginConfiguration.getValidServerList(), Matchers.hasSize(0));
+    }
+    
+    @Test
+    public void testGetValidServerListByName() {
+        pluginConfiguration.setServerList(Arrays.asList(validServerConfiguration, invalidServerConfigurationOne));
+        assertThat(pluginConfiguration.getValidServerListByName("serverName"), Matchers.hasSize(1));
+    }
+    
+    @Test
+    public void testGetValidServerListEmptyByName() {
+        pluginConfiguration.setServerList(Collections.emptyList());
+        assertThat(pluginConfiguration.getValidServerListByName("serverName"), Matchers.hasSize(0));
+    }
+
+    @Test
+    public void testGetValidServerListNonMatchingName() {
+        pluginConfiguration.setServerList(Arrays.asList(validServerConfiguration, invalidServerConfigurationOne));
+        assertThat(pluginConfiguration.getValidServerListByName("nonMatchingName"), Matchers.hasSize(0));
+    }
+    
+    @Test
+    public void testGetValidServerListMultipleMatchingNames() {
+        pluginConfiguration.setServerList(Arrays.asList(validServerConfiguration, validServerConfiguration));
+        assertThat(pluginConfiguration.getValidServerListByName("serverName"), Matchers.hasSize(2));
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepTest.java
@@ -49,7 +49,7 @@ public class BitbucketSCMStepTest {
                 .descriptor(descriptor)
                 .serverName(SERVER_NAME)
                 .build();
-        doReturn(Collections.singletonList(serverConfiguration)).when(descriptor).getConfigurationByName(SERVER_NAME);
+        doReturn(Collections.singletonList(serverConfiguration)).when(descriptor).getServerListByName(SERVER_NAME);
         BitbucketSCMRepository result = scmStep.createSCM().getBitbucketSCMRepository();
 
         assertThat(result.getServerId(), equalTo(SERVER_ID));
@@ -61,20 +61,21 @@ public class BitbucketSCMStepTest {
                 .descriptor(descriptor)
                 .serverName(SERVER_NAME)
                 .build();
-        doReturn(Collections.emptyList()).when(descriptor).getConfigurationByName(SERVER_NAME);
+        doReturn(Collections.emptyList()).when(descriptor).getServerListByName(SERVER_NAME);
 
         Exception thrown = assertThrows(BitbucketSCMException.class, scmStep::createSCM);
         assertThat(thrown.getMessage(), equalTo("Error creating Bitbucket SCM: No server configuration matches provided name"));
     }
-    
+
     @Test
     public void testCreateSCMServerMultipleMatchingNames() {
+        BitbucketServerConfiguration otherConfiguration = mock(BitbucketServerConfiguration.class);
         TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
                 .descriptor(descriptor)
                 .serverName(SERVER_NAME)
                 .build();
-        doReturn(Arrays.asList(serverConfiguration, mock(BitbucketServerConfiguration.class)))
-                .when(descriptor).getConfigurationByName(SERVER_NAME);
+        doReturn(Arrays.asList(serverConfiguration, otherConfiguration))
+                .when(descriptor).getServerListByName(SERVER_NAME);
 
         Exception thrown = assertThrows(BitbucketSCMException.class, scmStep::createSCM);
         assertThat(thrown.getMessage(), equalTo("Error creating Bitbucket SCM: Multiple server configurations match " +

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepTest.java
@@ -1,0 +1,108 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import it.com.atlassian.bitbucket.jenkins.internal.fixture.TestSCMStep;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketSCMStepTest {
+    
+    private static final String SERVER_NAME = "serverName";
+    private static final String SERVER_ID = "random-uuid-1fjiosf9r";
+    
+    @Mock
+    private BitbucketSCMStep.DescriptorImpl descriptor;
+    @Mock
+    private BitbucketServerConfiguration serverConfiguration;
+    
+    @Before
+    public void setup() {
+        doReturn(SERVER_ID).when(serverConfiguration).getId();
+    }
+    
+    @Test
+    public void testCreateSCMServerId() {
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .serverId(SERVER_ID)
+                .build();
+        BitbucketSCMRepository result = scmStep.createSCM().getBitbucketSCMRepository();
+        
+        assertThat(result.getServerId(), equalTo(SERVER_ID));
+    }
+
+    @Test
+    public void testCreateSCMServerName() {
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .serverName(SERVER_NAME)
+                .build();
+        doReturn(Collections.singletonList(serverConfiguration)).when(descriptor).getConfigurationByName(SERVER_NAME);
+        BitbucketSCMRepository result = scmStep.createSCM().getBitbucketSCMRepository();
+
+        assertThat(result.getServerId(), equalTo(SERVER_ID));
+    }
+
+    @Test
+    public void testCreateSCMServerNoMatchingName() {
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .serverName(SERVER_NAME)
+                .build();
+        doReturn(Collections.emptyList()).when(descriptor).getConfigurationByName(SERVER_NAME);
+
+        Exception thrown = assertThrows(BitbucketSCMException.class, scmStep::createSCM);
+        assertThat(thrown.getMessage(), equalTo("Error creating Bitbucket SCM: No server configuration matches provided name"));
+    }
+    
+    @Test
+    public void testCreateSCMServerMultipleMatchingNames() {
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .serverName(SERVER_NAME)
+                .build();
+        doReturn(Arrays.asList(serverConfiguration, mock(BitbucketServerConfiguration.class)))
+                .when(descriptor).getConfigurationByName(SERVER_NAME);
+
+        Exception thrown = assertThrows(BitbucketSCMException.class, scmStep::createSCM);
+        assertThat(thrown.getMessage(), equalTo("Error creating Bitbucket SCM: Multiple server configurations match " +
+                                                "provided service name. Use serverId to disambiguate"));
+    }
+    
+    @Test
+    public void testCreateSCMServerNoServerIndentifierProvided() {
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .build();
+
+        Exception thrown = assertThrows(BitbucketSCMException.class, scmStep::createSCM);
+        assertThat(thrown.getMessage(), equalTo("Error creating Bitbucket SCM: No server name or ID provided"));
+    }
+    
+    @Test
+    public void testCreateSCMServerConflictingIdAndNameProvided() {
+        // In the event we receive a serverName AND a serverId, we ignore the server name as the id is more specific
+        // There's a potential for the name to not match an id (GIGO). We don't need special handling for it
+        TestSCMStep scmStep = new TestSCMStep.Builder("id", "project", "repository")
+                .descriptor(descriptor)
+                .serverId(SERVER_ID)
+                .serverName("UnrelatedName")
+                .build();
+        BitbucketSCMRepository result = scmStep.createSCM().getBitbucketSCMRepository();
+
+        assertThat(result.getServerId(), equalTo(SERVER_ID));
+        verifyZeroInteractions(descriptor);
+    }
+}

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/TestSCMStep.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/TestSCMStep.java
@@ -12,18 +12,31 @@ import java.util.List;
  * A test class to expose the createSCM method publicly for tests
  */
 public class TestSCMStep extends BitbucketSCMStep {
+    
+    private final StepDescriptor descriptor;
 
-    public TestSCMStep(String id, List<BranchSpec> branches, String credentialsId, String sshCredentialsId,
-                       String projectName, String repositoryName, String serverId, String mirrorName) {
-        super(projectName, repositoryName, serverId);
-        // Stapler applies the fields using data-bound setters, so we replicate that behaviour rather than setting manually
-        setBranches(branches);
-        setCredentialsId(credentialsId);
-        setId(id);
-        setSshCredentialsId(sshCredentialsId);
-        setMirrorName(mirrorName);
+    protected TestSCMStep(Builder builder) {
+        super(builder.projectName, builder.repositoryName);
+        setId(builder.id);
+        if (builder.descriptor != null) {
+            descriptor = builder.descriptor;
+        } else {
+            descriptor = (StepDescriptor) Jenkins.get().getDescriptorOrDie(BitbucketSCMStep.class);
+        }
+        if (builder.branches != null) {
+            setBranches(builder.branches);
+        }
+        if (builder.serverId != null) {
+            setServerId(builder.serverId);
+        }
+        if (builder.serverName != null) {
+            setServerName(builder.serverName);
+        }
+        setCredentialsId(builder.credentialsId);
+        setSshCredentialsId(builder.sshCredentialsId);
+        setMirrorName(builder.mirrorName);
     }
-
+    
     @Override
     public TestSCM createSCM() {
         return new TestSCM((BitbucketSCM) super.createSCM());
@@ -31,6 +44,65 @@ public class TestSCMStep extends BitbucketSCMStep {
 
     @Override
     public StepDescriptor getDescriptor() {
-        return (StepDescriptor) Jenkins.get().getDescriptorOrDie(BitbucketSCMStep.class);
+        return descriptor;
+    }
+    
+    public static class Builder {
+        
+        private final String id;
+        private final String projectName;
+        private final String repositoryName;
+        private List<BranchSpec> branches;
+        private String credentialsId;
+        private String sshCredentialsId;
+        private String serverId;
+        private String serverName;
+        private String mirrorName;
+        private StepDescriptor descriptor;
+        
+        public Builder(String id, String projectName, String repositoryName) {
+            this.id = id;
+            this.projectName = projectName;
+            this.repositoryName = repositoryName;
+        }
+        
+        public Builder branches(List<BranchSpec> branches) {
+            this.branches = branches;
+            return this;
+        }
+        
+        public TestSCMStep build() {
+            return new TestSCMStep(this);
+        }
+        
+        public Builder credentialsId(String credentialsId) {
+            this.credentialsId = credentialsId;
+            return this;
+        }
+        
+        public Builder descriptor(StepDescriptor descriptor) {
+            this.descriptor = descriptor;
+            return this;
+        }
+        
+        public Builder mirrorName(String mirrorName) {
+            this.mirrorName = mirrorName;
+            return this;
+        }
+        
+        public Builder serverId(String serverId) {
+            this.serverId = serverId;
+            return this;
+        }
+        
+        public Builder serverName(String serverName) {
+            this.serverName = serverName;
+            return this;
+        }
+        
+        public Builder sshCredentialsId(String sshCredentialsId) {
+            this.sshCredentialsId = sshCredentialsId;
+            return this;
+        }
     }
 }

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSnippetGeneratorIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSnippetGeneratorIT.java
@@ -65,7 +65,6 @@ public class BitbucketSCMSnippetGeneratorIT {
         json.put("stapler-class", "com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMStep");
         json.put("$class", "com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMStep");
 
-        json.put("projectName", "Project 1");
         json.put("repositoryName", "rep_1");
 
         RestAssured.expect()

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepIT.java
@@ -36,8 +36,11 @@ public class BitbucketSCMStepIT {
         String credentialsId = bbJenkinsRule.getBbAdminUsernamePasswordCredentialsId();
         String id = UUID.randomUUID().toString();
         String serverId = serverConf.getId();
-        TestSCMStep scmStep = new TestSCMStep(id, singletonList(new BranchSpec("master")),
-                credentialsId, "", PROJECT_NAME, REPO_NAME, serverId, "");
+        TestSCMStep scmStep = new TestSCMStep.Builder(id, PROJECT_NAME, REPO_NAME)
+                .credentialsId(credentialsId)
+                .branches(singletonList(new BranchSpec("master")))
+                .serverId(serverId)
+                .build();
         TestSCM scm = scmStep.createSCM();
 
         assertThat(scmStep.getBranches(), hasSize(1));
@@ -75,8 +78,11 @@ public class BitbucketSCMStepIT {
         String credentialsId = bbJenkinsRule.getBbAdminUsernamePasswordCredentialsId();
         String id = UUID.randomUUID().toString();
         String serverId = serverConf.getId();
-        TestSCMStep scmStep = new TestSCMStep(id, singletonList(new BranchSpec("test-branch")),
-                credentialsId, "", PROJECT_NAME, REPO_NAME, serverId, "");
+        TestSCMStep scmStep = new TestSCMStep.Builder(id, PROJECT_NAME, REPO_NAME)
+                .credentialsId(credentialsId)
+                .branches(singletonList(new BranchSpec("test-branch")))
+                .serverId(serverId)
+                .build();
         TestSCM scm = scmStep.createSCM();
         scm.getAndInitializeGitScmIfNull(null);
 
@@ -119,8 +125,12 @@ public class BitbucketSCMStepIT {
         String sshCredentialsId = bbJenkinsRule.getSshCredentialsId();
         String id = UUID.randomUUID().toString();
         String serverId = serverConf.getId();
-        TestSCMStep scmStep = new TestSCMStep(id, singletonList(new BranchSpec("master")),
-                credentialsId, sshCredentialsId, PROJECT_NAME, REPO_NAME, serverId, "");
+        TestSCMStep scmStep = new TestSCMStep.Builder(id, PROJECT_NAME, REPO_NAME)
+                .credentialsId(credentialsId)
+                .sshCredentialsId(sshCredentialsId)
+                .branches(singletonList(new BranchSpec("master")))
+                .serverId(serverId)
+                .build();
         TestSCM scm = scmStep.createSCM();
         scm.getAndInitializeGitScmIfNull(null);
 
@@ -163,8 +173,12 @@ public class BitbucketSCMStepIT {
         String sshCredentialsId = bbJenkinsRule.getSshCredentialsId();
         String id = UUID.randomUUID().toString();
         String serverId = serverConf.getId();
-        TestSCMStep scmStep = new TestSCMStep(id, singletonList(new BranchSpec("master")),
-                credentialsId, sshCredentialsId, PROJECT_NAME, REPO_NAME, serverId, "");
+        TestSCMStep scmStep = new TestSCMStep.Builder(id, PROJECT_NAME, REPO_NAME)
+                .credentialsId(credentialsId)
+                .sshCredentialsId(sshCredentialsId)
+                .branches(singletonList(new BranchSpec("master")))
+                .serverId(serverId)
+                .build();
         TestSCM scm = scmStep.createSCM();
 
         assertThat(scmStep.getBranches(), hasSize(1));


### PR DESCRIPTION
This adds the ability to declare a human-readable Bitbucket server instance name as so:
```
bbs_checkout branches: [[name: '*/master']], credentialsId: 'fe048ca8-1461-41ff-bfe1-f40ebd29e92c', projectName: 'Project 1', repositoryName: 'jenkins', serverName: 'Bitbucket'
```
Note that using a server id will still work fine. There are a few cases to consider
- Server names are not unique- if multiple matching server names are found, we kick back an error requesting to use an id instead (but you can still use both for readability)
- Names are case sensitive and must appear exactly as they're edited on the config page (including whitespace etc.). If the strings aren't equal we error
- Sever id always takes precedence over name
- This _technically_ makes both id and name optional, but trying to do anything while having both null will error immediately explaining the issue