### PR TITLE
Bumped parent pom version to 4.42.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.17</version>
+        <version>4.42</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -243,10 +243,9 @@
             <version>1.0.24</version>
         </dependency>
         <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>trilead-putty-extension</artifactId>
-            <version>1.2</version>
-            <scope>runtime</scope>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <!--        Test dependencies -->
         <dependency>

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookTriggerImpl.java
@@ -301,7 +301,7 @@ public class BitbucketWebhookTriggerImpl extends Trigger<Job<?, ?>>
         }
 
         @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "If jenkinsProvider is null we inject one, this is a false positive")
-        private boolean webhookExists(Job<?, ?> project, BitbucketSCM input) {
+        private boolean webhookExists(@Nullable Job<?, ?> project, BitbucketSCM input) {
             try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
                 if (jenkinsProvider == null) {
                     Guice.createInjector(new JenkinsProviderModule()).injectMembers(this);


### PR DESCRIPTION
Updated parent pom version to 4.42 to future proof 

Removed unused dependency `org.kohsuke.trilead-putty-extension` from pom. 
Added `@Nullable` annotation to `BitbucketWebhookTriggerImpl::webhookExists` since the version of `jenkins-core` imported by parent pom 4.42 includes a `@CheckForNull` annotation on the `job` field of `Trigger`
Added dependency `com.google.code.findbugs.jsr305` to pom since this is excluded by parent pom 4.42, required for nullability annotations

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue - N/A
