### PR TITLE
Use PR source branch for build status

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
@@ -44,9 +44,13 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
                 BitbucketPullRequestSCMHead prHead = (BitbucketPullRequestSCMHead) prRevision.getHead();
 
                 // The BitbucketPullRequestSCMHead uses the PR id as the head name, so we need to use a custom
-                // refspec to be able to map to the correct PR refs
+                // refspec to be able to map to the correct PR refs during checkout.
                 gitSCMBuilder.withRefSpec("+refs/heads/" + prHead.getOriginName() +
                         ":refs/remotes/@{remote}/" + prHead.getName());
+
+                // Additionally, we also need to add the source branch name the underlying GitSCM's environment
+                // so it can be easily referenced if needed.
+                gitSCMBuilder.withExtension(new BitbucketPullRequestSourceBranch(prHead.getPullRequest()));
 
                 // Use the merge checkout strategy if the head specifies it
                 if (prHead.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
@@ -1,0 +1,29 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Adds the pull request origin branch to the underlying {@link GitSCM} environment variables.
+ *
+ * @since 4.0.0
+ */
+public class BitbucketPullRequestSourceBranch extends GitSCMExtension {
+
+    public static final String PULL_REQUEST_SOURCE_BRANCH = "PULL_REQUEST_SOURCE_BRANCH";
+
+    private final MinimalPullRequest pullRequest;
+
+    public BitbucketPullRequestSourceBranch(MinimalPullRequest pullRequest) {
+        this.pullRequest = requireNonNull(pullRequest, "pullRequest");
+    }
+
+    @Override
+    public void populateEnvironmentVariables(GitSCM scm, Map<String, String> env) {
+        env.put(PULL_REQUEST_SOURCE_BRANCH, pullRequest.getFromRefDisplayId());
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_BRANCH;
+
 @Extension
 public class LocalSCMListener extends SCMListener {
 
@@ -98,7 +100,9 @@ public class LocalSCMListener extends SCMListener {
         Map<String, String> env = new HashMap<>();
         underlyingScm.buildEnvironment(build, env);
 
-        String branch = env.get(GitSCM.GIT_BRANCH);
+        String branch = env.containsKey(PULL_REQUEST_SOURCE_BRANCH) ?
+                env.get(PULL_REQUEST_SOURCE_BRANCH) :
+                env.get(GitSCM.GIT_BRANCH);
         String refName = branch != null ? underlyingScm.deriveLocalBranchName(branch) : null;
         BitbucketRevisionAction revisionAction =
                 new BitbucketRevisionAction(bitbucketSCMRepository, refName, env.get(GitSCM.GIT_COMMIT));

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -126,7 +127,8 @@ public class BitbucketPullRequestDiscoveryTraitTest {
         underTest.decorateBuilder(scmBuilder);
 
         assertThat(scmBuilder.refSpecs().get(0), equalTo("+refs/heads/from:refs/remotes/@{remote}/PR-1"));
-        MergeWithGitSCMExtension mergeExtension = (MergeWithGitSCMExtension) scmBuilder.extensions().get(0);
+        assertThat(scmBuilder.extensions().get(0), instanceOf(BitbucketPullRequestSourceBranch.class));
+        MergeWithGitSCMExtension mergeExtension = (MergeWithGitSCMExtension) scmBuilder.extensions().get(1);
         assertThat(mergeExtension.getBaseName(), equalTo("to"));
         assertThat(mergeExtension.getBaseHash(), equalTo("toCommit"));
     }


### PR DESCRIPTION
The new `BitbucketPullRequestSCMHead` uses `PR-{id}` as the format for the head name. This means that when the build status is posted back to bitbucket it uses that as the ref name. This PR modifies this so that it uses the PR source branch instead.