### PR TITLE
Fix Jenkins PR support lightweight checkout

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
@@ -11,6 +11,8 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadMigration;
 import jenkins.scm.api.SCMRevision;
 
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+
 /**
  * @since 4.0.0
  */
@@ -32,6 +34,11 @@ public class BitbucketBranchSCMHead extends BitbucketSCMHead {
 
     public BitbucketBranchSCMHead(BitbucketRefChange refChange) {
         super(refChange.getRef().getDisplayId(), refChange.getToHash(), UNKNOWN_TIMESTAMP);
+    }
+
+    @Override
+    public String getFullRef() {
+        return R_HEADS + getName();
     }
 
     /**

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
@@ -4,6 +4,8 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequest;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
 
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+
 /**
  * @since 4.0.0
  */
@@ -23,9 +25,7 @@ public class BitbucketPullRequestSCMHead extends BitbucketSCMHead implements Cha
         this.originName = pullRequest.getFromRef().getDisplayId();
         this.pullRequest = new MinimalPullRequest(pullRequest);
         this.pullRequestId = Long.toString(pullRequest.getId());
-        this.target = new BitbucketSCMHead(pullRequest.getToRef().getDisplayId(),
-                pullRequest.getToRef().getLatestCommit(),
-                -1);
+        this.target = new BitbucketBranchSCMHead(pullRequest.getToRef());
     }
 
     @Override
@@ -33,6 +33,11 @@ public class BitbucketPullRequestSCMHead extends BitbucketSCMHead implements Cha
         return ChangeRequestCheckoutStrategy.MERGE;
     }
 
