### PR TITLE
Bumped minor version to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>atlassian-bitbucket-server-integration</artifactId>
-    <version>3.2.4-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <bitbucket.version>6.10.15</bitbucket.version>

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,10 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 3.3.0 (24 August 2022)
+- Fix JENKINS-63031: Ref changed webhooks now correctly trigger updated and removed SCM head events
+- Fix JENKINS-69288: Misleading validation message on OAuth consumer creation page
+
 ### 3.2.3 (18 August 2022)
 - Fix JENKINS-68956: Multibranch pipeline jobs configured to clone from the mirror will now do so.
 


### PR DESCRIPTION
Despite both issues being bugs, I think the changes to our webhook handling are sufficiently large to merit a minor version release, but open to opinions.