### PR TITLE
Fix addPathSegment on scmFile.getFilePath

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClientImpl.java
@@ -57,7 +57,7 @@ public class BitbucketFilePathClientImpl implements BitbucketFilePathClient {
                 .addPathSegment("repos")
                 .addPathSegment(repositorySlug)
                 .addPathSegment("raw")
-                .addPathSegment(scmFile.getFilePath());
+                .addPathSegments(scmFile.getFilePath());
         scmFile.getRef().map(ref -> urlBuilder.addQueryParameter("at", ref));
         HttpUrl url = urlBuilder.build();
 


### PR DESCRIPTION
Fix "Invalid URI: noSlash" on scenario where the "jenkinsfile" file is on a subpath.

Sorry for not following the checklist but I believe the fix is simple to understand and probably a bug introduced by mistake on the last refactoring done for version 3.4.0.