### PR TITLE
Support for cancelled build state

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClient.java
@@ -2,10 +2,12 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 
+import java.util.function.Consumer;
+
 /**
  * Client to post build status to remote server
  */
 public interface BitbucketBuildStatusClient {
 
-    void post(BitbucketBuildStatus buildStatus);
+    void post(BitbucketBuildStatus.Builder buildStatusBuilder, Consumer<BitbucketBuildStatus> beforePost);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImpl.java
@@ -34,6 +34,6 @@ public class BitbucketBuildStatusClientImpl implements BitbucketBuildStatusClien
                 .addPathSegment("commits")
                 .addPathSegment(revisionSha)
                 .build();
-        bitbucketRequestExecutor.makePostRequest(url, buildStatusBuilder, new RetryOnRateLimitConfig(maxAttempts));
+        bitbucketRequestExecutor.makePostRequest(url, buildStatus, new RetryOnRateLimitConfig(maxAttempts));
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImpl.java
@@ -4,6 +4,8 @@ import com.atlassian.bitbucket.jenkins.internal.http.RetryOnRateLimitConfig;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import okhttp3.HttpUrl;
 
+import java.util.function.Consumer;
+
 import static com.atlassian.bitbucket.jenkins.internal.util.SystemPropertiesConstants.REQUEST_RETRY_MAX_ATTEMPTS;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
@@ -21,7 +23,10 @@ public class BitbucketBuildStatusClientImpl implements BitbucketBuildStatusClien
     }
 
     @Override
