### PR TITLE
The minimum version of Jenkins changed to be 2.401.1

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -17,9 +17,9 @@
         <jenkins.acceptance-test-harness.version>5504.v485694f31cdf</jenkins.acceptance-test-harness.version>
         <bitbucket.version>7.21.9</bitbucket.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jenkins.version>2.375.4</jenkins.version>
+        <jenkins.version>2.401.1</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
-        <jackson.version>2.10.3</jackson.version>
+        <jackson.version>2.15.1</jackson.version>
         <groovy.version>3.0.7</groovy.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <jgit.version>4.5.7.201904151645-r</jgit.version>

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -24,10 +24,11 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     public BitbucketScmConfig bitbucketScmJenkinsFileSource() {
         select("Pipeline script from SCM");
         select("Bitbucket Server");
-        // "yui-gen13" is the ID of the "Test Connection" button. Once this has loaded on the page, it's safe to
-        // select other elements without getting a StaleElementReferenceException
+        // Once the "Test Connection" button has loaded on the page, it's safe
+        // to select other elements without getting a StaleElementReferenceException
         ExpectedCondition<WebElement> refreshed =
-                ExpectedConditions.refreshed(ExpectedConditions.presenceOfElementLocated(by.id("yui-gen13")));
+                ExpectedConditions.refreshed(
+                        ExpectedConditions.presenceOfElementLocated(by.button("Test Connection")));
         WebDriverWait wait = new WebDriverWait(driver, 5);
         wait.until(refreshed);
         return new BitbucketScmConfig(this, "/definition/scm");

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -3,6 +3,7 @@ package it.com.atlassian.bitbucket.jenkins.internal.pageobjects;
 import com.google.inject.Injector;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -24,17 +25,25 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
     public BitbucketScmConfig bitbucketScmJenkinsFileSource() {
         select("Pipeline script from SCM");
         select("Bitbucket Server");
+
         // Once the "Test Connection" button has loaded on the page, it's safe
         // to select other elements without getting a StaleElementReferenceException
-        ExpectedCondition<WebElement> refreshed =
-                ExpectedConditions.refreshed(
-                        ExpectedConditions.presenceOfElementLocated(by.button("Test connection")));
-        WebDriverWait wait = new WebDriverWait(driver, 5);
-        wait.until(refreshed);
+        waitForPresence(by.button("Test connection"));
+
         return new BitbucketScmConfig(this, "/definition/scm");
     }
 
     private void select(final String option) {
-        find(by.option(option)).click();
+        // Wait for the option to be present befor clicking it
+        By selector = by.option(option);
+        waitForPresence(selector);
+        find(selector).click();
+    }
+
+    private void waitForPresence(By selector) {
+        ExpectedCondition<WebElement> refreshed = ExpectedConditions
+                .refreshed(ExpectedConditions.presenceOfElementLocated(selector));
+        WebDriverWait wait = new WebDriverWait(driver, 5);
+        wait.until(refreshed);
     }
 }

--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketScmWorkflowJob.java
@@ -28,7 +28,7 @@ public class BitbucketScmWorkflowJob extends WorkflowJob {
         // to select other elements without getting a StaleElementReferenceException
         ExpectedCondition<WebElement> refreshed =
                 ExpectedConditions.refreshed(
-                        ExpectedConditions.presenceOfElementLocated(by.button("Test Connection")));
+                        ExpectedConditions.presenceOfElementLocated(by.button("Test connection")));
         WebDriverWait wait = new WebDriverWait(driver, 5);
         wait.until(refreshed);
         return new BitbucketScmConfig(this, "/definition/scm");

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.1</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
-        <jenkins.version>2.375.4</jenkins.version>
+        <jenkins.version>2.401.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -41,8 +41,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.375.x</artifactId>
-                <version>1948.veb_1fd345d3a_e</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2102.v854b_fec19c92</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>atlassian-bitbucket-server-integration</artifactId>
-    <version>3.4.3-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <bitbucket.version>6.10.15</bitbucket.version>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The plugin streamlines the entire configuration process and removes the need for
 
 ## Requirements
 
-- Jenkins 2.375.4+
+- Jenkins 2.401.1+
 - Bitbucket Server 7.4+
 
 Note: Bitbucket Server 6.0 to 7.3 are also supported, but they're not recommended. This is because some plugin features are not available when using these versions. Instead, we recommend using Bitbucket Server 7.4+. With 7.0+ you can make use of pull request triggers for jobs. With 7.4+ you can set up an Application Link to have access to all plugin features.
@@ -219,6 +219,9 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ---
 
 ## Changelog
+
+### 3.5.0
+- The minimum version of Jenkins changed to be **2.401.1**
 
 ### 3.4.2 (6 June 2023)
 - Fix JENKINS-71363 streaming support for Jenkinsfiles not in root directory


### PR DESCRIPTION
This fixes https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/security/dependabot/37