### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
@@ -82,7 +82,7 @@ public class OAuthGlobalConfiguration extends ManagementLink implements Describa
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return "secure.gif";
+        return "secure.png";
     }
 
     @CheckForNull

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration.java
@@ -60,7 +60,7 @@ public class OAuthTokenConfiguration implements Action, Describable<OAuthGlobalC
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return "secure.gif";
+        return "secure.png";
     }
 
     @SuppressWarnings("unused") // Stapler

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction/sidepanel.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction/sidepanel.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:side-panel>
         <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
         <l:tasks>
-            <l:task icon="images/24x24/up.png" href=".." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
+            <l:task icon="icon-up icon-md" href=".." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
         </l:tasks>
     </l:side-panel>
 </j:jelly>

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerUpdateAction/sidepanel.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerUpdateAction/sidepanel.jelly
@@ -1,12 +1,12 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:side-panel>
         <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
         <l:tasks>
-            <l:task icon="images/24x24/up.png" href="../.." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
-            <l:task icon="images/24x24/help.png" href="${url}/applinkinfo" title="${%bitbucket.oauth.consumer.applink.info}" />
-            <l:task icon="images/24x24/edit-delete.png" href="${url}/delete" title="${%bitbucket.oauth.consumer.delete}"/>
+            <l:task icon="icon-up icon-md" href="../.." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
+            <l:task icon="icon-help icon-md" href="${url}/applinkinfo" title="${%bitbucket.oauth.consumer.applink.info}" />
+            <l:task icon="icon-edit-delete icon-md" href="${url}/delete" title="${%bitbucket.oauth.consumer.delete}"/>
         </l:tasks>
     </l:side-panel>
 </j:jelly>

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration/index.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration/index.jelly
@@ -5,7 +5,6 @@
     <l:layout permission="${app.ADMINISTER}" xmlns:local="local" norefresh="true">
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/${it.iconFileName}" alt="${it.displayName}"/>
                 ${%bitbucket.oauth.consumer.title}
             </h1>
             <p>${%bitbucket.oauth.consumer.help}</p>

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration/sidepanel.jelly
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration/sidepanel.jelly
@@ -1,9 +1,9 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:side-panel>
         <l:tasks>
-            <l:task icon="images/24x24/up.png" href=".." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
+            <l:task icon="icon-up icon-md" href=".." title="${%bitbucket.oauth.consumer.back}" contextMenu="false"/>
         </l:tasks>
     </l:side-panel>
 </j:jelly>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this 
change.
Additionally I've removed the mainpanel icon, because that's what modern Jenkins does look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @mhenschke-atl 
Thanks in advance!