### PR TITLE
Fix merge direction

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
@@ -8,8 +8,9 @@ import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfigurat
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestState;
 import hudson.Extension;
+import hudson.plugins.git.UserMergeOptions;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import jenkins.plugins.git.GitSCMBuilder;
-import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
@@ -17,6 +18,7 @@ import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.inject.Inject;
@@ -56,8 +58,13 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
                 if (prHead.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
                     BitbucketSCMRevision targetRevision = (BitbucketSCMRevision) prRevision.getTarget();
                     SCMHead targetHead = targetRevision.getHead();
-                    gitSCMBuilder.withExtension(new MergeWithGitSCMExtension(targetHead.getName(),
-                            targetRevision.getCommitHash()));
+
+                    UserMergeOptions mergeOptions = new UserMergeOptions(gitSCMBuilder.remoteName(),
+                            targetHead.getName(),
+                            MergeCommand.Strategy.DEFAULT.toString(),
+                            MergeCommand.GitPluginFastForwardMode.FF);
+
+                    gitSCMBuilder.withExtension(new PreBuildMerge(mergeOptions));
                 }
             }
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
@@ -15,6 +15,7 @@ import static java.util.Objects.requireNonNull;
 public class BitbucketPullRequestSourceBranch extends GitSCMExtension {
 
     public static final String PULL_REQUEST_SOURCE_BRANCH = "PULL_REQUEST_SOURCE_BRANCH";
+    public static final String PULL_REQUEST_SOURCE_COMMIT = "PULL_REQUEST_SOURCE_COMMIT";
 
     private final MinimalPullRequest pullRequest;
 
@@ -25,5 +26,6 @@ public class BitbucketPullRequestSourceBranch extends GitSCMExtension {
     @Override
     public void populateEnvironmentVariables(GitSCM scm, Map<String, String> env) {
         env.put(PULL_REQUEST_SOURCE_BRANCH, pullRequest.getFromRefDisplayId());
+        env.put(PULL_REQUEST_SOURCE_COMMIT, pullRequest.getFromLatestCommit());
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -115,7 +115,8 @@ public class LocalSCMListener extends SCMListener {
     private String getCommitFromEnvironment(Map<String, String> env) {
         // Pull requests may be built using a merge between the source and target branches which could result in a new
         // commit for the merge. This new merge commit will not exist in Bitbucket, so we need to use the pull request
-        // source commit when posting the build status so that Bitbucket can correctly resolve it.
+        // source commit when posting the build status so that Bitbucket can correctly resolve the build to the correct
+        // commit.
         String commit = env.get(PULL_REQUEST_SOURCE_COMMIT);
         if (commit == null) {
             commit = env.get(GitSCM.GIT_COMMIT);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -113,7 +113,7 @@ public class LocalSCMListener extends SCMListener {
     }
 
     private String getCommitFromEnvironment(Map<String, String> env) {
-        // Pull request may be built using a merge between the source and target branches which could result in a new
+        // Pull requests may be built using a merge between the source and target branches which could result in a new
         // commit for the merge. This new merge commit will not exist in Bitbucket, so we need to use the pull request
         // source commit when posting the build status so that Bitbucket can correctly resolve it.
         String commit = env.get(PULL_REQUEST_SOURCE_COMMIT);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
@@ -10,13 +10,14 @@ import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.*;
 import com.cloudbees.plugins.credentials.Credentials;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import jenkins.plugins.git.GitSCMBuilder;
-import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -130,9 +131,12 @@ public class BitbucketPullRequestDiscoveryTraitTest {
 
         assertThat(scmBuilder.refSpecs().get(0), equalTo("+refs/heads/from:refs/remotes/@{remote}/PR-1"));
         assertThat(scmBuilder.extensions().get(0), instanceOf(BitbucketPullRequestSourceBranch.class));
-        MergeWithGitSCMExtension mergeExtension = (MergeWithGitSCMExtension) scmBuilder.extensions().get(1);
-        assertThat(mergeExtension.getBaseName(), equalTo("to"));
-        assertThat(mergeExtension.getBaseHash(), equalTo("toCommit"));
+
+        PreBuildMerge mergeBuild = (PreBuildMerge) scmBuilder.extensions().get(1);
+        assertThat(mergeBuild.getOptions().getMergeRemote(), equalTo("origin"));
+        assertThat(mergeBuild.getOptions().getMergeTarget(), equalTo("to"));
+        assertThat(mergeBuild.getOptions().getMergeStrategy(), equalTo(MergeCommand.Strategy.DEFAULT));
+        assertThat(mergeBuild.getOptions().getFastForwardMode(), equalTo(MergeCommand.GitPluginFastForwardMode.FF));
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_BRANCH;
+import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_COMMIT;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.*;
@@ -49,6 +50,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     private static final String GIT_TAG_VALUE = "refs/tags/v.1.0.0";
     private static final String PR_BRANCH_NAME = "prsourcebranch";
     private static final String PR_BRANCH_VALUE = "origin/prsourcebranch";
+    private static final String PR_COMMIT_VALUE = "1041ad01cafa9cb2832a2f53c9bc2ba3dc15a582";
 
     private final Map<String, String> buildMap = new HashMap<>();
     @Rule
@@ -172,13 +174,14 @@ public class LocalSCMListenerTest extends HudsonTestCase {
             Map<String, String> m = (Map<String, String>) invocation.getArguments()[1];
             m.putAll(buildMap);
             m.put(PULL_REQUEST_SOURCE_BRANCH, PR_BRANCH_VALUE);
+            m.put(PULL_REQUEST_SOURCE_COMMIT, PR_COMMIT_VALUE);
             return null;
         }).when(gitSCM).buildEnvironment(notNull(), anyMap());
 
         listener.onCheckout(build, gitSCM, null, taskListener, null, null);
 
         BitbucketRevisionAction expectedRevision =
-                new BitbucketRevisionAction(scmRepository, "refs/heads/prsourcebranch", GIT_COMMIT_VALUE);
+                new BitbucketRevisionAction(scmRepository, "refs/heads/prsourcebranch", PR_COMMIT_VALUE);
 
         verify(buildStatusPoster).postBuildStatus(expectedRevision, build, taskListener);
     }


### PR DESCRIPTION
The plugin is merging the wrong direction when building PRs. For example, if We have a PR from source -> master, in the build logs we have:
```
Merging master commit 15292fb296688ce9cc0543baf48e183cb4a821cc into PR head commit 783f4bd57afe9bfdd105b143531493dc9449aca8
```

Which is wrong, it should merge 783f4bd5 into 15292fb29 (which is the master commit)

This PR solves this by using `PreBuildMerge` instead of `MergeWithGitSCMExtension`.

Example log after the fix:
```
Merging Revision 783f4bd57afe9bfdd105b143531493dc9449aca8 (origin/PR-1) to origin/master, UserMergeOptions{mergeRemote='origin', mergeTarget='master', mergeStrategy='DEFAULT', fastForwardMode='FF'}
```