### PR TITLE
Use event heads in PR discovery handler if present

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
@@ -11,11 +11,11 @@ import java.util.stream.Stream;
  * or processing a {@link BitbucketSCMSourceRequest request}.
  */
 public interface BitbucketSCMHeadDiscoveryHandler {
-    
+
     /**
      * @return as stream of {@link SCMHead heads} to be used for processing the source request
      */
-    Stream<SCMHead> discoverHeads();
+    Stream<? extends SCMHead> discoverHeads();
 
     /**
      * Creates a {@link SCMRevision revision} for the specified head.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.TaskListener;
+import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
@@ -18,14 +19,17 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
 
     private final Credentials credentials;
     private final Collection<BitbucketSCMHeadDiscoveryHandler> discoveryHandlers = new ArrayList<>();
+    private final Collection<SCMHead> eventHeads;
     private final BitbucketSCMRepository repository;
 
     public BitbucketSCMSourceContext(@CheckForNull SCMSourceCriteria criteria,
                                      SCMHeadObserver observer,
                                      @CheckForNull Credentials credentials,
+                                     Collection<SCMHead> eventHeads,
                                      BitbucketSCMRepository repository) {
         super(criteria, observer);
         this.credentials = credentials;
+        this.eventHeads = requireNonNull(eventHeads, "eventHeads");
         this.repository = requireNonNull(repository, "repository");
     }
 
@@ -36,6 +40,10 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
 
     public Collection<BitbucketSCMHeadDiscoveryHandler> getDiscoveryHandlers() {
         return Collections.unmodifiableCollection(discoveryHandlers);
+    }
+
+    public Collection<SCMHead> getEventHeads() {
+        return Collections.unmodifiableCollection(eventHeads);
     }
 
     @Override


### PR DESCRIPTION
Lets the PR discovery handler avoid having to fetch all open PRs if the retrieve was triggered by a webhook event. This is done via the following changes
* Pass the heads from `SCMHeadEvent#heads` into the `BitbucketSCMSourceContext`
* Update `BitbucketPullRequestDiscoveryTrait#decorateContext` so that it checks if the context has the "event heads"
* If event, heads are present simply use these as the return value for `BitbucketSCMHeadDiscoveryHandler#discoverHeads()`
* Otherwise, fetch all open PRs from Bitbucket