### PR TITLE
JENKINS-69268-fix-bitbucket-shared-library-build-status

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultGlobalLibrariesProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/DefaultGlobalLibrariesProvider.java
@@ -1,0 +1,12 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import javax.inject.Singleton;
+
+@Singleton
+public class DefaultGlobalLibrariesProvider implements GlobalLibrariesProvider {
+
+    public GlobalLibraries get() {
+        return GlobalLibraries.get();
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/GlobalLibrariesProvider.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/provider/GlobalLibrariesProvider.java
@@ -1,0 +1,15 @@
+package com.atlassian.bitbucket.jenkins.internal.provider;
+
+import com.google.inject.ImplementedBy;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+
+@ImplementedBy(DefaultGlobalLibrariesProvider.class)
+public interface GlobalLibrariesProvider {
+
+    /**
+     * Returns the result of calling GlobalLibraries.get()
+     *
+     * @return the GlobalLibraries instance
+     */
+    GlobalLibraries get();
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactory.java
@@ -7,5 +7,5 @@ import hudson.model.Run;
 @ImplementedBy(BitbucketBuildStatusFactoryImpl.class)
 public interface BitbucketBuildStatusFactory {
 
-    BitbucketBuildStatus.Builder prepareBuildStatus(Run<?, ?> build);
+    BitbucketBuildStatus.Builder prepareBuildStatus(Run<?, ?> build, BitbucketRevisionAction revisionAction);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
@@ -4,10 +4,7 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus;
 import com.atlassian.bitbucket.jenkins.internal.model.BuildState;
 import com.atlassian.bitbucket.jenkins.internal.model.TestResults;
 import com.google.common.annotations.VisibleForTesting;
-import hudson.model.ItemGroup;
-import hudson.model.Job;
-import hudson.model.Result;
-import hudson.model.Run;
+import hudson.model.*;
 import hudson.tasks.junit.TestResultAction;
 import jenkins.branch.MultiBranchProject;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
@@ -33,7 +30,7 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
     }
 
     @Override
-    public BitbucketBuildStatus.Builder prepareBuildStatus(Run<?, ?> build) {
+    public BitbucketBuildStatus.Builder prepareBuildStatus(Run<?, ?> build, BitbucketRevisionAction revisionAction) {
         Job<?, ?> job = build.getParent();
         ItemGroup parent = job.getParent();
         boolean isMultibranch = parent instanceof MultiBranchProject;
@@ -55,8 +52,6 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
         BitbucketBuildStatus.Builder bbs = new BitbucketBuildStatus.Builder(key, state, url)
                 .setName(name)
                 .setDescription(state.getDescriptiveText(build.getDisplayName(), build.getDurationString()));
-
-        BitbucketRevisionAction revisionAction = build.getAction(BitbucketRevisionAction.class);
 
         bbs.setBuildNumber(build.getId())
                 .setTestResults(getTestResults(build))

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -59,8 +59,7 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
 
     @Override
     public void onCompleted(Run<?, ?> r, TaskListener listener) {
-        List<BitbucketRevisionAction> actions = r.getActions(BitbucketRevisionAction.class);
-        for (BitbucketRevisionAction action : actions) {
+        for (BitbucketRevisionAction action : r.getActions(BitbucketRevisionAction.class)) {
                 postBuildStatus(action, r, listener);
         }
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -16,6 +16,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,9 +59,11 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
 
     @Override
     public void onCompleted(Run<?, ?> r, TaskListener listener) {
-        BitbucketRevisionAction bitbucketRevisionAction = r.getAction(BitbucketRevisionAction.class);
-        if (bitbucketRevisionAction != null) {
-            postBuildStatus(bitbucketRevisionAction, r, listener);
+        List<BitbucketRevisionAction> actions = r.getActions(BitbucketRevisionAction.class);
+        if (actions != null) {
+            for (BitbucketRevisionAction action : actions) {
+                postBuildStatus(action, r, listener);
+            }
         }
     }
 
@@ -85,7 +88,7 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
         try {
             BitbucketClientFactory bbsClient = getBbsClient(server, globalCredentialsProvider);
 
-            BitbucketBuildStatus.Builder buildStatusBuilder = bitbucketBuildStatusFactory.prepareBuildStatus(run);
+            BitbucketBuildStatus.Builder buildStatusBuilder = bitbucketBuildStatusFactory.prepareBuildStatus(run, revisionAction);
 
             BitbucketSCMRepository bitbucketSCMRepo = revisionAction.getBitbucketSCMRepo();
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -60,10 +60,8 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
     @Override
     public void onCompleted(Run<?, ?> r, TaskListener listener) {
         List<BitbucketRevisionAction> actions = r.getActions(BitbucketRevisionAction.class);
-        if (actions != null) {
-            for (BitbucketRevisionAction action : actions) {
+        for (BitbucketRevisionAction action : actions) {
                 postBuildStatus(action, r, listener);
-            }
         }
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -4,35 +4,26 @@ import com.atlassian.bitbucket.jenkins.internal.provider.GlobalLibrariesProvider
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper;
-import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.Extension;
-import hudson.ExtensionList;
 import hudson.FilePath;
-import hudson.model.ItemGroup;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.model.TopLevelItem;
 import hudson.model.listeners.SCMListener;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.util.DescribableList;
-import jenkins.branch.MultiBranchProject;
-import jenkins.model.GlobalConfiguration;
-import jenkins.mvn.DefaultGlobalSettingsProvider;
 import org.jenkinsci.plugins.workflow.libs.*;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
 import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Scanner;
 
 @Extension
 public class LocalSCMListener extends SCMListener {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -3,16 +3,27 @@ package com.atlassian.bitbucket.jenkins.internal.status;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper;
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
+import hudson.model.ItemGroup;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.TopLevelItem;
 import hudson.model.listeners.SCMListener;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
+import hudson.util.DescribableList;
+import jenkins.branch.MultiBranchProject;
+import jenkins.model.GlobalConfiguration;
+import jenkins.mvn.DefaultGlobalSettingsProvider;
 import org.jenkinsci.plugins.workflow.libs.*;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
 import javax.annotation.CheckForNull;
 import javax.inject.Inject;
@@ -20,6 +31,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Scanner;
 
 @Extension
 public class LocalSCMListener extends SCMListener {
@@ -51,6 +63,40 @@ public class LocalSCMListener extends SCMListener {
         return null;
     }
 
+    private boolean isFolderLib(Folder folder, SCM scm) {
+        return hasFolderLibrary(scm, folder.getProperties(), folder.getParent());
+    }
+
+    private boolean hasFolderLibrary(SCM scm,
+                                     DescribableList<AbstractFolderProperty<?>, AbstractFolderPropertyDescriptor> properties,
+                                     ItemGroup parent) {
+        for (Object folderItem : properties) {
+            if (folderItem instanceof FolderLibraries) {
+                FolderLibraries folderLibraries = (FolderLibraries) folderItem;
+                for (LibraryConfiguration folderLib : folderLibraries.getLibraries()) {
+                    if (folderLib.getRetriever() instanceof SCMRetriever) {
+                        SCMRetriever retriever = (SCMRetriever) folderLib.getRetriever();
+                        if (retriever.getScm() instanceof BitbucketSCM && scm instanceof BitbucketSCM) {
+                            BitbucketSCM libraryScm = (BitbucketSCM) retriever.getScm();
+                            BitbucketSCM bitbucketScm = (BitbucketSCM) scm;
+                            if (libraryScm.getId().equals(bitbucketScm.getId())) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (parent instanceof Folder) {
+            return isFolderLib((Folder) parent, scm);
+        }
+        return false;
+    }
+
+    private boolean isFolderLib(WorkflowMultiBranchProject project, SCM scm) {
+        return hasFolderLibrary(scm, project.getProperties(), project.getParent());
+    }
+
     @Override
     public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener,
                            @CheckForNull File changelogFile,
@@ -58,6 +104,16 @@ public class LocalSCMListener extends SCMListener {
 
         // Check if the current SCM we are checking out is configured as a library SCM. We don't want to send status
         // to library SCMs.
+        if (build.getParent().getParent() instanceof Folder
+            && isFolderLib((Folder) build.getParent().getParent(), scm)) {
+            return;
+        }
+        if (build.getParent().getParent() instanceof WorkflowMultiBranchProject
+            && isFolderLib((WorkflowMultiBranchProject) build.getParent().getParent(), scm)) {
+            return;
+        }
+
+
         for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
             for (LibraryConfiguration cfg : resolver.forJob(build.getParent(), Collections.emptyMap())) {
                 if (cfg.getRetriever() instanceof SCMRetriever) {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImplTest.java
@@ -41,6 +41,8 @@ public class BitbucketBuildStatusFactoryImplTest {
     private Job freeStyleProject;
     private Jenkins parent;
     @Mock
+    private BitbucketRevisionAction revisionAction;
+    @Mock
     private Run workflowRun;
     private Job workflowJob;
     @Mock
@@ -246,7 +248,7 @@ public class BitbucketBuildStatusFactoryImplTest {
     private BitbucketBuildStatus createBitbucketBuildStatus(Run<?, ?> run, boolean createRich) {
         BitbucketBuildStatusFactoryImpl statusFactory =
                 new BitbucketBuildStatusFactoryImpl(displayUrlProvider);
-        return createRich ? statusFactory.prepareBuildStatus(run).build() :
-                            statusFactory.prepareBuildStatus(run).legacy().build();
+        return createRich ? statusFactory.prepareBuildStatus(run, revisionAction).build() :
+                            statusFactory.prepareBuildStatus(run, revisionAction).legacy().build();
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.MockitoJUnitRunner.Silent;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.atlassian.bitbucket.jenkins.internal.fixture.mocks.BitbucketJenkinsSetup.SERVER_ID;
@@ -74,7 +75,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testBitbucketClientException() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
         doThrow(BitbucketClientException.class).when(clientFactoryMock.getBuildStatusClient()).post(any(BitbucketBuildStatus.Builder.class), any());
         buildStatusPoster.onCompleted(run, listener);
         verify(clientFactoryMock.getBuildStatusClient()).post(any(), any());
@@ -82,7 +83,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testNoBuildAction() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(null);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.emptyList());
         buildStatusPoster.onCompleted(run, listener);
         verifyZeroInteractions(jenkinsSetupMock.getPluginConfiguration());
         verifyZeroInteractions(listener);
@@ -90,7 +91,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testNoMatchingServer() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
         when(jenkinsSetupMock.getPluginConfiguration().getServerById(SERVER_ID)).thenReturn(Optional.empty());
         buildStatusPoster.onCompleted(run, listener);
         verify(listener).error(eq("Failed to post build status as the provided Bitbucket Server config does not exist"));
@@ -99,7 +100,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testBuildStatusDisabled() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
         try {
             System.setProperty("bitbucket.status.disable", "true");
             buildStatusPoster.onCompleted(run, listener);
@@ -113,7 +114,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testSuccessfulPost() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
 
         buildStatusPoster.onCompleted(run, listener);
 
@@ -123,7 +124,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testRichBuildStatusForSupportedCapabilities() {
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
         when(clientFactoryMock.getCICapabilities().supportsRichBuildStatus()).thenReturn(true);
 
         buildStatusPoster.onCompleted(run, listener);
@@ -135,7 +136,7 @@ public class BuildStatusPosterTest {
     @Test
     public void testRichBuildStatusUseLegacyEnabled() {
         when(buildStatusPoster.useLegacyBuildStatus()).thenReturn(true);
-        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Collections.singletonList(action));
         when(clientFactoryMock.getCICapabilities().supportsRichBuildStatus()).thenReturn(true);
 
         buildStatusPoster.onCompleted(run, listener);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner.Silent;
 
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -143,5 +142,15 @@ public class BuildStatusPosterTest {
 
         verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
         verify(buildStatusFactory).prepareBuildStatus(run, action);
+    }
+
+    @Test
+    public void testSuccessfulPostMultipleActions() {
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action, action));
+
+        buildStatusPoster.onCompleted(run, listener);
+
+        verify(clientFactoryMock.getBuildStatusClient(), times(2)).post(eq(buildStatus), any());
+        verify(buildStatusFactory, times(2)).prepareBuildStatus(run, action);
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner.Silent;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.atlassian.bitbucket.jenkins.internal.fixture.mocks.BitbucketJenkinsSetup.SERVER_ID;
@@ -67,12 +69,12 @@ public class BuildStatusPosterTest {
 
         when(run.getProject()).thenReturn(project);
         when(listener.getLogger()).thenReturn(logger);
-        when(buildStatusFactory.prepareBuildStatus(run)).thenReturn(buildStatus);
+        when(buildStatusFactory.prepareBuildStatus(run, action)).thenReturn(buildStatus);
     }
-    
+
     @Test
     public void testBitbucketClientException() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
         doThrow(BitbucketClientException.class).when(clientFactoryMock.getBuildStatusClient()).post(any(BitbucketBuildStatus.Builder.class), any());
         buildStatusPoster.onCompleted(run, listener);
         verify(clientFactoryMock.getBuildStatusClient()).post(any(), any());
@@ -80,7 +82,7 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testNoBuildAction() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(null);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(null);
         buildStatusPoster.onCompleted(run, listener);
         verifyZeroInteractions(jenkinsSetupMock.getPluginConfiguration());
         verifyZeroInteractions(listener);
@@ -88,16 +90,16 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testNoMatchingServer() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
         when(jenkinsSetupMock.getPluginConfiguration().getServerById(SERVER_ID)).thenReturn(Optional.empty());
         buildStatusPoster.onCompleted(run, listener);
         verify(listener).error(eq("Failed to post build status as the provided Bitbucket Server config does not exist"));
         verifyZeroInteractions(clientFactoryMock.getBitbucketClientFactoryProvider());
     }
-    
+
     @Test
     public void testBuildStatusDisabled() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
         try {
             System.setProperty("bitbucket.status.disable", "true");
             buildStatusPoster.onCompleted(run, listener);
@@ -111,34 +113,34 @@ public class BuildStatusPosterTest {
 
     @Test
     public void testSuccessfulPost() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
 
         buildStatusPoster.onCompleted(run, listener);
 
         verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
-        verify(buildStatusFactory).prepareBuildStatus(run);
+        verify(buildStatusFactory).prepareBuildStatus(run, action);
     }
 
     @Test
     public void testRichBuildStatusForSupportedCapabilities() {
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
         when(clientFactoryMock.getCICapabilities().supportsRichBuildStatus()).thenReturn(true);
 
         buildStatusPoster.onCompleted(run, listener);
 
         verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
-        verify(buildStatusFactory).prepareBuildStatus(run);
+        verify(buildStatusFactory).prepareBuildStatus(run, action);
     }
 
     @Test
     public void testRichBuildStatusUseLegacyEnabled() {
         when(buildStatusPoster.useLegacyBuildStatus()).thenReturn(true);
-        when(run.getAction(BitbucketRevisionAction.class)).thenReturn(action);
+        when(run.getActions(BitbucketRevisionAction.class)).thenReturn(Arrays.asList(action));
         when(clientFactoryMock.getCICapabilities().supportsRichBuildStatus()).thenReturn(true);
 
         buildStatusPoster.onCompleted(run, listener);
 
         verify(clientFactoryMock.getBuildStatusClient()).post(eq(buildStatus), any());
-        verify(buildStatusFactory).prepareBuildStatus(run);
+        verify(buildStatusFactory).prepareBuildStatus(run, action);
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
@@ -1,14 +1,18 @@
 package com.atlassian.bitbucket.jenkins.internal.status;
 
+import com.atlassian.bitbucket.jenkins.internal.provider.GlobalLibrariesProvider;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper;
+import com.cloudbees.hudson.plugins.folder.*;
 import hudson.model.*;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.transport.RemoteConfig;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.libs.*;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,11 +22,12 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner.Silent;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -31,14 +36,18 @@ import static org.mockito.Mockito.*;
 public class LocalSCMListenerTest extends HudsonTestCase {
 
     private final Map<String, String> buildMap = new HashMap<>();
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
     @Mock
     private BitbucketSCM bitbucketSCM;
     @Mock
     private BuildStatusPoster buildStatusPoster;
     @Mock
     private GitSCM gitSCM;
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+    @Mock
+    private GlobalLibraries globalLibraries;
+    @Mock
+    private GlobalLibrariesProvider librariesProvider;
     private LocalSCMListener listener;
     @Mock
     private BitbucketSCMRepositoryHelper repositoryHelper;
@@ -66,7 +75,28 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         when(bitbucketSCM.getBitbucketSCMRepository()).thenReturn(scmRepository);
         when(repositoryHelper.getRepository(any(), eq(bitbucketSCM))).thenReturn(scmRepository);
         when(repositoryHelper.getRepository(any(), eq(gitSCM))).thenReturn(scmRepository);
-        listener = spy(new LocalSCMListener(buildStatusPoster, repositoryHelper));
+        listener = spy(new LocalSCMListener(buildStatusPoster, librariesProvider, repositoryHelper));
+        when(librariesProvider.get()).thenReturn(globalLibraries);
+    }
+
+    @Test
+    public void testOnCheckoutMultiBranchPipelineWithFolderLibraryDoesNotPostBuildStatus() throws IOException {
+        when(bitbucketSCM.getId()).thenReturn("SomeId");
+        WorkflowMultiBranchProject workflowMultiBranchProject =
+                jenkinsRule.getInstance().createProject(WorkflowMultiBranchProject.class, "MultiBranchProject");
+        WorkflowJob workflowJob = new WorkflowJob(workflowMultiBranchProject, "Job1");
+        when(run.getParent()).thenReturn(workflowJob);
+        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
+        SCMRetriever scmRetriever = mock(SCMRetriever.class);
+        when(libConfig.getRetriever()).thenReturn(scmRetriever);
+        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
+        workflowMultiBranchProject.addProperty(folderLibraries);
+
+        listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
+
+        verify(bitbucketSCM, times(2)).getId();
+        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
 
     @Test
@@ -74,6 +104,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         FreeStyleProject project = mock(FreeStyleProject.class);
         FreeStyleBuild build = mock(FreeStyleBuild.class);
         when(build.getParent()).thenReturn(project);
+        when(globalLibraries.getLibraries()).thenReturn(emptyList());
 
         listener.onCheckout(build, bitbucketSCM, null, taskListener, null, null);
 
@@ -84,10 +115,30 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     }
 
     @Test
+    public void testOnCheckoutWithFolderLibraryDoesNotPostBuildStatus() throws Exception {
+        when(bitbucketSCM.getId()).thenReturn("SomeID");
+        Folder folder = new Folder(jenkinsRule.getInstance().getItemGroup(), "Folder");
+        WorkflowJob workflowJob = new WorkflowJob(folder, "Job1");
+        when(run.getParent()).thenReturn(workflowJob);
+        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
+        SCMRetriever scmRetriever = mock(SCMRetriever.class);
+        when(libConfig.getRetriever()).thenReturn(scmRetriever);
+        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
+        folder.addProperty(folderLibraries);
+
+        listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
+
+        verify(bitbucketSCM, times(2)).getId();
+        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
+    }
+
+    @Test
     public void testOnCheckoutWithGitSCM() {
         FreeStyleProject project = mock(FreeStyleProject.class);
         FreeStyleBuild build = mock(FreeStyleBuild.class);
         when(build.getParent()).thenReturn(project);
+        when(globalLibraries.getLibraries()).thenReturn(emptyList());
 
         listener.onCheckout(build, gitSCM, null, taskListener, null, null);
 
@@ -98,32 +149,9 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     }
 
     @Test
-    public void testOnCheckoutWithNoRepositoryDoesNotPostBuildStatus() {
-        SCM scm = mock(SCM.class);
-        FreeStyleProject project = mock(FreeStyleProject.class);
-        when(run.getParent()).thenReturn(project);
-
-        listener.onCheckout(run, scm, null, taskListener, null, null);
-
-        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
-    }
-
-    @Test
-    public void testOnCheckoutWithNonGitSCMDoesNotPostBuildStatus() {
-        SCM scm = mock(SCM.class);
-        when(repositoryHelper.getRepository(run, scm)).thenReturn(scmRepository);
-        FreeStyleProject project = mock(FreeStyleProject.class);
-        when(run.getParent()).thenReturn(project);
-
-        listener.onCheckout(run, scm, null, taskListener, null, null);
-
-        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
-    }
-
-    @Test
-    public void testOnCheckoutWithSharedLibrariesDoesNotPostBuildStatus() {
+    public void testOnCheckoutWithGlobalLibrariesDoesNotPostBuildStatus() {
         LibraryConfiguration libraryConfiguration = mock(LibraryConfiguration.class);
-        GlobalLibraries.get().setLibraries(singletonList(libraryConfiguration));
+        when(globalLibraries.getLibraries()).thenReturn(singletonList(libraryConfiguration));
         SCMRetriever scmRetriever = mock(SCMRetriever.class);
         when(libraryConfiguration.getRetriever()).thenReturn(scmRetriever);
         when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
@@ -137,9 +165,9 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     }
 
     @Test
-    public void testOnCheckoutWithSharedLibrariesPostToNonLibrarySCM() {
+    public void testOnCheckoutWithGlobalLibrariesPostToNonLibrarySCM() {
         LibraryConfiguration libraryConfiguration = mock(LibraryConfiguration.class);
-        GlobalLibraries.get().setLibraries(singletonList(libraryConfiguration));
+        when(globalLibraries.getLibraries()).thenReturn(singletonList(libraryConfiguration));
         SCMRetriever scmRetriever = mock(SCMRetriever.class);
         when(libraryConfiguration.getRetriever()).thenReturn(scmRetriever);
         BitbucketSCM scm = mock(BitbucketSCM.class);
@@ -155,5 +183,52 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         verify(bitbucketSCM, times(1)).getId();
         verify(scm, times(1)).getId();
         verify(buildStatusPoster, times(1)).postBuildStatus(any(), any(), any());
+    }
+
+    @Test
+    public void testOnCheckoutWithNestedFolderLibraryDoesNotPostBuildStatus() throws IOException {
+        when(bitbucketSCM.getId()).thenReturn("SomeID");
+        Folder parentFolder = new Folder(jenkinsRule.getInstance().getItemGroup(), "ParentFolder");
+        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
+        SCMRetriever scmRetriever = mock(SCMRetriever.class);
+        when(libConfig.getRetriever()).thenReturn(scmRetriever);
+        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
+        parentFolder.addProperty(folderLibraries);
+        Folder folder = new Folder(parentFolder, "Folder");
+        parentFolder.add(folder, "ChildFolder");
+        WorkflowJob workflowJob = new WorkflowJob(folder, "Job1");
+        doReturn(workflowJob).when(run).getParent();
+        when(run.getParent()).thenReturn(workflowJob);
+
+        listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
+
+        verify(bitbucketSCM, times(2)).getId();
+        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
+    }
+
+    @Test
+    public void testOnCheckoutWithNonGitSCMDoesNotPostBuildStatus() {
+        SCM scm = mock(SCM.class);
+        when(repositoryHelper.getRepository(run, scm)).thenReturn(scmRepository);
+        FreeStyleProject project = mock(FreeStyleProject.class);
+        when(run.getParent()).thenReturn(project);
+        when(globalLibraries.getLibraries()).thenReturn(emptyList());
+
+        listener.onCheckout(run, scm, null, taskListener, null, null);
+
+        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
+    }
+
+    @Test
+    public void testOnCheckoutWithNoRepositoryDoesNotPostBuildStatus() {
+        FreeStyleProject project = mock(FreeStyleProject.class);
+        when(run.getParent()).thenReturn(project);
+        when(globalLibraries.getLibraries()).thenReturn(emptyList());
+        SCM scm = mock(SCM.class);
+
+        listener.onCheckout(run, scm, null, taskListener, null, null);
+
+        verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
@@ -95,6 +95,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
 
         listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
 
+        // Twice since the same ID will be compared to itself.
         verify(bitbucketSCM, times(2)).getId();
         verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
@@ -129,6 +130,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
 
         listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
 
+        // Twice since the same ID will be compared to itself.
         verify(bitbucketSCM, times(2)).getId();
         verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
@@ -160,7 +162,8 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         when(bitbucketSCM.getId()).thenReturn("SomeID");
 
         listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
-        verify(bitbucketSCM, times(2)).getId(); // Twice since the same ID will be compared to itself.
+        // Twice since the same ID will be compared to itself.
+        verify(bitbucketSCM, times(2)).getId();
         verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
 
@@ -201,6 +204,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
 
         listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
 
+        // Twice since the same ID will be compared to itself.
         verify(bitbucketSCM, times(2)).getId();
         verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }
@@ -221,6 +225,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
 
         listener.onCheckout(run, bitbucketSCM, null, taskListener, null, null);
 
+        // Twice since the same ID will be compared to itself.
         verify(bitbucketSCM, times(2)).getId();
         verify(buildStatusPoster, never()).postBuildStatus(any(), any(), any());
     }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes the bug where the build status is not sent correctly when global pipeline libraries are used in a job.

https://issues.jenkins.io/browse/JENKINS-69268?filter=-1

This change ensures that build status is sent to all repos used in the job, except for repos hosting a global pipeline library.

I still need to perform testing with a freestyle job and a pipeline job and write extra unit tests.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [] Ensure that the pull request title represents the desired changelog entry - WIP PR - N/A 
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

