### PR TITLE
Fix capability cache

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImpl.java
@@ -26,12 +26,12 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
      */
     public static final long CAPABILITIES_CACHE_DURATION =
             parsePositiveLongFromSystemProperty(CAPABILITIES_CACHE_DURATION_KEY, 360000);
+    private static Supplier<AtlassianServerCapabilities> capabilitiesCache;
+    
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
-    private final Supplier<AtlassianServerCapabilities> capabilitiesCache;
 
-    BitbucketCapabilitiesClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, BitbucketCapabilitiesSupplier supplier) {
+    BitbucketCapabilitiesClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor) {
         this.bitbucketRequestExecutor = bitbucketRequestExecutor;
-        capabilitiesCache = Suppliers.memoizeWithExpiration(supplier, CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -55,6 +55,10 @@ public class BitbucketCapabilitiesClientImpl implements BitbucketCapabilitiesCli
 
     @Override
     public AtlassianServerCapabilities getServerCapabilities() {
+        if (capabilitiesCache == null) {
+            capabilitiesCache = Suppliers.memoizeWithExpiration(new BitbucketCapabilitiesSupplier(bitbucketRequestExecutor),
+                    CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS);
+        }
         return capabilitiesCache.get();
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -21,7 +21,7 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
     public static final long CAPABILITIES_CACHE_DURATION =
             parsePositiveLongFromSystemProperty(CAPABILITIES_CACHE_DURATION_KEY, 360000);
     private final Cache<HttpUrl, AtlassianServerCapabilities> capabilitiesCache = CacheBuilder.newBuilder()
-            .expireAfterAccess(CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS)
             .build();
             
     private final BitbucketRequestExecutor bitbucketRequestExecutor;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -1,19 +1,16 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
-import com.atlassian.bitbucket.jenkins.internal.client.supply.BitbucketCapabilitiesSupplier;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
-    private final BitbucketCapabilitiesSupplier capabilitiesSupplier;
 
     BitbucketClientFactoryImpl(String serverUrl, BitbucketCredentials credentials, ObjectMapper objectMapper,
                                HttpRequestExecutor httpRequestExecutor) {
         bitbucketRequestExecutor = new BitbucketRequestExecutor(serverUrl, httpRequestExecutor, objectMapper,
                 credentials);
-        capabilitiesSupplier = new BitbucketCapabilitiesSupplier(bitbucketRequestExecutor);
     }
 
     @Override
@@ -23,7 +20,7 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
     @Override
     public BitbucketCapabilitiesClient getCapabilityClient() {
-        return new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor, capabilitiesSupplier);
+        return new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor);
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -1,10 +1,29 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
+import com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import okhttp3.HttpUrl;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertiesConstants.CAPABILITIES_CACHE_DURATION_KEY;
+import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertyUtils.parsePositiveLongFromSystemProperty;
 
 public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
+    /**
+     * Cache duration for the capabilities response. Defaults to 1 hour in ms.
+     */
+    public static final long CAPABILITIES_CACHE_DURATION =
+            parsePositiveLongFromSystemProperty(CAPABILITIES_CACHE_DURATION_KEY, 360000);
+    private final Cache<HttpUrl, AtlassianServerCapabilities> capabilitiesCache = CacheBuilder.newBuilder()
+            .expireAfterAccess(CAPABILITIES_CACHE_DURATION, TimeUnit.MILLISECONDS)
+            .build();
+            
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
 
     BitbucketClientFactoryImpl(String serverUrl, BitbucketCredentials credentials, ObjectMapper objectMapper,
@@ -20,7 +39,7 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
     @Override
     public BitbucketCapabilitiesClient getCapabilityClient() {
-        return new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor);
+        return new BitbucketCapabilitiesClientImpl(bitbucketRequestExecutor, capabilitiesCache);
     }
 
     @Override

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCapabilitiesClientImplTest.java
@@ -1,46 +1,69 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClientException;
-import com.atlassian.bitbucket.jenkins.internal.client.supply.BitbucketCapabilitiesSupplier;
 import com.atlassian.bitbucket.jenkins.internal.model.AtlassianServerCapabilities;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketResponse;
+import okhttp3.HttpUrl;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketCapabilitiesClientImplTest {
 
-    @Mock
-    private BitbucketCapabilitiesSupplier capabilitiesSupplier;
-    @Mock
-    private AtlassianServerCapabilities newCapabilities, cachedCapabilities;
+    private static final String BASE_URL = "http://example.domain.org:7990/bitbucket";
     @InjectMocks
     private BitbucketCapabilitiesClientImpl capabilitiesClient;
+    @Mock
+    private AtlassianServerCapabilities newCapabilities;
+    @Mock
+    private BitbucketRequestExecutor requestExecutor;
+
+    @Before
+    public void setup() {
+        doReturn(HttpUrl.parse(BASE_URL)).when(requestExecutor).getBaseUrl();
+    }
 
     @Test(expected = BitbucketClientException.class)
     public void testGetServerCapabilitiesExceptionFromSupplier() {
-        doThrow(new BitbucketClientException("Client exception")).when(capabilitiesSupplier).get();
+        doThrow(new BitbucketClientException("Client exception")).when(requestExecutor).makeGetRequest(
+                eq(HttpUrl.parse(BASE_URL + "/rest/capabilities")), eq(AtlassianServerCapabilities.class));
         capabilitiesClient.getServerCapabilities();
     }
 
     @Test
     public void testGetServerCapabilitiesNoCache() {
-        when(capabilitiesSupplier.get()).thenReturn(newCapabilities);
+        BitbucketResponse response = mock(BitbucketResponse.class);
+        doReturn(newCapabilities).when(response).getBody();
+        doReturn(response).when(requestExecutor).makeGetRequest(
+                eq(HttpUrl.parse(BASE_URL + "/rest/capabilities")), eq(AtlassianServerCapabilities.class));
+
         assertEquals(newCapabilities, capabilitiesClient.getServerCapabilities());
-        verify(capabilitiesSupplier).get();
+        verify(requestExecutor).getBaseUrl();
+        verify(requestExecutor).makeGetRequest(
+                eq(HttpUrl.parse(BASE_URL + "/rest/capabilities")), eq(AtlassianServerCapabilities.class));
     }
 
     @Test
     public void testGetServerCapabilitiesWithCache() {
-        when(capabilitiesSupplier.get()).thenReturn(cachedCapabilities);
-        capabilitiesClient.getServerCapabilities();
-        verify(capabilitiesSupplier).get();
+        testGetServerCapabilitiesNoCache();
 
-        assertEquals(cachedCapabilities, capabilitiesClient.getServerCapabilities());
-        verifyNoMoreInteractions(capabilitiesSupplier);
+        assertEquals(newCapabilities, capabilitiesClient.getServerCapabilities());
+        verifyNoMoreInteractions(requestExecutor);
+    }
+    
+    @Test
+    public void testGetServerCapabilitiesMultipleClients() {
+        testGetServerCapabilitiesNoCache();
+        
+        BitbucketCapabilitiesClientImpl newClient = new BitbucketCapabilitiesClientImpl(requestExecutor);
+        assertEquals(newCapabilities, capabilitiesClient.getServerCapabilities());
+        verifyNoMoreInteractions(requestExecutor);
     }
 }


### PR DESCRIPTION
Our capability cache was being initialized in the client constructor, which meant every call being made to that client was using a fresh cache.
I've made the cache static and moved initialization to `getServerCapabilities` so we don't make repeated calls across multiple clients.