+    @Override
+    public String getFullRef() {
+        return R_HEADS + originName;
+    }
+    
     @Override
     public String getId() {
         return pullRequestId;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
@@ -7,12 +7,12 @@ import javax.annotation.CheckForNull;
 /**
  * @since 4.0.0
  */
-public class BitbucketSCMHead extends SCMHead {
+public abstract class BitbucketSCMHead extends SCMHead {
 
     private final String latestCommit;
     private final long updatedDate;
 
-    public BitbucketSCMHead(String name, @CheckForNull String latestCommit, long updatedDate) {
+    protected BitbucketSCMHead(String name, @CheckForNull String latestCommit, long updatedDate) {
         super(name);
         this.latestCommit = latestCommit;
         this.updatedDate = updatedDate;
@@ -26,4 +26,6 @@ public class BitbucketSCMHead extends SCMHead {
     public long getUpdatedDate() {
         return updatedDate;
     }
+
+    public abstract String getFullRef();
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/filesystem/BitbucketSCMFileSystem.java
@@ -5,9 +5,7 @@ import com.atlassian.bitbucket.jenkins.internal.client.BitbucketFilePathClient;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource;
+import com.atlassian.bitbucket.jenkins.internal.scm.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
@@ -15,7 +13,6 @@ import hudson.plugins.git.BranchSpec;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.util.FormValidation.Kind;
-import jenkins.plugins.git.GitBranchSCMHead;
 import jenkins.scm.api.*;
 
 import javax.annotation.CheckForNull;
@@ -122,9 +119,10 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
                             .getRepositoryClient(repository.getRepositorySlug())
                             .getFilePathClient();
 
-            if (scmRevision != null && scmRevision.getHead() instanceof GitBranchSCMHead) {
-                return new BitbucketSCMFileSystem(filePathClient, scmRevision, ((GitBranchSCMHead) scmRevision.getHead()).getRef());
+            if (scmRevision != null && scmRevision.getHead() instanceof BitbucketSCMHead) {
+                return new BitbucketSCMFileSystem(filePathClient, scmRevision, ((BitbucketSCMHead) scmRevision.getHead()).getFullRef());
             }
+
             // Unsupported ref type. Lightweight checkout not supported
             LOGGER.finer("Lightweight checkout for Bitbucket SCM source only supported for Multibranch Pipeline jobs. " +
                          "Cannot build file system for job " + ownerName);

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/filesystem/BitbucketSCMFileSystemIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/scm/filesystem/BitbucketSCMFileSystemIT.java
@@ -4,7 +4,9 @@ import com.atlassian.bitbucket.jenkins.internal.client.*;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketBranchSCMHead;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRevision;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource;
 import com.atlassian.bitbucket.jenkins.internal.scm.filesystem.BitbucketSCMFile;
 import com.atlassian.bitbucket.jenkins.internal.scm.filesystem.BitbucketSCMFileSystem;
@@ -14,8 +16,6 @@ import hudson.scm.SCM;
 import hudson.util.FormValidation;
 import it.com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketJenkinsRule;
 import it.com.atlassian.bitbucket.jenkins.internal.fixture.JenkinsProjectHandler;
-import jenkins.plugins.git.GitBranchSCMHead;
-import jenkins.plugins.git.GitBranchSCMRevision;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
@@ -112,8 +112,8 @@ public class BitbucketSCMFileSystemIT {
     public void testBuildSCMSource() throws Exception {
         WorkflowMultiBranchProject multiBranchProject =
                 projectHandler.createMultibranchJob("testBuildSCMSource", "PROJECT_1", "rep_1");
-        GitBranchSCMHead head = new GitBranchSCMHead("master");
-        SCMRevision revision = new GitBranchSCMRevision(head, "");
+        BitbucketBranchSCMHead head = new BitbucketBranchSCMHead("master");
+        SCMRevision revision = new BitbucketSCMRevision(head, "");
 
         String serverConfigID = ((BitbucketSCMSource) multiBranchProject.getSCMSources().get(0)).getServerId();
         doReturn(Optional.of(validConfiguration)).when(pluginConfiguration).getServerById(eq(serverConfigID));
@@ -130,7 +130,7 @@ public class BitbucketSCMFileSystemIT {
     public void testBuildSCMSourceInvalidRevision() throws Exception {
         WorkflowMultiBranchProject multiBranchProject =
                 projectHandler.createMultibranchJob("testBuildSCMSourceInvalidRevision", "PROJECT_1", "rep_1");
-        SCMRevision revision = new GitBranchSCMRevision(mock(GitBranchSCMHead.class), "");
+        SCMRevision revision = new BitbucketSCMRevision(mock(BitbucketBranchSCMHead.class), "");
 
         assertThat(builder.build(multiBranchProject.getSCMSources().get(0), revision.getHead(), revision),
                 Matchers.nullValue());
@@ -144,7 +144,7 @@ public class BitbucketSCMFileSystemIT {
 
         doReturn(Optional.of(invalidConfiguration)).when(pluginConfiguration).getServerById(scmSource.getServerId());
 
-        assertThat(builder.build(scmSource, mock(GitBranchSCMHead.class), mock(GitBranchSCMRevision.class)), Matchers.nullValue());
+        assertThat(builder.build(scmSource, mock(BitbucketBranchSCMHead.class), mock(BitbucketSCMRevision.class)), Matchers.nullValue());
     }
 
     @Test
@@ -155,7 +155,7 @@ public class BitbucketSCMFileSystemIT {
 
         doReturn(Optional.empty()).when(pluginConfiguration).getServerById(scmSource.getServerId());
 
-        assertThat(builder.build(scmSource, mock(GitBranchSCMHead.class), mock(GitBranchSCMRevision.class)), Matchers.nullValue());
+        assertThat(builder.build(scmSource, mock(BitbucketBranchSCMHead.class), mock(BitbucketSCMRevision.class)), Matchers.nullValue());
     }
 
     @Test


### PR DESCRIPTION
Fix lightweight checkout for multibranch pipelines. The `BitbucketSCMFileSystem` was not recognising the `BitbucketBranchScmHead` & `BitbucketPullRequestScmHead` as it expected `GitScmHead`. 