### PR TITLE
Add support of multiple repositories checkout

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -58,8 +58,7 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
 
     @Override
     public void onCompleted(Run<?, ?> r, TaskListener listener) {
-        BitbucketRevisionAction bitbucketRevisionAction = r.getAction(BitbucketRevisionAction.class);
-        if (bitbucketRevisionAction != null) {
+        for (BitbucketRevisionAction bitbucketRevisionAction : r.getActions(BitbucketRevisionAction.class)) {
             postBuildStatus(bitbucketRevisionAction, r, listener);
         }
     }


### PR DESCRIPTION
When checking out for more than 1 repository -  the build start status is sent for all of the related checkouts but the build result is sent only for the first checkout.
This is because the 'onCompleted' function was searching for the first BitbucketRevisionAction.
I updated it to process all BitbucketRevisionAction found and now all of the related checkouts sends the build result

![multiple build status](https://user-images.githubusercontent.com/20265933/215751074-2845d604-a27d-42bd-be49-8aaf1a43a7a5.jpg)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue