### PR TITLE
None bump Jenkins to 2.375

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(
+useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -14,7 +14,7 @@
         <plugin.build.dir>../target</plugin.build.dir>
         <!-- The name of the plugin being tested (i.e. the artifact name in the plugin's pom.xml) -->
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
-        <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
+        <jenkins.acceptance-test-harness.version>5504.v485694f31cdf</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jenkins.version>2.387.1</jenkins.version>
@@ -23,10 +23,11 @@
         <groovy.version>3.0.7</groovy.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <jgit.version>4.5.7.201904151645-r</jgit.version>
+        <junit.version>5.9.2</junit.version>
         <log4j.version>1.7.25</log4j.version>
         <rest-assured.version>3.0.7</rest-assured.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -40,6 +41,16 @@
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-core</artifactId>
             <version>${scribejava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.90.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -106,6 +117,31 @@
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.junit</artifactId>
             <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>${junit.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>5504.v485694f31cdf</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.21.9</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.387.1</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -132,12 +132,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.version}</version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,7 +17,7 @@
         <jenkins.acceptance-test-harness.version>1.97</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.8.0</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
         <jackson.version>2.10.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -15,7 +15,7 @@
         <!-- The name of the plugin being tested (i.e. the artifact name in the plugin's pom.xml) -->
         <plugin-under-test.name>atlassian-bitbucket-server-integration</plugin-under-test.name>
         <jenkins.acceptance-test-harness.version>5504.v485694f31cdf</jenkins.acceptance-test-harness.version>
-        <bitbucket.version>7.8.0</bitbucket.version>
+        <bitbucket.version>7.21.9</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jenkins.version>2.387.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>

--- a/acceptance-tests/readme.md
+++ b/acceptance-tests/readme.md
@@ -268,6 +268,7 @@ will have to start up an instance of Bitbucket Server listening on port `7990` (
 `bitbucket.baseurl` system property.
 
 #### Running the smoke tests on macOS
+Note: Running individual tests through your IDE is not supported on macOS.
 
 Using Docker to start Firefox does not work on macOS. Instead, you can install the appropriate browser with [Homebrew](https://brew.sh/):
 
@@ -278,5 +279,11 @@ brew install geckodriver
 Once you've installed the browser, you can run the smoke tests by specifying the browser type and path:
 
 ```
-BROWSER=firefox mvn clean verify -Psmoke-tests -Dwebdriver.gecko.driver="$(brew --prefix geckodriver)/bin/geckodriver"
+BROWSER=firefox mvn clean verify -Psmoke-tests -Dwebdriver.gecko.driver=/opt/homebrew/bin/geckodriver
 ```
+If you wish to run a single test, append the test name to the end of the command:
+
+```
+BROWSER=firefox mvn clean verify -Psmoke-tests -Dwebdriver.gecko.driver=/opt/homebrew/bin/geckodriver -Dit.test=SmokeTest#<Test Name>
+```
+If you experience issues, confirm your geckodriver location by running `whereis geckodriver`

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
@@ -3,6 +3,9 @@ package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 import org.jenkinsci.test.acceptance.po.*;
 import org.openqa.selenium.support.ui.Select;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Represents the {@link PageAreaImpl page area} for configuring a job to use a Bitbucket Server SCM
  *
@@ -10,7 +13,7 @@ import org.openqa.selenium.support.ui.Select;
  */
 @Describable("Bitbucket Server")
 public class BitbucketScmConfig extends Scm {
-
+    private static final Logger LOGGER = Logger.getLogger(BitbucketScmWorkflowJob.class.getName());
     private final Control sshCredentialsId = control("sshCredentialsId");
     private final Control credentialsId = control("credentialsId");
     private final Control serverId = control("serverId");
@@ -23,8 +26,13 @@ public class BitbucketScmConfig extends Scm {
     }
 
     public BitbucketScmConfig credentialsId(String credentialsId) {
+        LOGGER.log(Level.INFO, "Zero:");
         scrollIntoView(this.credentialsId);
-        new Select(this.credentialsId.resolve()).selectByValue(credentialsId);
+        LOGGER.log(Level.INFO, "One:");
+        Select select = new Select(this.credentialsId.resolve());
+        LOGGER.log(Level.INFO, "Two:");
+        select.selectByValue(credentialsId);
+        LOGGER.log(Level.INFO, "Three:");
         return this;
     }
 

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmConfig.java
@@ -3,9 +3,6 @@ package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 import org.jenkinsci.test.acceptance.po.*;
 import org.openqa.selenium.support.ui.Select;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 /**
  * Represents the {@link PageAreaImpl page area} for configuring a job to use a Bitbucket Server SCM
  *
@@ -13,7 +10,7 @@ import java.util.logging.Logger;
  */
 @Describable("Bitbucket Server")
 public class BitbucketScmConfig extends Scm {
-    private static final Logger LOGGER = Logger.getLogger(BitbucketScmWorkflowJob.class.getName());
+
     private final Control sshCredentialsId = control("sshCredentialsId");
     private final Control credentialsId = control("credentialsId");
     private final Control serverId = control("serverId");
@@ -26,13 +23,8 @@ public class BitbucketScmConfig extends Scm {
     }
 
     public BitbucketScmConfig credentialsId(String credentialsId) {
-        LOGGER.log(Level.INFO, "Zero:");
         scrollIntoView(this.credentialsId);
-        LOGGER.log(Level.INFO, "One:");
-        Select select = new Select(this.credentialsId.resolve());
-        LOGGER.log(Level.INFO, "Two:");
-        select.selectByValue(credentialsId);
-        LOGGER.log(Level.INFO, "Three:");
+        new Select(this.credentialsId.resolve()).selectByValue(credentialsId);
         return this;
     }
 

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -6,8 +6,10 @@ import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.URL;
 import java.util.logging.Level;
@@ -31,20 +33,22 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     public BitbucketScmConfig bitbucketScmJenkinsFileSource() {
         select("Pipeline script from SCM");
         select("Bitbucket Server");
+        ExpectedCondition<WebElement> refreshed =
+                ExpectedConditions.refreshed(ExpectedConditions.presenceOfElementLocated(by.id("yui-gen13")));
+        WebDriverWait wait = new WebDriverWait(driver, 5);
+        wait.until(refreshed);
         return new BitbucketScmConfig(this, "/definition/scm");
     }
 
     private void select(final String option) {
-        LOGGER.log(Level.INFO, "Zero:");
         WebElement dropdownOption = find(by.option(option));
-        LOGGER.log(Level.INFO, "First "  + isStale(dropdownOption));
         // Get the parent dropdown
         WebElement dropdownBox = dropdownOption
                 .findElement(By.xpath("./parent::select[@class='jenkins-select__input dropdownList']"));
-        LOGGER.log(Level.INFO, "Second "  + isStale(dropdownOption));
+
         Select dropdownSelect = new Select(dropdownBox);
-        LOGGER.log(Level.INFO, "Third "  + isStale(dropdownOption));
+
         dropdownSelect.selectByVisibleText(option);
-        LOGGER.log(Level.INFO, "Fourth "  + isStale(dropdownOption));
+
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -1,21 +1,14 @@
 package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 
-import com.atlassian.plugin.util.WaitUntil;
 import com.google.inject.Injector;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static java.time.Duration.ofSeconds;
 
 /**
  * A {@link WorkflowJob workflow (a.k.a. pipeline) job} that uses a Bitbucket Server SCM to fetch the
@@ -24,8 +17,6 @@ import static java.time.Duration.ofSeconds;
 @Describable("org.jenkinsci.plugins.workflow.job.WorkflowJob")
 public class BitbucketScmWorkflowJob extends WorkflowJob {
 
-    private static final Logger LOGGER = Logger.getLogger(BitbucketScmWorkflowJob.class.getName());
-
     public BitbucketScmWorkflowJob(Injector injector, URL url, String name) {
         super(injector, url, name);
     }
@@ -33,6 +24,8 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     public BitbucketScmConfig bitbucketScmJenkinsFileSource() {
         select("Pipeline script from SCM");
         select("Bitbucket Server");
+        // "yui-gen13" is the ID of the "Test Connection" button. Once this has loaded on the page, it's safe to
+        // select other elements without getting a StaleElementReferenceException
         ExpectedCondition<WebElement> refreshed =
                 ExpectedConditions.refreshed(ExpectedConditions.presenceOfElementLocated(by.id("yui-gen13")));
         WebDriverWait wait = new WebDriverWait(driver, 5);
@@ -41,14 +34,6 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     }
 
     private void select(final String option) {
-        WebElement dropdownOption = find(by.option(option));
-        // Get the parent dropdown
-        WebElement dropdownBox = dropdownOption
-                .findElement(By.xpath("./parent::select[@class='jenkins-select__input dropdownList']"));
-
-        Select dropdownSelect = new Select(dropdownBox);
-
-        dropdownSelect.selectByVisibleText(option);
-
+        find(by.option(option)).click();
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -1,5 +1,6 @@
 package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 
+import com.atlassian.plugin.util.WaitUntil;
 import com.google.inject.Injector;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
@@ -34,6 +35,7 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     }
 
     private void select(final String option) {
+        LOGGER.log(Level.INFO, "Zero:");
         WebElement dropdownOption = find(by.option(option));
         LOGGER.log(Level.INFO, "First "  + isStale(dropdownOption));
         // Get the parent dropdown

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -9,6 +9,10 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
 import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.time.Duration.ofSeconds;
 
 /**
  * A {@link WorkflowJob workflow (a.k.a. pipeline) job} that uses a Bitbucket Server SCM to fetch the
@@ -16,6 +20,8 @@ import java.net.URL;
  */
 @Describable("org.jenkinsci.plugins.workflow.job.WorkflowJob")
 public class BitbucketScmWorkflowJob extends WorkflowJob {
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketScmWorkflowJob.class.getName());
 
     public BitbucketScmWorkflowJob(Injector injector, URL url, String name) {
         super(injector, url, name);
@@ -29,12 +35,14 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
 
     private void select(final String option) {
         WebElement dropdownOption = find(by.option(option));
-        waitFor(ExpectedConditions.stalenessOf(dropdownOption));
-        dropdownOption = find(by.option(option));
+        LOGGER.log(Level.INFO, "First "  + isStale(dropdownOption));
         // Get the parent dropdown
         WebElement dropdownBox = dropdownOption
                 .findElement(By.xpath("./parent::select[@class='jenkins-select__input dropdownList']"));
+        LOGGER.log(Level.INFO, "Second "  + isStale(dropdownOption));
         Select dropdownSelect = new Select(dropdownBox);
+        LOGGER.log(Level.INFO, "Third "  + isStale(dropdownOption));
         dropdownSelect.selectByVisibleText(option);
+        LOGGER.log(Level.INFO, "Fourth "  + isStale(dropdownOption));
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -5,6 +5,7 @@ import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
 import java.net.URL;
@@ -28,6 +29,8 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
 
     private void select(final String option) {
         WebElement dropdownOption = find(by.option(option));
+        waitFor(ExpectedConditions.stalenessOf(dropdownOption));
+        dropdownOption = find(by.option(option));
         // Get the parent dropdown
         WebElement dropdownBox = dropdownOption
                 .findElement(By.xpath("./parent::select[@class='jenkins-select__input dropdownList']"));

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -3,6 +3,9 @@ package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 import com.google.inject.Injector;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
 
 import java.net.URL;
 
@@ -24,6 +27,11 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     }
 
     private void select(final String option) {
-        find(by.option(option)).click();
+        WebElement dropdownOption = find(by.option(option));
+        // Get the parent dropdown
+        WebElement dropdownBox = dropdownOption
+                .findElement(By.xpath("./parent::select[@class='jenkins-select__input dropdownList']"));
+        Select dropdownSelect = new Select(dropdownBox);
+        dropdownSelect.selectByVisibleText(option);
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
@@ -32,9 +32,7 @@ public class BitbucketScmWorkflowMultiBranchJob extends WorkflowMultiBranchJob {
         try {
             super.reIndex();
         } catch (NoSuchElementException e) {
-
             find(by.xpath("//*[text()=\"Scan Multibranch Pipeline Now\"]/ancestor::A")).click();
-            //find(by.xpath("//div[@class=\"task \"]//*[text()=\"Scan Multibranch Pipeline Now\"]")).click();
         }
     }
 

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowMultiBranchJob.java
@@ -32,10 +32,9 @@ public class BitbucketScmWorkflowMultiBranchJob extends WorkflowMultiBranchJob {
         try {
             super.reIndex();
         } catch (NoSuchElementException e) {
-            // JENKINS-63044
-            // This selector is out of date as of Jenkins 2.249.1
-            // find(by.xpath("//div[@class=\"task\"]//*[text()=\"Scan Multibranch Pipeline Now\"]")).click();
-            find(by.xpath("//a[@title=\"Scan Multibranch Pipeline Now\"]")).click();
+
+            find(by.xpath("//*[text()=\"Scan Multibranch Pipeline Now\"]/ancestor::A")).click();
+            //find(by.xpath("//div[@class=\"task \"]//*[text()=\"Scan Multibranch Pipeline Now\"]")).click();
         }
     }
 

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
@@ -193,7 +193,7 @@ public class SmokeTest extends AbstractJUnitTest {
     @Test
     @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
     // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
-    // Jenkins version (v2.319) we are using or the LTS (v2.319.1). Jenkins version should be >= v2.323 for v1.109 of
+    // Jenkins version (v2.387) we are using or the LTS (v2.387.1). Jenkins version should be >= v2.323 for v1.109 of
     // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
     // acceptance-test-harness.
     public void testRunBuildActionWtihFreestlyeJob() throws Exception {

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/SmokeTest.java
@@ -193,7 +193,7 @@ public class SmokeTest extends AbstractJUnitTest {
     @Test
     @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
     // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
-    // Jenkins version (v2.387) we are using or the LTS (v2.387.1). Jenkins version should be >= v2.323 for v1.109 of
+    // Jenkins version (v2.375) we are using or the LTS (v2.375.4). Jenkins version should be >= v2.323 for v1.109 of
     // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
     // acceptance-test-harness.
     public void testRunBuildActionWtihFreestlyeJob() throws Exception {

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
@@ -75,7 +75,7 @@ public class ThreeLeggedOAuthAcceptanceTest extends AbstractJUnitTest {
     @Test
     @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
     // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
-    // Jenkins version (v2.319) we are using or the LTS (v2.319.1). Jenkins version should be >= v2.323 for v1.109 of
+    // Jenkins version (v2.387) we are using or the LTS (v2.387.1). Jenkins version should be >= v2.323 for v1.109 of
     // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
     // acceptance-test-harness.
     public void testAuthorize() {

--- a/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/applink/oauth/ThreeLeggedOAuthAcceptanceTest.java
@@ -75,7 +75,7 @@ public class ThreeLeggedOAuthAcceptanceTest extends AbstractJUnitTest {
     @Test
     @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/721")
     // This issue is fixed in the v1.109 of acceptance-test-harness but that version is not compatible with current
-    // Jenkins version (v2.387) we are using or the LTS (v2.387.1). Jenkins version should be >= v2.323 for v1.109 of
+    // Jenkins version (v2.375) we are using or the LTS (v2.375.4). Jenkins version should be >= v2.323 for v1.109 of
     // the acceptance-test-harness. This test can be enabled when we are able to upgrade to v1.109 of
     // acceptance-test-harness.
     public void testAuthorize() {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.42</version>
+        <version>4.56</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -16,8 +16,7 @@
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
-        <java.level>11</java.level>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
         <jenkins.version>2.387.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -106,13 +105,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.14</version>
+            <version>4.4.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.2</version>
-            <scope>provided</scope>
+            <version>142.v04572ca_5b_265</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -296,7 +295,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.56</version>
+        <version>4.42</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -18,7 +18,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.14.2</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
-        <jenkins.version>2.387.1</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -41,8 +41,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>1887.vda_d0ddb_c15c4</version>
+                <artifactId>bom-2.375.x</artifactId>
+                <version>1948.veb_1fd345d3a_e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.5.1</version>
+            <version>4.4.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.level>8</java.level>
         <jackson.version>2.13.4</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -42,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1539.v6a_85813638f8</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>1887.vda_d0ddb_c15c4</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
-        <java.level>8</java.level>
+        <java.level>11</java.level>
         <jackson.version>2.13.4</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
         <jenkins.version>2.387.1</jenkins.version>

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,10 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 3.3.4 (24 March 2023)
+- The minimum version of Jenkins changed to be **2.387.1**
+- The minimum supported version of BitBucket changed to be **6.0**
+
 ### 3.3.3 (9 January 2023)
 - The minimum version of Jenkins changed to be **2.319.3**
 - Now compatible with Jenkins 2.382

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.387.1+
+- Jenkins 2.375.4+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 6.0 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
@@ -221,7 +221,7 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ## Changelog
 
 ### 3.3.4 (24 March 2023)
-- The minimum version of Jenkins changed to be **2.387.1**
+- The minimum version of Jenkins changed to be **2.375.4**
 - The minimum supported version of BitBucket changed to be **6.0**
 
 ### 3.3.3 (9 January 2023)

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The plugin streamlines the entire configuration process and removes the need for
 - Jenkins 2.387.1+
 - Bitbucket Server 7.4+
 
-Note: Bitbucket Server 5.5 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
+Note: Bitbucket Server 6.0 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
 
 ## In this document
 1. [Install the plugin](#install-the-plugin)

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.319.3+
+- Jenkins 2.387.1+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 5.5 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtils.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtils.java
@@ -45,7 +45,8 @@ public class TestUtils {
     public static String readFileToString(String relativeFilename) {
         try {
             return new String(
-                    readAllBytes(Paths.get(TestUtils.class.getResource(relativeFilename).toURI())));
+                    readAllBytes(Paths.get(TestUtils.class.getResource(relativeFilename).toURI())))
+                    .replaceAll("\\r\\n?", "\n"); // Normalize line endings between operating systems
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
@@ -1,0 +1,31 @@
+package com.atlassian.bitbucket.jenkins.internal.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUtilsTest {
+
+    @Test
+    public void testReadFileToStringLfLineEndings() {
+        String lfEndings = "This\n" +
+                           "File\n" +
+                           "Has\n" +
+                           "LF\n" +
+                           "Line\n" +
+                           "Endings";
+        // The file should be unchanged since it already has LF endings.
+        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/lf-line-endings.txt"));
+    }
+
+    @Test
+    public void testReadFileToStringCrLineEndings() {
+        String lfEndings =   "This\n" +
+                             "File\n" +
+                             "Has\n" +
+                             "CR\n" +
+                             "Line\n" +
+                             "Endings";
+        // The CRs should be removed from the file.
+        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/cr-line-endings.txt"));
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestUtilsTest {
+
     @Test
     public void testReadFileToStringCrLineEndings() {
         String lfEndings =   "This\n" +

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
@@ -1,20 +1,21 @@
 package com.atlassian.bitbucket.jenkins.internal.util;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestUtilsTest {
 
     @Test
     public void testReadFileToStringCrLineEndings() {
-        String lfEndings =   "This\n" +
-                             "File\n" +
-                             "Has\n" +
-                             "CR\n" +
-                             "Line\n" +
-                             "Endings";
+        String lfEndings = "This\n" +
+                           "File\n" +
+                           "Has\n" +
+                           "CR\n" +
+                           "Line\n" +
+                           "Endings";
         // The CRs should be removed from the file.
-        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/cr-line-endings.txt"));
+        assertEquals(lfEndings, TestUtils.readFileToString("/cr-line-endings.txt"));
     }
 
     @Test
@@ -26,6 +27,6 @@ public class TestUtilsTest {
                            "Line\n" +
                            "Endings";
         // The file should be unchanged since it already has LF endings.
-        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/lf-line-endings.txt"));
+        assertEquals(lfEndings, TestUtils.readFileToString("/lf-line-endings.txt"));
     }
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/TestUtilsTest.java
@@ -4,6 +4,17 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestUtilsTest {
+    @Test
+    public void testReadFileToStringCrLineEndings() {
+        String lfEndings =   "This\n" +
+                             "File\n" +
+                             "Has\n" +
+                             "CR\n" +
+                             "Line\n" +
+                             "Endings";
+        // The CRs should be removed from the file.
+        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/cr-line-endings.txt"));
+    }
 
     @Test
     public void testReadFileToStringLfLineEndings() {
@@ -15,17 +26,5 @@ public class TestUtilsTest {
                            "Endings";
         // The file should be unchanged since it already has LF endings.
         Assert.assertEquals(lfEndings,TestUtils.readFileToString("/lf-line-endings.txt"));
-    }
-
-    @Test
-    public void testReadFileToStringCrLineEndings() {
-        String lfEndings =   "This\n" +
-                             "File\n" +
-                             "Has\n" +
-                             "CR\n" +
-                             "Line\n" +
-                             "Endings";
-        // The CRs should be removed from the file.
-        Assert.assertEquals(lfEndings,TestUtils.readFileToString("/cr-line-endings.txt"));
     }
 }

--- a/src/test/resources/cr-line-endings.txt
+++ b/src/test/resources/cr-line-endings.txt
@@ -1,0 +1,1 @@
+ThisFileHasCRLineEndings

--- a/src/test/resources/lf-line-endings.txt
+++ b/src/test/resources/lf-line-endings.txt
@@ -1,0 +1,6 @@
+This
+File
+Has
+LF
+Line
+Endings


### PR DESCRIPTION
Bumping the Jenkins version to resolve [vulnerabilities](https://www.jenkins.io/security/advisory/2023-03-08/).

Updated the readme with steps to run the acceptance tests on macOS.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
