### PR TITLE
JENKINS-70275 git scm owner is reinitialized if null whenever accessi…

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -105,7 +105,7 @@ public class BitbucketSCMSource extends SCMSource {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Building SCM for " + head.getName() + " at revision " + revision);
         }
-        return getAndInitializeGitSCMSourceIfNull().build(head, revision);
+        return getFullyInitializedGitSCMSource().build(head, revision);
     }
     
     @Override
@@ -178,12 +178,13 @@ public class BitbucketSCMSource extends SCMSource {
         return repository;
     }
 
-    CustomGitSCMSource getAndInitializeGitSCMSourceIfNull() {
+    CustomGitSCMSource getFullyInitializedGitSCMSource() {
         if (gitSCMSource == null) {
             initializeGitScmSource();
         } 
         if (getOwner() != null && gitSCMSource.getOwner() == null) {
             gitSCMSource.setOwner(getOwner());
+            gitSCMSource.setBrowser(new BitbucketServer(selfLink));
         }
         return gitSCMSource;
     }
@@ -211,7 +212,7 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     public String getRemote() {
-        return getAndInitializeGitSCMSourceIfNull().getRemote();
+        return getFullyInitializedGitSCMSource().getRemote();
     }
 
     public String getRepositoryName() {
@@ -285,7 +286,7 @@ public class BitbucketSCMSource extends SCMSource {
                                " Check the configuration before running this job again.");
                 return;
             }
-            getAndInitializeGitSCMSourceIfNull().accessibleRetrieve(criteria, observer, event, listener);
+            getFullyInitializedGitSCMSource().accessibleRetrieve(criteria, observer, event, listener);
         }
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -184,7 +184,6 @@ public class BitbucketSCMSource extends SCMSource {
         } 
         if (getOwner() != null && gitSCMSource.getOwner() == null) {
             gitSCMSource.setOwner(getOwner());
-            gitSCMSource.setBrowser(new BitbucketServer(selfLink));
         }
         return gitSCMSource;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -181,6 +181,9 @@ public class BitbucketSCMSource extends SCMSource {
     CustomGitSCMSource getAndInitializeGitSCMSourceIfNull() {
         if (gitSCMSource == null) {
             initializeGitScmSource();
+        } 
+        if (getOwner() != null && gitSCMSource.getOwner() == null) {
+            gitSCMSource.setOwner(getOwner());
         }
         return gitSCMSource;
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -14,10 +14,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.Action;
 import hudson.model.Actionable;
 import jenkins.branch.MultiBranchProject;
-import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.SCMHeadEvent;
-import jenkins.scm.api.SCMSourceDescriptor;
-import jenkins.scm.api.SCMSourceEvent;
+import jenkins.scm.api.*;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 
 import org.apache.commons.lang3.StringUtils;
@@ -215,6 +212,23 @@ public class BitbucketSCMSourceTest {
 
         CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull();
         assertThat(gitSource.getRemote(), equalTo(HTTP_CLONE_LINK));
+    }
+    
+    @Test
+    public void testGetAndInitializeGitSCMSourceSetsOwnerIfNull() {
+        BitbucketSCMSource source = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositoryName(REPOSITORY_NAME)
+                .build();
+        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull(); // Initializes with no owner
+        assertThat(gitSource.getOwner(), equalTo(null));
+
+        SCMSourceOwner owner = mock(SCMSourceOwner.class);
+        source.setOwner(owner); // This is handled by Jenkins during typical execution
+        
+        gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        assertThat(gitSource.getOwner(), equalTo(owner));
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -184,7 +184,7 @@ public class BitbucketSCMSourceTest {
                 .mirrorName(MIRROR_NAME)
                 .build();
 
-        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        CustomGitSCMSource gitSource = source.getFullyInitializedGitSCMSource();
         assertThat(gitSource.getRemote(), equalTo(HTTP_MIRROR_CLONE_LINK));
     }
 
@@ -198,7 +198,7 @@ public class BitbucketSCMSourceTest {
                 .mirrorName(MIRROR_NAME)
                 .build();
 
-        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        CustomGitSCMSource gitSource = source.getFullyInitializedGitSCMSource();
         assertThat(gitSource.getRemote(), equalTo(SSH_MIRROR_CLONE_LINK));
     }
 
@@ -210,7 +210,7 @@ public class BitbucketSCMSourceTest {
                 .repositoryName(REPOSITORY_NAME)
                 .build();
 
-        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        CustomGitSCMSource gitSource = source.getFullyInitializedGitSCMSource();
         assertThat(gitSource.getRemote(), equalTo(HTTP_CLONE_LINK));
     }
     
@@ -221,13 +221,13 @@ public class BitbucketSCMSourceTest {
                 .projectName(PROJECT_NAME)
                 .repositoryName(REPOSITORY_NAME)
                 .build();
-        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull(); // Initializes with no owner
+        CustomGitSCMSource gitSource = source.getFullyInitializedGitSCMSource(); // Initializes with no owner
         assertThat(gitSource.getOwner(), equalTo(null));
 
         SCMSourceOwner owner = mock(SCMSourceOwner.class);
         source.setOwner(owner); // This is handled by Jenkins during typical execution
         
-        gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        gitSource = source.getFullyInitializedGitSCMSource();
         assertThat(gitSource.getOwner(), equalTo(owner));
     }
 
@@ -240,7 +240,7 @@ public class BitbucketSCMSourceTest {
                 .repositoryName(REPOSITORY_NAME)
                 .build();
 
-        CustomGitSCMSource gitSource = source.getAndInitializeGitSCMSourceIfNull();
+        CustomGitSCMSource gitSource = source.getFullyInitializedGitSCMSource();
         assertThat(gitSource.getRemote(), equalTo(SSH_CLONE_LINK));
     }
 


### PR DESCRIPTION
This issue can be replicated locally by taking the following steps:
- Create a multibranch pipeline, using folder-level credentials that will be used for checkout
- Restart Jenkins
- Trigger a job using a webhook
The result is a stack trace in the Jenkins logs related to a 401 on checkout. Inspecting the request in Bitbucket reveals Jenkins has sent a pair of garbled strings instead of real credentials, which probably isn't great but is ultimately a red herring.

This issue relates closely to [JENKINS-65541](https://issues.jenkins.io/browse/JENKINS-65541), and has to do with the way we wrap the GitSCMSource. We provide a credential id to the git scm when attempting a retrieve rather than a full credential- it then uses it's owner context (which refers to the containing job or folder) so it can only retrieve credentials it has access to. All items have global access. However, our GitSCMSource doesn't have an owner, as it's wrapped in the BitbucketSCMSource, so the solution to this bug was to ensure we added the same owner when the GitSCMSource is initialized.

The problem comes when Jenkins restarts. We added the setOwner check in the git initialization code, that's called whenever a BitbucketSCMSource is created, but upon restart Jenkins doesn't create a new SCMSource, it _deserializes it_ from the job's config.xml file. An example is shown below:

```
<?xml version='1.1' encoding='UTF-8'?>
<org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject plugin="workflow-multibranch@716.vc692a_e52371b_">
...
        <source class="com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource" plugin="atlassian-bitbucket-server-integration@3.3.2">
          <id>0f0efe43-ae80-4610-913f-f2ef88d2de24</id>
          <traits>
            <jenkins.plugins.git.traits.BranchDiscoveryTrait plugin="git@5.0.0"/>
          </traits>
          <gitSCMSource>
            <id>0f0efe43-ae80-4610-913f-f2ef88d2de24-git-scm</id>
            <remote>http://localhost:7990/bitbucket/scm/project_1/jenkins.git</remote>
            <credentialsId>a61cbccc-fd6b-480d-98dc-0ff551e2bd1a</credentialsId>
            <traits>
              <jenkins.plugins.git.traits.BranchDiscoveryTrait reference="../../../traits/jenkins.plugins.git.traits.BranchDiscoveryTrait"/>
            </traits>
            <repository>
              <credentialsId>a61cbccc-fd6b-480d-98dc-0ff551e2bd1a</credentialsId>
              <mirrorName></mirrorName>
              <projectKey>PROJECT_1</projectKey>
              <projectName>Project 1</projectName>
              <repositoryName>jenkins</repositoryName>
              <repositorySlug>jenkins</repositorySlug>
              <serverId>26440aa8-7e48-4ca1-afbc-1c506c10a162</serverId>
              <sshCredentialsId></sshCredentialsId>
            </repository>
          </gitSCMSource>
          <repository reference="../gitSCMSource/repository"/>
          <webhookRegistered>false</webhookRegistered>
        </source>
...
```
Notice that the GitSCMSource serializes the credential id fine, but _not_ the owner- which is why the credential is passed through with no problems to the SCM which attempts to fetch the credential and fails. Hence, the authentication check with Bitbucket fails and the job cannot succeed until the user has re-saved the config, this creating the SCMSource anew with the appropriate owner.

This bug will reoccur every time Jenkins restarts.

You may be asking is "why doesn't this happen with the BitbucketSCMSource as well"? Unlike the GitSCMSource, the Bitbucket source has a _real_ owner- a multibranch pipeline. These extend `Item`, which exposes an `onLoad` method- a method called as part of deserialization of the config file, where any implied information (such as the owner) can be added dynamically. You can see the workings in `MultiBranchProject#init2`- it cycles over all deserialized SCMSources it knows about and simply adds itself to them as owner manually. Our GitSCMSource is not in this list, so it is omitted and we have to do it ourself. It would be really convenient if SCMSource exposed an `onLoad` method, but it doesn't because this sort of dynamic setting is designed to be done by Projects, not SCMs- which is one more compelling reason to do away with the GitSCMSource in the future.