-    public void post(BitbucketBuildStatus buildStatus) {
+    public void post(BitbucketBuildStatus.Builder buildStatusBuilder, Consumer<BitbucketBuildStatus> beforePost) {
+        BitbucketBuildStatus buildStatus = buildStatusBuilder.legacy().build();
+        beforePost.accept(buildStatus);
+        
         HttpUrl url = bitbucketRequestExecutor.getBaseUrl().newBuilder()
                 .addPathSegment("rest")
                 .addPathSegment("build-status")
@@ -29,6 +34,6 @@ public class BitbucketBuildStatusClientImpl implements BitbucketBuildStatusClien
                 .addPathSegment("commits")
                 .addPathSegment(revisionSha)
                 .build();
-        bitbucketRequestExecutor.makePostRequest(url, buildStatus, new RetryOnRateLimitConfig(maxAttempts));
+        bitbucketRequestExecutor.makePostRequest(url, buildStatusBuilder, new RetryOnRateLimitConfig(maxAttempts));
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketClientFactoryImpl.java
@@ -49,7 +49,7 @@ public class BitbucketClientFactoryImpl implements BitbucketClientFactory {
 
     @Override
     public BitbucketProjectClient getProjectClient(String projectKey) {
-        return new BitbucketProjectClientImpl(bitbucketRequestExecutor, projectKey);
+        return new BitbucketProjectClientImpl(bitbucketRequestExecutor, getCapabilityClient(), projectKey);
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketProjectClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketProjectClientImpl.java
@@ -9,10 +9,13 @@ import static org.apache.commons.lang3.StringUtils.stripToNull;
 public class BitbucketProjectClientImpl implements BitbucketProjectClient {
 
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
+    private final BitbucketCapabilitiesClient capabilitiesClient;
     private final String projectKey;
 
-    BitbucketProjectClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey) {
+    BitbucketProjectClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, 
+                               BitbucketCapabilitiesClient capabilitiesClient, String projectKey) {
         this.bitbucketRequestExecutor = requireNonNull(bitbucketRequestExecutor, "bitbucketRequestExecutor");
+        this.capabilitiesClient = capabilitiesClient;
         this.projectKey = requireNonNull(stripToNull(projectKey), "projectKey");
     }
 
@@ -26,6 +29,6 @@ public class BitbucketProjectClientImpl implements BitbucketProjectClient {
 
     @Override
     public BitbucketRepositoryClient getRepositoryClient(String repositorySlug) {
-        return new BitbucketRepositoryClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug);
+        return new BitbucketRepositoryClientImpl(bitbucketRequestExecutor, capabilitiesClient, projectKey, repositorySlug);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
@@ -3,7 +3,6 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketDefaultBranch;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCICapabilities;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequest;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestState;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
@@ -49,11 +48,10 @@ public interface BitbucketRepositoryClient {
      * Return a client that can post the current status of a build to Bitbucket.
      *
      * @param revisionSha      the revision for the build status
-     * @param ciCapabilities   CI capabilities of the remote server
      * @return a client that can post a build status
      * @since 3.1.0
      */
-    BitbucketBuildStatusClient getBuildStatusClient(String revisionSha, BitbucketCICapabilities ciCapabilities);
+    BitbucketBuildStatusClient getBuildStatusClient(String revisionSha);
 
     /**
      * Return a client that can post deployment information to Bitbucket.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
@@ -45,7 +45,7 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
         if (ciCapabilities.supportsRichBuildStatus()) {
             return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
                     bitbucketSCMRepo.getRepositorySlug(), revisionSha, instanceKeyPairProvider, displayURLProvider,
-                    ciCapabilities.supportsCancelledAndUnknownBuildStates());
+                    ciCapabilities.supportsCancelledBuildStates());
         }
         return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
     }
@@ -55,7 +55,7 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
         BitbucketCICapabilities ciCapabilities = capabilitiesClient.getCICapabilities();
         if (ciCapabilities.supportsRichBuildStatus()) {
             return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug,
-                    revisionSha, ciCapabilities.supportsCancelledAndUnknownBuildStates());
+                    revisionSha, ciCapabilities.supportsCancelledBuildStates());
         }
         return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
@@ -24,12 +24,15 @@ import static org.apache.commons.lang3.StringUtils.stripToNull;
 public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient {
 
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
+    private final BitbucketCapabilitiesClient capabilitiesClient;
     private final String projectKey;
     private final String repositorySlug;
 
-    BitbucketRepositoryClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, String projectKey,
+    BitbucketRepositoryClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor, 
+                                  BitbucketCapabilitiesClient capabilitiesClient, String projectKey, 
                                   String repositorySlug) {
         this.bitbucketRequestExecutor = requireNonNull(bitbucketRequestExecutor, "bitbucketRequestExecutor");
+        this.capabilitiesClient = capabilitiesClient;
         this.projectKey = requireNonNull(stripToNull(projectKey), "projectKey");
         this.repositorySlug = requireNonNull(stripToNull(repositorySlug), "repositorySlug");
     }
@@ -41,16 +44,18 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
                                                            DisplayURLProvider displayURLProvider) {
         if (ciCapabilities.supportsRichBuildStatus()) {
             return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, bitbucketSCMRepo.getProjectKey(),
-                    bitbucketSCMRepo.getRepositorySlug(), revisionSha, instanceKeyPairProvider, displayURLProvider);
+                    bitbucketSCMRepo.getRepositorySlug(), revisionSha, instanceKeyPairProvider, displayURLProvider,
+                    ciCapabilities.supportsCancelledAndUnknownBuildStates());
         }
         return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
     }
 
     @Override
-    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha, BitbucketCICapabilities ciCapabilities) {
+    public BitbucketBuildStatusClient getBuildStatusClient(String revisionSha) {
+        BitbucketCICapabilities ciCapabilities = capabilitiesClient.getCICapabilities();
         if (ciCapabilities.supportsRichBuildStatus()) {
             return new ModernBitbucketBuildStatusClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug,
-                    revisionSha);
+                    revisionSha, ciCapabilities.supportsCancelledAndUnknownBuildStates());
         }
         return new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatus.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatus.java
@@ -74,7 +74,7 @@ public class BitbucketBuildStatus {
             testResults = builder.testResults;
         }
         
-        if (builder.state == BuildState.CANCELLED && (builder.isLegacy || !builder.isCancelledSupported)) {
+        if (builder.state == BuildState.CANCELLED && (builder.isLegacy || builder.noCancelledState)) {
             state = BuildState.FAILED;
         } else {
             state = requireNonNull(builder.state, "state");
@@ -167,8 +167,8 @@ public class BitbucketBuildStatus {
         private String buildNumber;
         private String description;
         private Long duration;
-        private boolean isLegacy = false;
-        private boolean isCancelledSupported = true;
+        private boolean isLegacy;
+        private boolean noCancelledState;
         private String key;
         private String name;
         private String parent;
@@ -193,7 +193,7 @@ public class BitbucketBuildStatus {
         }
         
         public Builder noCancelledState() {
-            isCancelledSupported = false;
+            noCancelledState = true;
             return this;
         }
         

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCICapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCICapabilities.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
@@ -15,7 +13,7 @@ import static java.util.Objects.requireNonNull;
 public class BitbucketCICapabilities {
 
     private static final String RICH_BUILD_STATUS_CAPABILITY = "richBuildStatus";
-    private static final List<String> BUILD_STATE_CAPABILITIES = Arrays.asList("unknownStatus", "cancelledStatus");
+    private static final String CANCELLED_BUILD_STATE_CAPABILITIES = "cancelledStatus";
     private final Set<String> ciCapabilities;
 
     @JsonCreator
@@ -27,8 +25,8 @@ public class BitbucketCICapabilities {
         return ciCapabilities;
     }
 
-    public boolean supportsCancelledAndUnknownBuildStates() {
-        return ciCapabilities.containsAll(BUILD_STATE_CAPABILITIES);
+    public boolean supportsCancelledBuildStates() {
+        return ciCapabilities.contains(CANCELLED_BUILD_STATE_CAPABILITIES);
     }
 
     public boolean supportsRichBuildStatus() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCICapabilities.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCICapabilities.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
@@ -12,8 +14,8 @@ import static java.util.Objects.requireNonNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketCICapabilities {
 
-    public static final String RICH_BUILD_STATUS_CAPABILITY = "richBuildStatus";
-
+    private static final String RICH_BUILD_STATUS_CAPABILITY = "richBuildStatus";
+    private static final List<String> BUILD_STATE_CAPABILITIES = Arrays.asList("unknownStatus", "cancelledStatus");
     private final Set<String> ciCapabilities;
 
     @JsonCreator
@@ -23,6 +25,10 @@ public class BitbucketCICapabilities {
 
     public Set<String> getCiCapabilities() {
         return ciCapabilities;
+    }
+
+    public boolean supportsCancelledAndUnknownBuildStates() {
+        return ciCapabilities.containsAll(BUILD_STATE_CAPABILITIES);
     }
 
     public boolean supportsRichBuildStatus() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BuildState.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BuildState.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum BuildState {
 
+    @JsonProperty("CANCELLED")
+    CANCELLED("%s cancelled"),
     @JsonProperty("FAILED")
     FAILED("%s failed in %s"),
     @JsonProperty("INPROGRESS")

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
@@ -7,7 +7,5 @@ import hudson.model.Run;
 @ImplementedBy(BitbucketBuildStatusFactoryImpl.class)
 public interface BitbucketBuildStatusFactory {
 
-    BitbucketBuildStatus createLegacyBuildStatus(Run<?, ?> build);
-
-    BitbucketBuildStatus createRichBuildStatus(Run<?, ?> build);
+    BitbucketBuildStatus.Builder prepareBuildStatus(Run<?, ?> build);
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
@@ -5,15 +5,12 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
 import com.atlassian.bitbucket.jenkins.internal.model.TestResults;
 import okhttp3.HttpUrl;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.annotation.Nullable;
 
 import java.util.function.Consumer;
 
@@ -25,23 +22,27 @@ import static org.mockito.Mockito.verify;
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketBuildStatusClientImplTest {
 
+    private static final String REVISION_SHA = "revisionSha";
+    BitbucketBuildStatusClientImpl bitbucketBuildStatusClient;
     @Mock
     BitbucketRequestExecutor bitbucketRequestExecutor;
-
-    String revisionSha = "revisionSha";
-
-    BitbucketBuildStatusClientImpl bitbucketBuildStatusClient;
 
     @Before
     public void setup() {
         when(bitbucketRequestExecutor.getBaseUrl()).thenReturn(HttpUrl.parse("http://example.com"));
-        bitbucketBuildStatusClient = new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
+        bitbucketBuildStatusClient = new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, REVISION_SHA);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testPost() {
-        BitbucketBuildStatus.Builder buildStatusBuilder = createTestBuildStatus("ref");
+        BitbucketBuildStatus.Builder buildStatusBuilder =
+                new BitbucketBuildStatus.Builder("REPO-42", BuildState.CANCELLED, "http://example.com/builds/repo-42")
+                        .setDescription("Test description")
+                        .setTestResults(new TestResults(42, 21, 12))
+                        .setName("Test-Name")
+                        .setDuration(21L)
+                        .setRef("ref");
         BitbucketBuildStatus buildStatus = buildStatusBuilder.legacy().build();
         Consumer<BitbucketBuildStatus> consumer = (Consumer<BitbucketBuildStatus>) mock(Consumer.class);
 
@@ -52,14 +53,4 @@ public class BitbucketBuildStatusClientImplTest {
         verify(bitbucketRequestExecutor).makePostRequest(eq(url), eq(buildStatus), ArgumentMatchers.any(RetryOnRateLimitConfig.class));
         verify(consumer).accept(buildStatus);
     }
-
-    private BitbucketBuildStatus.Builder createTestBuildStatus(@Nullable String ref) {
-        return new BitbucketBuildStatus.Builder("REPO-42", BuildState.CANCELLED, "http://example.com/builds/repo-42")
-                .setDescription("Test description")
-                .setTestResults(new TestResults(42, 21, 12))
-                .setName("Test-Name")
-                .setDuration(21L)
-                .setRef(StringUtils.stripToNull(ref));
-    }
-
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.annotation.Nullable;

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBuildStatusClientImplTest.java
@@ -1,0 +1,66 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.http.RetryOnRateLimitConfig;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
+import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
+import com.atlassian.bitbucket.jenkins.internal.model.TestResults;
+import okhttp3.HttpUrl;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketBuildStatusClientImplTest {
+
+    @Mock
+    BitbucketRequestExecutor bitbucketRequestExecutor;
+
+    String revisionSha = "revisionSha";
+
+    BitbucketBuildStatusClientImpl bitbucketBuildStatusClient;
+
+    @Before
+    public void setup() {
+        when(bitbucketRequestExecutor.getBaseUrl()).thenReturn(HttpUrl.parse("http://example.com"));
+        bitbucketBuildStatusClient = new BitbucketBuildStatusClientImpl(bitbucketRequestExecutor, revisionSha);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPost() {
+        BitbucketBuildStatus.Builder buildStatusBuilder = createTestBuildStatus("ref");
+        BitbucketBuildStatus buildStatus = buildStatusBuilder.legacy().build();
+        Consumer<BitbucketBuildStatus> consumer = (Consumer<BitbucketBuildStatus>) mock(Consumer.class);
+
+        bitbucketBuildStatusClient.post(buildStatusBuilder, consumer);
+
+        HttpUrl url = HttpUrl.parse("http://example.com/rest/build-status/1.0/commits/revisionSha");
+
+        verify(bitbucketRequestExecutor).makePostRequest(eq(url), eq(buildStatus), ArgumentMatchers.any(RetryOnRateLimitConfig.class));
+        verify(consumer).accept(buildStatus);
+    }
+
+    private BitbucketBuildStatus.Builder createTestBuildStatus(@Nullable String ref) {
+        return new BitbucketBuildStatus.Builder("REPO-42", BuildState.CANCELLED, "http://example.com/builds/repo-42")
+                .setDescription("Test description")
+                .setTestResults(new TestResults(42, 21, 12))
+                .setName("Test-Name")
+                .setDuration(21L)
+                .setRef(StringUtils.stripToNull(ref));
+    }
+
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
@@ -68,7 +68,7 @@ public class BitbucketRepositoryClientImplTest {
     public void setup() {
         when(capabilitiesClient.getCICapabilities()).thenReturn(ciCapabilities);
         when(ciCapabilities.supportsRichBuildStatus()).thenReturn(false);
-        when(ciCapabilities.supportsCancelledAndUnknownBuildStates()).thenReturn(false);
+        when(ciCapabilities.supportsCancelledBuildStates()).thenReturn(false);
         when(bitbucketSCMRepo.getProjectKey()).thenReturn(PROJECT_KEY);
         when(bitbucketSCMRepo.getRepositorySlug()).thenReturn(REPO_SLUG);
         

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
@@ -13,6 +13,7 @@ import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okio.Buffer;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials.ANONYMOUS_CREDENTIALS;
 import static com.atlassian.bitbucket.jenkins.internal.util.TestUtils.*;
@@ -39,6 +41,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketRepositoryClientImplTest {
 
@@ -52,8 +55,9 @@ public class BitbucketRepositoryClientImplTest {
     private final HttpRequestExecutor requestExecutor = new HttpRequestExecutorImpl(fakeRemoteHttpServer);
     private final BitbucketRequestExecutor bitbucketRequestExecutor = new BitbucketRequestExecutor(BITBUCKET_BASE_URL,
             requestExecutor, OBJECT_MAPPER, ANONYMOUS_CREDENTIALS);
-    private final BitbucketRepositoryClientImpl client = new BitbucketRepositoryClientImpl(bitbucketRequestExecutor,
-            PROJECT_KEY, REPO_SLUG);
+    @Mock
+    private BitbucketCapabilitiesClient capabilitiesClient;
+    private BitbucketRepositoryClientImpl client;
 
     @Mock
     private BitbucketSCMRepository bitbucketSCMRepo;
@@ -62,9 +66,14 @@ public class BitbucketRepositoryClientImplTest {
 
     @Before
     public void setup() {
+        when(capabilitiesClient.getCICapabilities()).thenReturn(ciCapabilities);
         when(ciCapabilities.supportsRichBuildStatus()).thenReturn(false);
+        when(ciCapabilities.supportsCancelledAndUnknownBuildStates()).thenReturn(false);
         when(bitbucketSCMRepo.getProjectKey()).thenReturn(PROJECT_KEY);
         when(bitbucketSCMRepo.getRepositorySlug()).thenReturn(REPO_SLUG);
+        
+        client = new BitbucketRepositoryClientImpl(bitbucketRequestExecutor,
+                capabilitiesClient, PROJECT_KEY, REPO_SLUG);
     }
 
     @Test
@@ -75,7 +84,7 @@ public class BitbucketRepositoryClientImplTest {
 
         List<BitbucketPullRequest> pullRequests = client.getPullRequests(BitbucketPullRequestState.OPEN).collect(toList());
 
-        assertThat(pullRequests.size(), is(equalTo(2)));
+        MatcherAssert.assertThat(pullRequests.size(), is(equalTo(2)));
         assertThat(pullRequests.stream().map(BitbucketPullRequest::getId).collect(toSet()), hasItems(new Long(96), new Long(97)));
         assertThat(pullRequests.stream().map(BitbucketPullRequest::getState).collect(toSet()), hasItems(BitbucketPullRequestState.OPEN));
     }
@@ -135,10 +144,9 @@ public class BitbucketRepositoryClientImplTest {
     @Test
     public void testPostBuildStatus() throws IOException {
         String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
-        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
+        BitbucketBuildStatus.Builder buildStatusBuilder = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
                 .setName("Local BBS Project")
-                .setDescription("#15 in progress")
-                .build();
+                .setDescription("#15 in progress");
 
         String url = HttpUrl.get(BITBUCKET_BASE_URL)
                 .newBuilder()
@@ -152,15 +160,15 @@ public class BitbucketRepositoryClientImplTest {
         String requestString = readFileToString("/build-status-request.json");
         fakeRemoteHttpServer.mapPostRequestToResult(url, requestString, "");
         Buffer b = new Buffer();
-
-        BitbucketBuildStatusClient client = this.client.getBuildStatusClient(REVISION, ciCapabilities);
-        client.post(buildStatus);
+        
+        BitbucketBuildStatusClient client = this.client.getBuildStatusClient(REVISION);
+        client.post(buildStatusBuilder, (Consumer<BitbucketBuildStatus>) mock(Consumer.class));
 
         Request clientRequest = fakeRemoteHttpServer.getRequest(url);
         clientRequest.body().writeTo(b);
         assertEquals(StringUtils.deleteWhitespace(requestString), StringUtils.deleteWhitespace(b.readString(UTF_8)));
     }
-
+    
     @Test
     public void testPostBuildStatusModernClient() throws IOException {
         String postURL = "http://localhost:8080/jenkins/job/Local%20BBS%20Project/15/display/redirect";
@@ -172,10 +180,9 @@ public class BitbucketRepositoryClientImplTest {
 
         when(ciCapabilities.supportsRichBuildStatus()).thenReturn(true);
 
-        BitbucketBuildStatus buildStatus = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
+        BitbucketBuildStatus.Builder buildStatusBuilder = new BitbucketBuildStatus.Builder("15", BuildState.INPROGRESS, postURL)
                 .setName("Local BBS Project")
-                .setDescription("#15 in progress")
-                .build();
+                .setDescription("#15 in progress");
 
         String url = getCommitUrl()
                 .addPathSegment("builds")
@@ -187,7 +194,7 @@ public class BitbucketRepositoryClientImplTest {
 
         BitbucketBuildStatusClient client =
                 this.client.getBuildStatusClient(REVISION, bitbucketSCMRepo, ciCapabilities, keyPairProvider, displayURLProvider);
-        client.post(buildStatus);
+        client.post(buildStatusBuilder, (Consumer<BitbucketBuildStatus>) mock(Consumer.class));
 
         Request clientRequest = fakeRemoteHttpServer.getRequest(url);
         clientRequest.body().writeTo(b);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/ModernBitbucketBuildStatusClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/ModernBitbucketBuildStatusClientImplTest.java
@@ -16,7 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -42,6 +41,8 @@ public class ModernBitbucketBuildStatusClientImplTest {
     private static final String BBS_BASE_URL = "http://localhost:7990/bitbucket";
     private static final String JENKINS_BASE_URL = "http://localhost:8080/jenkins";
     private static final String SHA1 = "5ab78046a50050b8aa3e4accf80950a60f716391";
+    private static final HttpUrl
+            EXPECTED_URL = HttpUrl.parse(BBS_BASE_URL + "/rest/api/1.0/projects/PROJ/repos/repo/commits/" + SHA1 + "/builds");
     static KeyPair keyPair;
     @Captor
     ArgumentCaptor<RequestConfiguration> captor;
@@ -75,7 +76,7 @@ public class ModernBitbucketBuildStatusClientImplTest {
         
         client.post(buildStatusBuilder, consumer);
 
-        verify(executor).makePostRequest(ArgumentMatchers.any(HttpUrl.class), eq(buildStatus), captor.capture());
+        verify(executor).makePostRequest(eq(EXPECTED_URL), eq(buildStatus), captor.capture());
         verify(consumer).accept(buildStatus);
 
         //this shortcuts the testing route. We capture the RequestConfiguration applied, and just give it a fake
@@ -101,16 +102,20 @@ public class ModernBitbucketBuildStatusClientImplTest {
         
         client.post(buildStatusBuilder, consumer);
 
-        verify(executor).makePostRequest(ArgumentMatchers.any(HttpUrl.class), eq(buildStatus), captor.capture());
+        verify(executor).makePostRequest(eq(EXPECTED_URL), eq(buildStatus), captor.capture());
         verify(consumer).accept(buildStatus);
     }
 
     @Test
     public void testPostNoRef() {
         BitbucketBuildStatus.Builder buildStatusBuilder = createTestBuildStatus(null);
-//        client.post(buildStatusBuilder);
+        BitbucketBuildStatus buildStatus = buildStatusBuilder.build();
+        Consumer<BitbucketBuildStatus> consumer = (Consumer<BitbucketBuildStatus>) mock(Consumer.class);
 
-        verify(executor).makePostRequest(ArgumentMatchers.any(HttpUrl.class), eq(buildStatusBuilder.build()), captor.capture());
+        client.post(buildStatusBuilder, consumer);
+
+        verify(executor).makePostRequest(eq(EXPECTED_URL), eq(buildStatus), captor.capture());
+        verify(consumer).accept(buildStatus);
 
         //this shortcuts the testing route. We capture the RequestConfiguration applied, and just give it a fake
         // Request.Builder and we can then assert it did the right thing from that.

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/mocks/TestBitbucketClientFactoryHandler.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/mocks/TestBitbucketClientFactoryHandler.java
@@ -54,7 +54,7 @@ public class TestBitbucketClientFactoryHandler {
         when(clientFactory
                 .getProjectClient(scmRepo.getProjectKey())
                 .getRepositoryClient(scmRepo.getRepositorySlug())
-                .getBuildStatusClient(revision, ciCapabilities))
+                .getBuildStatusClient(revision))
                 .thenReturn(buildStatusClient);
         return this;
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatusTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatusTest.java
@@ -14,16 +14,17 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.SUCCESSFUL, TEST_RESULTS, "url");
         
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+        BitbucketBuildStatus status = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .build();
         
-        assertThat(builder.build(), equalTo(expected));
+        assertThat(status, equalTo(expected));
     }
     
     @Test
@@ -31,16 +32,17 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.CANCELLED, TEST_RESULTS, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+        BitbucketBuildStatus status = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .build();
 
-        assertThat(builder.build(), equalTo(expected));
+        assertThat(status, equalTo(expected));
     }
 
     @Test
@@ -48,11 +50,13 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 null, "description", null, "key", "name", null, null, BuildState.SUCCESSFUL, null, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+        BitbucketBuildStatus legacyStatus = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
                 .setDescription("description")
-                .setName("name");
+                .setName("name")
+                .legacy()
+                .build();
 
-        assertThat(builder.legacy().build(), equalTo(expected));
+        assertThat(legacyStatus, equalTo(expected));
     }
 
     @Test
@@ -60,11 +64,13 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 null, "description", null, "key", "name", null, null, BuildState.FAILED, null, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+        BitbucketBuildStatus legacyStatus = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
                 .setDescription("description")
-                .setName("name");
+                .setName("name")
+                .legacy()
+                .build();
 
-        assertThat(builder.legacy().build(), equalTo(expected));
+        assertThat(legacyStatus, equalTo(expected));
     }
 
     @Test
@@ -72,16 +78,19 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 null, "description", null, "key", "name", null, null, BuildState.FAILED, null, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+        BitbucketBuildStatus legacyNoCancelledStatus = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .legacy()
+                .noCancelledState()
+                .build();
 
-        assertThat(builder.legacy().noCancelledState().build(), equalTo(expected));
+        assertThat(legacyNoCancelledStatus, equalTo(expected));
     }
 
     @Test
@@ -89,16 +98,18 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 null, "description", null, "key", "name", null, null, BuildState.SUCCESSFUL, null, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+        BitbucketBuildStatus legacyStatus = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .legacy()
+                .build();
 
-        assertThat(builder.legacy().build(), equalTo(expected));
+        assertThat(legacyStatus, equalTo(expected));
     }
 
     @Test
@@ -106,16 +117,18 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.SUCCESSFUL, TEST_RESULTS, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+        BitbucketBuildStatus noCancelledStatus = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .noCancelledState()
+                .build();
 
-        assertThat(builder.noCancelledState().build(), equalTo(expected));
+        assertThat(noCancelledStatus, equalTo(expected));
     }
 
     @Test
@@ -123,15 +136,17 @@ public class BitbucketBuildStatusTest {
         BitbucketBuildStatus expected = new BitbucketBuildStatus(
                 "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.FAILED, TEST_RESULTS, "url");
 
-        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+        BitbucketBuildStatus noCancelledState = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
                 .setBuildNumber("1")
                 .setDescription("description")
                 .setDuration(500L)
                 .setName("name")
                 .setParent("parent")
                 .setRef("refs/head/master")
-                .setTestResults(TEST_RESULTS);
+                .setTestResults(TEST_RESULTS)
+                .noCancelledState()
+                .build();
 
-        assertThat(builder.noCancelledState().build(), equalTo(expected));
+        assertThat(noCancelledState, equalTo(expected));
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatusTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketBuildStatusTest.java
@@ -1,0 +1,137 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BitbucketBuildStatusTest {
+
+    private static TestResults TEST_RESULTS = new TestResults(3, 2, 1);
+    
+    @Test
+    public void testBuild() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.SUCCESSFUL, TEST_RESULTS, "url");
+        
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+        
+        assertThat(builder.build(), equalTo(expected));
+    }
+    
+    @Test
+    public void testBuildWithCancelledState() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.CANCELLED, TEST_RESULTS, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+
+        assertThat(builder.build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildLegacy() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                null, "description", null, "key", "name", null, null, BuildState.SUCCESSFUL, null, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+                .setDescription("description")
+                .setName("name");
+
+        assertThat(builder.legacy().build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildLegacyWithCancelledState() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                null, "description", null, "key", "name", null, null, BuildState.FAILED, null, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+                .setDescription("description")
+                .setName("name");
+
+        assertThat(builder.legacy().build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildLegacyAndNoCancelledState() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                null, "description", null, "key", "name", null, null, BuildState.FAILED, null, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+
+        assertThat(builder.legacy().noCancelledState().build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildLegacyWithUnsupportedInfo() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                null, "description", null, "key", "name", null, null, BuildState.SUCCESSFUL, null, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+
+        assertThat(builder.legacy().build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildNoCancelledState() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.SUCCESSFUL, TEST_RESULTS, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.SUCCESSFUL, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+
+        assertThat(builder.noCancelledState().build(), equalTo(expected));
+    }
+
+    @Test
+    public void testBuildNoCancelledStateWithCancelledState() {
+        BitbucketBuildStatus expected = new BitbucketBuildStatus(
+                "1", "description", 500L, "key", "name", "parent", "refs/head/master", BuildState.FAILED, TEST_RESULTS, "url");
+
+        BitbucketBuildStatus.Builder builder = new BitbucketBuildStatus.Builder("key", BuildState.CANCELLED, "url")
+                .setBuildNumber("1")
+                .setDescription("description")
+                .setDuration(500L)
+                .setName("name")
+                .setParent("parent")
+                .setRef("refs/head/master")
+                .setTestResults(TEST_RESULTS);
+
+        assertThat(builder.noCancelledState().build(), equalTo(expected));
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -104,19 +104,18 @@ public class BuildStatusPosterTest {
         } finally {
             System.setProperty("bitbucket.status.disable", "");
         }
-        verify(logger).println((eq("Build statuses disabled, no build status sent.")));
+        verify(logger).println(eq("Build statuses disabled, no build status sent."));
         
         verifyZeroInteractions(clientFactoryMock.getBitbucketClientFactoryProvider());
     }
 
-    // TODO: Rethink this
     @Test
     public void testSuccessfulPost() {
         when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
 
         buildStatusPoster.onCompleted(run, listener);
 
-        verify(clientFactoryMock.getBuildStatusClient()).post(buildStatus, any());
+        verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
         verify(buildStatusFactory).prepareBuildStatus(run);
     }
 
@@ -127,7 +126,7 @@ public class BuildStatusPosterTest {
 
         buildStatusPoster.onCompleted(run, listener);
 
-        verify(clientFactoryMock.getBuildStatusClient()).post(buildStatus, any());
+        verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
         verify(buildStatusFactory).prepareBuildStatus(run);
     }
 
@@ -139,7 +138,7 @@ public class BuildStatusPosterTest {
 
         buildStatusPoster.onCompleted(run, listener);
 
-        verify(clientFactoryMock.getBuildStatusClient()).post(buildStatus, any());
+        verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
         verify(buildStatusFactory).prepareBuildStatus(run);
     }
 }

--- a/upload-to-jwar.sh
+++ b/upload-to-jwar.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mvn package -Dmaven.test.skip=true
+echo "Uploading plugin"
+curl -kv http://localhost:8080/pluginManager/uploadPlugin -u admin:admin -F file=@target/atlassian-bitbucket-server-integration.hpi
+echo "Restarting jenkins"
+curl -kv http://localhost:8080/safeRestart -u admin:admin -F Submit=Yes

--- a/upload-to-jwar.sh
+++ b/upload-to-jwar.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-mvn package -Dmaven.test.skip=true
-echo "Uploading plugin"
-curl -kv http://localhost:8080/pluginManager/uploadPlugin -u admin:admin -F file=@target/atlassian-bitbucket-server-integration.hpi
-echo "Restarting jenkins"
-curl -kv http://localhost:8080/safeRestart -u admin:admin -F Submit=Yes


### PR DESCRIPTION
Adds the "cancelled" build status to supporting instances (Bitbucket 8.0 and above), and cleans up the handling of the different types of statuses we send 