### PR TITLE
Replace BranchDiscoveryTrait with BitbucketBranchDiscoveryTrait

### DIFF
--- a/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketBranchSource.java
+++ b/acceptance-tests/src/main/java/it/com/atlassian/bitbucket/jenkins/internal/pageobjects/BitbucketBranchSource.java
@@ -38,7 +38,7 @@ public class BitbucketBranchSource extends BranchSource {
         if (isDiscoveryEnabled) {
             addTrait("Discover branches");
         } else {
-            removeTraitIfEnabled("jenkins.plugins.git.traits.BranchDiscoveryTrait");
+            removeTraitIfEnabled("com.atlassian.bitbucket.jenkins.internal.scm.BitbucketBranchDiscoveryTrait");
         }
 
         return this;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchDiscoveryTrait.java
@@ -69,7 +69,8 @@ public class BitbucketBranchDiscoveryTrait extends BitbucketSCMSourceTrait {
                         @Override
                         public SCMRevision toRevision(SCMHead head) {
                             if (head instanceof BitbucketBranchSCMHead) {
-                                return new BitbucketSCMRevision((BitbucketBranchSCMHead) head, ((BitbucketBranchSCMHead) head).getLatestCommit());
+                                return new BitbucketSCMRevision((BitbucketBranchSCMHead) head,
+                                        ((BitbucketBranchSCMHead) head).getLatestCommit());
                             }
 
                             RuntimeException e = new IllegalStateException("The specified head needs to be an " +

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
@@ -1,10 +1,56 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketDefaultBranch;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestRef;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRefChange;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.plugins.git.GitBranchSCMHead;
+import jenkins.plugins.git.GitBranchSCMRevision;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadMigration;
+import jenkins.scm.api.SCMRevision;
 
 public class BitbucketBranchSCMHead extends BitbucketSCMHead {
 
+    private static final long UNKNOWN_TIMESTAMP = -1;
+
+    public BitbucketBranchSCMHead(String name) {
+        super(name, null, UNKNOWN_TIMESTAMP);
+    }
+
     public BitbucketBranchSCMHead(BitbucketDefaultBranch branch) {
-        super(branch.getDisplayId(), branch.getLatestCommit(), -1);
+        super(branch.getDisplayId(), branch.getLatestCommit(), UNKNOWN_TIMESTAMP);
+    }
+
+    public BitbucketBranchSCMHead(BitbucketPullRequestRef prRef) {
+        super(prRef.getDisplayId(), prRef.getLatestCommit(), UNKNOWN_TIMESTAMP);
+    }
+
+    public BitbucketBranchSCMHead(BitbucketRefChange refChange) {
+        super(refChange.getRef().getDisplayId(), refChange.getToHash(), UNKNOWN_TIMESTAMP);
+    }
+
+    /**
+     * Migration from {@link GitBranchSCMHead} to {@link BitbucketBranchSCMHead}.
+     */
+    @Extension
+    public static class SCMHeadMigrationImpl extends SCMHeadMigration<BitbucketSCMSource, GitBranchSCMHead,
+            GitBranchSCMRevision> {
+
+        public SCMHeadMigrationImpl() {
+            super(BitbucketSCMSource.class, GitBranchSCMHead.class, GitBranchSCMRevision.class);
+        }
+
+        @Override
+        public SCMHead migrate(@NonNull BitbucketSCMSource source, @NonNull GitBranchSCMHead head) {
+            return new BitbucketBranchSCMHead(head.getName());
+        }
+
+        @Override
+        public SCMRevision migrate(@NonNull BitbucketSCMSource source, @NonNull GitBranchSCMRevision revision) {
+            return new BitbucketSCMRevision(new BitbucketBranchSCMHead(revision.getHead().getName()),
+                    revision.getHash());
+        }
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
@@ -2,19 +2,20 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import jenkins.scm.api.SCMHead;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.CheckForNull;
 
 public class BitbucketSCMHead extends SCMHead {
 
     private final String latestCommit;
     private final long updatedDate;
 
-    public BitbucketSCMHead(String name, String latestCommit, long updatedDate) {
+    public BitbucketSCMHead(String name, @CheckForNull String latestCommit, long updatedDate) {
         super(name);
-        this.latestCommit = requireNonNull(latestCommit, "latestCommit");
+        this.latestCommit = latestCommit;
         this.updatedDate = updatedDate;
     }
 
+    @CheckForNull
     public String getLatestCommit() {
         return latestCommit;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
@@ -45,7 +45,10 @@ public class BitbucketSCMProbe extends SCMProbe {
 
     private String getRef() {
         if (head instanceof BitbucketSCMHead) {
-            return ((BitbucketSCMHead) head).getLatestCommit();
+            String latestCommit = ((BitbucketSCMHead) head).getLatestCommit();
+            if (latestCommit != null) {
+                return latestCommit;
+            }
         }
 
         return head.getName();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.scm.api.SCMRevision;
 
@@ -8,11 +9,12 @@ public class BitbucketSCMRevision extends SCMRevision {
     private static final long serialVersionUID = 1L;
     private final String commitHash;
 
-    public BitbucketSCMRevision(@NonNull BitbucketSCMHead head, String commitHash) {
+    public BitbucketSCMRevision(@NonNull BitbucketSCMHead head, @CheckForNull String commitHash) {
         super(head);
         this.commitHash = commitHash;
     }
 
+    @CheckForNull
     public String getCommitHash() {
         return commitHash;
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -34,8 +34,6 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.plugins.git.GitSCMBuilder;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.plugins.git.GitSCMSourceContext;
-import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.api.*;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
@@ -321,6 +319,11 @@ public class BitbucketSCMSource extends SCMSource {
             throws IOException, InterruptedException {
         if (head instanceof BitbucketPullRequestSCMHead) {
             return new BitbucketPullRequestSCMRevision((BitbucketPullRequestSCMHead) head);
+        }
+
+        if (head instanceof BitbucketBranchSCMHead) {
+            return new BitbucketSCMRevision((BitbucketBranchSCMHead) head,
+                    ((BitbucketBranchSCMHead) head).getLatestCommit());
         }
 
         return getFullyInitializedGitSCMSource().accessibleRetrieve(head, listener);
@@ -630,18 +633,12 @@ public class BitbucketSCMSource extends SCMSource {
         }
 
         public List<SCMSourceTrait> getTraitsDefaults() {
-            // TODO: Replace with our own branch discovery implementation.
-            return Collections.singletonList(new BranchDiscoveryTrait());
+            return Collections.singletonList(new BitbucketBranchDiscoveryTrait());
         }
 
         public List<NamedArrayList<? extends SCMSourceTraitDescriptor>> getTraitsDescriptorLists() {
             List<NamedArrayList<? extends SCMSourceTraitDescriptor>> result = new ArrayList<>();
             List<SCMSourceTraitDescriptor> descriptors = new ArrayList<>();
-
-            // TODO: Temporarily allow BranchDiscoveryTrait but remove once we've implemented our own branch discovery.
-            descriptors.addAll(SCMSourceTrait._for(gitScmSourceDescriptor, GitSCMSourceContext.class, GitSCMBuilder.class)
-                    .stream().filter(descriptor -> descriptor instanceof BranchDiscoveryTrait.DescriptorImpl)
-                    .collect(Collectors.toList()));
 
             descriptors.addAll(SCMSourceTrait._for(this, BitbucketSCMSourceContext.class, GitSCMBuilder.class));
                     SCMSourceTrait._for(this, BitbucketSCMSourceContext.class, GitSCMBuilder.class);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketLegacyTraitConverter.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketLegacyTraitConverter.java
@@ -12,7 +12,7 @@ import javax.annotation.CheckForNull;
 public class BitbucketLegacyTraitConverter {
 
     private BitbucketLegacyTraitConverter() {
-        throw new IllegalStateException("This is a utility class and should not be instantiated");
+        // This is a utility class and should not be instantiated
     }
 
     /**

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketLegacyTraitConverter.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketLegacyTraitConverter.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm.trait;
 
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketBranchDiscoveryTrait;
 import jenkins.plugins.git.traits.*;
 import jenkins.scm.api.trait.SCMSourceTrait;
 
@@ -26,6 +27,10 @@ public class BitbucketLegacyTraitConverter {
     public static SCMSourceTrait maybeConvert(SCMSourceTrait trait) {
         if (trait instanceof TagDiscoveryTrait || trait instanceof DiscoverOtherRefsTrait) {
             return null;
+        }
+
+        if (trait instanceof BranchDiscoveryTrait) {
+            return new BitbucketBranchDiscoveryTrait();
         }
 
         if (trait instanceof GitBrowserSCMSourceTrait) {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBranchClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketBranchClientImplTest.java
@@ -4,6 +4,7 @@ import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
 import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketDefaultBranch;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPage;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +22,6 @@ import static okhttp3.HttpUrl.parse;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BitbucketBranchClientImplTest {
@@ -72,13 +72,15 @@ public class BitbucketBranchClientImplTest {
         assertEquals(next.getSize(), values.size());
         assertTrue(next.getSize() > 0);
 
-        assertThat(values.stream().map(BitbucketDefaultBranch::getId).collect(toSet()), hasItems("refs/heads/master", "refs/heads/branch1"));
-        assertThat(next.isLastPage(), is(true));
+        MatcherAssert.assertThat(values.stream().map(BitbucketDefaultBranch::getId).collect(toSet()),
+                hasItems("refs/heads/master", "refs/heads/branch1"));
+        MatcherAssert.assertThat(next.isLastPage(), is(true));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLastPageDoesNotHaveNext() {
-        BitbucketBranchClientImpl.NextPageFetcherImpl fetcher = new BitbucketBranchClientImpl.NextPageFetcherImpl(parse(BITBUCKET_BASE_URL), bitbucketRequestExecutor);
+        BitbucketBranchClientImpl.NextPageFetcherImpl fetcher =
+                new BitbucketBranchClientImpl.NextPageFetcherImpl(parse(BITBUCKET_BASE_URL), bitbucketRequestExecutor);
         BitbucketPage<BitbucketDefaultBranch> page = new BitbucketPage<>();
         page.setLastPage(true);
 


### PR DESCRIPTION
This PR contains the changes require to replace the `BranchDiscoveryTrait` with the new `BitbucketBranchDiscoveryTrait`.