### PR TITLE
Added explicit version for instance identity module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <!--<version>managed by bom</version>-->
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
It looks like instance-identity was [removed from the BOM](https://github.com/jenkinsci/bom/releases) which is causing the plugin to fail to compile when depending on latest Jenkins.
The plugin was previous using version 2.2 and that appears to be what's in use [across other Jenkins plugins](https://mvnrepository.com/artifact/org.jenkins-ci.modules/instance-identity?repo=jenkins-releases) so I've opted to keep it the same.