### PR TITLE
Add support for forked pull requests

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTrait.java
@@ -47,7 +47,7 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
 
                 // The BitbucketPullRequestSCMHead uses the PR id as the head name, so we need to use a custom
                 // refspec to be able to map to the correct PR refs during checkout.
-                gitSCMBuilder.withRefSpec("+refs/heads/" + prHead.getOriginName() +
+                gitSCMBuilder.withRefSpec("+refs/pull-requests/" + prHead.getId() + "/from" +
                         ":refs/remotes/@{remote}/" + prHead.getName());
 
                 // Additionally, we also need to add the source branch name the underlying GitSCM's environment
@@ -96,15 +96,13 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
                             if (bitbucketContext.getEventHeads().isEmpty()) {
                                 return repositoryClient
                                         .getPullRequests(BitbucketPullRequestState.OPEN)
-                                        .map(BitbucketPullRequestSCMHead::new)
-                                        .filter(this::isSameOrigin); // We currently do not support forked PRs;
+                                        .map(BitbucketPullRequestSCMHead::new);
                             }
 
                             return bitbucketContext.getEventHeads().stream()
                                     .filter(BitbucketPullRequestSCMHead.class::isInstance)
                                     .map(BitbucketPullRequestSCMHead.class::cast)
-                                    .filter(head -> head.getPullRequest().getState() == BitbucketPullRequestState.OPEN)
-                                    .filter(this::isSameOrigin); // We currently do not support forked PRs;
+                                    .filter(head -> head.getPullRequest().getState() == BitbucketPullRequestState.OPEN);
                         }
 
                         @Override
@@ -117,11 +115,6 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
                                     "instance of BitbucketPullRequestSCMHead");
                             e.setStackTrace(new StackTraceElement[0]);
                             throw e;
-                        }
-
-                        private boolean isSameOrigin(BitbucketPullRequestSCMHead head) {
-                            MinimalPullRequest pullRequest = head.getPullRequest();
-                            return pullRequest.getFromRepositoryId() == pullRequest.getToRepositoryId();
                         }
                     });
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSourceBranch.java
@@ -14,7 +14,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class BitbucketPullRequestSourceBranch extends GitSCMExtension {
 
-    public static final String PULL_REQUEST_SOURCE_BRANCH = "PULL_REQUEST_SOURCE_BRANCH";
     public static final String PULL_REQUEST_SOURCE_COMMIT = "PULL_REQUEST_SOURCE_COMMIT";
 
     private final MinimalPullRequest pullRequest;
@@ -25,7 +24,6 @@ public class BitbucketPullRequestSourceBranch extends GitSCMExtension {
 
     @Override
     public void populateEnvironmentVariables(GitSCM scm, Map<String, String> env) {
-        env.put(PULL_REQUEST_SOURCE_BRANCH, pullRequest.getFromRefDisplayId());
         env.put(PULL_REQUEST_SOURCE_COMMIT, pullRequest.getFromLatestCommit());
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListener.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_BRANCH;
 import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_COMMIT;
 
 @Extension
@@ -127,14 +126,12 @@ public class LocalSCMListener extends SCMListener {
 
     @CheckForNull
     private String getRefFromEnvironment(Map<String, String> env, GitSCM scm) {
-        // If the pull request source branch is specified use that as the ref ID
-        String refId = StringUtils.stripToNull(env.get(PULL_REQUEST_SOURCE_BRANCH));
-
-        // Otherwise, use the default value from GIT_BRANCH
-        if (refId == null) {
-            refId = StringUtils.stripToNull(env.get(GitSCM.GIT_BRANCH));
+        // If the pull request source commit is specified we do not need to specify the ref
+        if (StringUtils.isNotBlank(env.get(PULL_REQUEST_SOURCE_COMMIT))) {
+            return null;
         }
 
+        String refId = StringUtils.stripToNull(env.get(GitSCM.GIT_BRANCH));
         if (refId == null) {
             return null;
         }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestDiscoveryTraitTest.java
@@ -129,7 +129,7 @@ public class BitbucketPullRequestDiscoveryTraitTest {
 
         underTest.decorateBuilder(scmBuilder);
 
-        assertThat(scmBuilder.refSpecs().get(0), equalTo("+refs/heads/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(scmBuilder.refSpecs().get(0), equalTo("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
         assertThat(scmBuilder.extensions().get(0), instanceOf(BitbucketPullRequestSourceBranch.class));
 
         PreBuildMerge mergeBuild = (PreBuildMerge) scmBuilder.extensions().get(1);
@@ -186,7 +186,10 @@ public class BitbucketPullRequestDiscoveryTraitTest {
 
         // Verify that the client fetches all open pullrequest and converts them into heads
         verify(bitbucketRepositoryClient).getPullRequests(BitbucketPullRequestState.OPEN);
-        assertThat(heads, Matchers.contains(new BitbucketPullRequestSCMHead(sameOriginPr)));
+        assertThat(heads, Matchers.containsInAnyOrder(
+                new BitbucketPullRequestSCMHead(sameOriginPr),
+                new BitbucketPullRequestSCMHead(forkedPr)
+        ));
     }
 
     private void initContext(Set<SCMHead> eventHeads) {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
@@ -34,7 +34,6 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_BRANCH;
 import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSourceBranch.PULL_REQUEST_SOURCE_COMMIT;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -173,7 +172,6 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         doAnswer(invocation -> {
             Map<String, String> m = (Map<String, String>) invocation.getArguments()[1];
             m.putAll(buildMap);
-            m.put(PULL_REQUEST_SOURCE_BRANCH, PR_BRANCH_VALUE);
             m.put(PULL_REQUEST_SOURCE_COMMIT, PR_COMMIT_VALUE);
             return null;
         }).when(gitSCM).buildEnvironment(notNull(), anyMap());
@@ -181,7 +179,7 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         listener.onCheckout(build, gitSCM, null, taskListener, null, null);
 
         BitbucketRevisionAction expectedRevision =
-                new BitbucketRevisionAction(scmRepository, "refs/heads/prsourcebranch", PR_COMMIT_VALUE);
+                new BitbucketRevisionAction(scmRepository, null, PR_COMMIT_VALUE);
 
         verify(buildStatusPoster).postBuildStatus(expectedRevision, build, taskListener);
     }


### PR DESCRIPTION
Includes the following changes to allow support for forked pull requests.
* Change refspec to use the Bitbucket custom `refs/pull-requests/{id}/from` ref to map the PR source ref
* Remove the ref restriction when posting a build status for PR builds to the target repo. This is made possible because the source commit is available in the target repo via the `refs/pull-requests/{id}/from` ref.