### PR TITLE
Enable fetch polyfill for test harness web client

### DIFF
--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketJenkinsRule.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketJenkinsRule.java
@@ -55,6 +55,8 @@ public class BitbucketJenkinsRule extends JenkinsRule {
 
     public BitbucketJenkinsRule() {
         webClient = createWebClient();
+        // Enable fetch polyfill so tests can use js fetch API
+        webClient.getOptions().setFetchPolyfillEnabled(true);
         LOGGER.setLevel(Level.INFO);
     }
 


### PR DESCRIPTION
In the most recent version of Jenkins, `Ajax.Request` usage has been removed in favor of the JavaScript fetch API (e.g. [combobox.js](https://github.com/jenkinsci/jenkins/pull/7900/files)).

This PR enables the fetch polyfill for the test harness web client, ensuring tests are compatible with newer Jenkins versions.