### PR TITLE
JENKINS-63031 removed ref change filtering DELETE events

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -87,7 +87,6 @@ public class BitbucketWebhookConsumer {
     private static Set<String> eligibleRefs(RefsChangedWebhookEvent event) {
         return event.getChanges()
                 .stream()
-                .filter(refChange -> refChange.getType() != BitbucketRefChangeType.DELETE)
                 .map(refChange -> refChange.getRef().getId())
                 .collect(Collectors.toSet());
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumerTest.java
@@ -290,14 +290,23 @@ public class BitbucketWebhookConsumerTest {
     }
 
     @Test
-    public void testRefsChangedShouldNotTriggerIfConfiguredRefIsDeleted() {
+    public void testRefsChangedShouldTriggerIfConfiguredRefIsDeleted() {
+        BitbucketServerConfiguration serverConfiguration = mock(BitbucketServerConfiguration.class);
+        when(bitbucketPluginConfiguration.getServerById(bitbucketSCM.getServerId())).thenReturn(Optional.of(serverConfiguration));
+        when(bitbucketPluginConfiguration.getValidServerList()).thenReturn(singletonList(serverConfiguration));
+        when(serverConfiguration.getBaseUrl()).thenReturn(BITBUCKET_BASE_URL);
+
         RefsChangedWebhookEvent event = new RefsChangedWebhookEvent(
                 BITBUCKET_USER, REPO_REF_CHANGE.getEventId(), new Date(), refChanges(BitbucketRefChangeType.DELETE), bitbucketRepository);
 
         consumer.process(event);
 
-        verify(bitbucketTrigger, never()).trigger(any());
-        verify(workflowTrigger, never()).trigger(any());
+        verify(bitbucketTrigger)
+                .trigger(
+                        eq(BitbucketWebhookTriggerRequest.builder().actor(BITBUCKET_USER).build()));
+        verify(workflowTrigger)
+                .trigger(
+                        eq(BitbucketWebhookTriggerRequest.builder().actor(BITBUCKET_USER).build()));
     }
 
     @Test


### PR DESCRIPTION
This informs multibranch projects with matching SCMs of deleted refs, which in turn are disabled. It has no impact on freestyle and pipeline jobs, as the ref doesn't change so git ignores the event.
Still to-do is an acceptance test verifying the deletion disables the appropriate job. It's hard to test this feature _doesn't_ impact other jobs as we always fire the trigger, which we pass onto git in our SCM, but can make tests for this too if we feel it's necessary.