### PR TITLE
Disable jacoco coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <!-- The jacoco integration is annoying when doing code reviews on github, we have the clover profile for
+                    coverage, thus disable the jacoco coverage -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <extensions>true</extensions>


### PR DESCRIPTION
Disable the jacoco integration, we don't use it anyway and it makes reviews harder for us.