### PR TITLE
Fix upgrade test to load the annotation from the correct classloader

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction.java
@@ -1,7 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.jenkins.oauth.consumer;
 
 import com.atlassian.bitbucket.jenkins.internal.annotations.NotUpgradeSensitive;
-import com.atlassian.bitbucket.jenkins.internal.annotations.UpgradeHandled;
 import com.atlassian.bitbucket.jenkins.internal.applink.oauth.serviceprovider.consumer.Consumer;
 import com.atlassian.bitbucket.jenkins.internal.applink.oauth.serviceprovider.consumer.ServiceProviderConsumerStore;
 import com.atlassian.bitbucket.jenkins.internal.jenkins.oauth.consumer.OAuthConsumerEntry.OAuthConsumerEntryDescriptor;
@@ -28,8 +27,6 @@ import static java.util.Objects.requireNonNull;
 public class OAuthConsumerCreateAction extends AbstractDescribableImpl<OAuthConsumerCreateAction> implements Action {
 
     private final ServiceProviderConsumerStore store;
-    // TODO: fix NotUpgradeSensitive so this annotation is not necessary
-    @UpgradeHandled(handledBy = "Not upgrade sensitive", removeAnnotationInVersion = "3.2.1")
     private final JenkinsProvider jenkinsProvider;
 
     public OAuthConsumerCreateAction(ServiceProviderConsumerStore store, JenkinsProvider jenkinsProvider) {


### PR DESCRIPTION
The upgrade test did not use the correct annotation when filtering classes, that is fixed in this PR