### PR TITLE
JENKINS-67482 changed from using job name to resolving SCM Head when …

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultSCMHeadByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultSCMHeadByItemProvider.java
@@ -1,0 +1,17 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import hudson.model.Item;
+import jenkins.scm.api.SCMHead;
+
+import javax.annotation.CheckForNull;
+import javax.inject.Singleton;
+
+@Singleton
+public class DefaultSCMHeadByItemProvider implements SCMHeadByItemProvider {
+
+    @CheckForNull
+    @Override
+    public SCMHead findHead(Item item) {
+        return SCMHead.HeadByItem.findHead(item);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultSCMSourceByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultSCMSourceByItemProvider.java
@@ -1,0 +1,17 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import hudson.model.Item;
+import jenkins.scm.api.SCMSource;
+
+import javax.annotation.CheckForNull;
+import javax.inject.Singleton;
+
+@Singleton
+public class DefaultSCMSourceByItemProvider implements SCMSourceByItemProvider{
+
+    @CheckForNull
+    @Override
+    public SCMSource findSource(Item item) {
+        return SCMSource.SourceByItem.findSource(item);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMHeadByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMHeadByItemProvider.java
@@ -1,0 +1,14 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import com.google.inject.ImplementedBy;
+import hudson.model.Item;
+import jenkins.scm.api.SCMHead;
+
+import javax.annotation.CheckForNull;
+
+@ImplementedBy(DefaultSCMHeadByItemProvider.class)
+public interface SCMHeadByItemProvider {
+    
+    @CheckForNull
+    SCMHead findHead(Item item);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMHeadByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMHeadByItemProvider.java
@@ -8,7 +8,11 @@ import javax.annotation.CheckForNull;
 
 @ImplementedBy(DefaultSCMHeadByItemProvider.class)
 public interface SCMHeadByItemProvider {
-    
+
+    /**
+     * @return the result of calling SCMHead.HeadByItem.findHead(item)
+     * @since 3.0.0
+     */
     @CheckForNull
     SCMHead findHead(Item item);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMSourceByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMSourceByItemProvider.java
@@ -8,7 +8,11 @@ import javax.annotation.CheckForNull;
 
 @ImplementedBy(DefaultSCMSourceByItemProvider.class)
 public interface SCMSourceByItemProvider {
-    
+
+    /**
+     * @return the result of calling SCMSource.SourceByItem.findSource(item)
+     * @since 3.0.0
+     */
     @CheckForNull
     SCMSource findSource(Item item);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMSourceByItemProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/SCMSourceByItemProvider.java
@@ -1,0 +1,14 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import com.google.inject.ImplementedBy;
+import hudson.model.Item;
+import jenkins.scm.api.SCMSource;
+
+import javax.annotation.CheckForNull;
+
+@ImplementedBy(DefaultSCMSourceByItemProvider.class)
+public interface SCMSourceByItemProvider {
+    
+    @CheckForNull
+    SCMSource findSource(Item item);
+}


### PR DESCRIPTION
Key change here is moving from resolving SCMHead directly instead of using the job name- which happens to, but doesn't _need_ to be the same as the branch name. Resolving the head gives us the git branch name, which is more correct and resolves the double-encoding incidentally.
Providers added for the SCMHead and SCMSource for testing