### PR TITLE
JENKINS-71289 create correct ref name for tags when posting build status

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketBuildStatusFactoryImpl.java
@@ -58,7 +58,7 @@ public final class BitbucketBuildStatusFactoryImpl implements BitbucketBuildStat
                 .setParent(isMultibranch ? parent.getFullName() : job.getFullName());
 
         if (revisionAction != null) {
-            bbs.setRef(revisionAction.getBranchAsRefFormat());
+            bbs.setRef(revisionAction.getRefName());
         }
 
         if (state != BuildState.INPROGRESS) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketRevisionAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BitbucketRevisionAction.java
@@ -5,20 +5,38 @@ import hudson.model.Action;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 public class BitbucketRevisionAction implements Action {
 
-    public static final String REF_PREFIX = "refs/heads/";
-
     private final BitbucketSCMRepository bitbucketSCMRepository;
-    private final String branchName;
+    private final String refName;
     private final String revisionSha1;
 
-    public BitbucketRevisionAction(BitbucketSCMRepository bitbucketSCMRepository, @Nullable String branchName,
+    public BitbucketRevisionAction(BitbucketSCMRepository bitbucketSCMRepository, @Nullable String refName,
                                    String revisionSha1) {
         this.bitbucketSCMRepository = bitbucketSCMRepository;
-        this.branchName = branchName;
+        this.refName = refName;
         this.revisionSha1 = revisionSha1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BitbucketRevisionAction that = (BitbucketRevisionAction) o;
+        return Objects.equals(bitbucketSCMRepository, that.bitbucketSCMRepository) &&
+               Objects.equals(refName, that.refName) &&
+               Objects.equals(revisionSha1, that.revisionSha1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bitbucketSCMRepository, refName, revisionSha1);
     }
 
     @CheckForNull
@@ -38,13 +56,8 @@ public class BitbucketRevisionAction implements Action {
     }
 
     @CheckForNull
-    public String getBranchName() {
-        return branchName;
-    }
-
-    @CheckForNull
-    public String getBranchAsRefFormat() {
-        return branchName != null ? REF_PREFIX + branchName : null;
+    public String getRefName() {
+        return refName;
     }
 
     public String getRevisionSha1() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPoster.java
@@ -93,7 +93,7 @@ public class BuildStatusPoster extends RunListener<Run<?, ?>> {
                     .getBuildStatusClient(revisionAction.getRevisionSha1())
                     .post(buildStatusBuilder, buildStatus -> 
                             listener.getLogger().println(String.format(BUILD_STATUS_FORMAT,
-                            buildStatus, server.getServerName(), revisionAction.getRevisionSha1(), buildStatus.getRef())));
+                            buildStatus.getState(), server.getServerName(), revisionAction.getRevisionSha1(), buildStatus.getRef())));
 
         } catch (RuntimeException e) {
             String errorMsg = BUILD_STATUS_ERROR_MSG + ' ' + e.getMessage();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -115,7 +115,7 @@ public class LocalSCMListener extends SCMListener {
             return null;
         }
 
-        // The GitSCM will treat the tag as a branch with a fully justified name, so if refs/tags/ is present,
+        // The GitSCM will treat the tag as a branch with a fully qualified name, so if refs/tags/ is present,
         // the name needs no further processing.
         if (refId.startsWith(TAG_PREFIX)) {
             return refId;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -7,7 +7,6 @@ import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
-import com.iwombat.util.StringUtil;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -17,7 +16,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.util.DescribableList;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.libs.FolderLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMRetriever;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -7,6 +7,7 @@ import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.iwombat.util.StringUtil;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -16,6 +17,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.util.DescribableList;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.libs.FolderLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
@@ -29,6 +31,9 @@ import java.util.Map;
 
 @Extension
 public class LocalSCMListener extends SCMListener {
+
+    public static final String BRANCH_PREFIX = "refs/heads/";
+    public static final String TAG_PREFIX = "refs/tags/";
 
     private BuildStatusPoster buildStatusPoster;
     private GlobalLibrariesProvider librariesProvider;
@@ -98,12 +103,28 @@ public class LocalSCMListener extends SCMListener {
         Map<String, String> env = new HashMap<>();
         underlyingScm.buildEnvironment(build, env);
 
-        String branch = env.get(GitSCM.GIT_BRANCH);
-        String refName = branch != null ? underlyingScm.deriveLocalBranchName(branch) : null;
-        BitbucketRevisionAction revisionAction =
-                new BitbucketRevisionAction(bitbucketSCMRepository, refName, env.get(GitSCM.GIT_COMMIT));
+        String refName = getRefFromEnvironment(env, underlyingScm);
+        BitbucketRevisionAction revisionAction = new BitbucketRevisionAction(bitbucketSCMRepository, refName, env.get(GitSCM.GIT_COMMIT));
         build.addAction(revisionAction);
         buildStatusPoster.postBuildStatus(revisionAction, build, listener);
+    }
+
+    @CheckForNull
+    private String getRefFromEnvironment(Map<String, String> env, GitSCM scm) {
+        String refId = StringUtils.stripToNull(env.get(GitSCM.GIT_BRANCH));
+        if (refId == null) {
+            return null;
+        }
+
+        // The GitSCM will treat the tag as a branch with a fully justified name, so if refs/tags/ is present,
+        // the name needs no further processing.
+        if (refId.startsWith(TAG_PREFIX)) {
+            return refId;
+        }
+
+        // Branches are in the form of the result of a git fetch, prepended with the repository name. The Git SCM
+        // can strip the repo name (if it's found in the list of remote configs), and we append refs/heads afterwards.
+        return BRANCH_PREFIX + scm.deriveLocalBranchName(refId);
     }
 
     private boolean isFolderLib(Folder folder, SCM scm) {


### PR DESCRIPTION
When Jenkins receives branches, they arrive in the form provided by a git fetch in the form `remotes/reponame/branchname`, which the GitSCM resolves to a simple branch name. Tags however appear in the form `refs/tags/tagname` and the GitSCM does not resolve provide a facility for this to be resolved- consequently when we receive the tag, we attempt to reduce it to a branch name and then blindly append `refs/heads` to it, causing an invalid identifier.

This change checks the `GIT_BRANCH` variable to determine if the value is a tag- if it does, it passes it along as normal, otherwise processes the branch name as it did before.

While I was here, I also addressed the issue of the logs attempting to print the entire build status to the listener rather than the state, so in the console logs of a build, instead of:
`Posting build status of com.atlassian.bitbucket.jenkins.internal.model.BitbucketBuildStatus@6047f7a9 to Bitbucket Local for commit id [c7f921db7492a756fb7897e69c3d2e59243d86e2] and ref 'refs/tags/v300`
we now see
`Posting build status of INPROGRESS to Bitbucket Local for commit id [c7f921db7492a756fb7897e69c3d2e59243d86e2] and ref 'refs/tags/v300'`