### PR TITLE
JENKINS-69203 remove suppressed add button from repeatable Branches t…

### DIFF
--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
@@ -30,7 +30,7 @@ f.section() {
     }
 
     f.entry(title: _("Branches to build")) {
-        f.repeatableProperty(field: "branches", addCaption: _("Add branch"), hasHeader: "true", minimum: "1", noAddButton: "true")
+        f.repeatableProperty(field: "branches", addCaption: _("Add branch"), hasHeader: "true", minimum: "1")
     }
 
     if (descriptor.showGitToolOptions) {


### PR DESCRIPTION
I'm not entirely sure what broke this field, in fact I'm not sure how it worked in the first place, but removing this suppression displays the repeatable Add button in Jenkins 2.289.1 on Git 4.10.0:
![Screenshot_20220818_163726](https://user-images.githubusercontent.com/53157896/185314285-ac07aeb2-6b30-43a6-b360-45f2ff77c340.png)

And in Jenkins 2.357 on Git 4.11.4:
![Screenshot_20220818_163441](https://user-images.githubusercontent.com/53157896/185315215-448a3e2b-fe98-409a-9098-3a0559cb19a5.png)



