### PR TITLE
Update OAuth configuration icons

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerCreateAction.java
@@ -55,7 +55,7 @@ public class OAuthConsumerCreateAction extends AbstractDescribableImpl<OAuthCons
 
     @Override
     public String getIconFileName() {
-        return "setting.png";
+        return "symbol-settings";
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerUpdateAction.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerUpdateAction.java
@@ -100,7 +100,7 @@ public class OAuthConsumerUpdateAction extends AbstractDescribableImpl<OAuthCons
 
     @Override
     public String getIconFileName() {
-        return "setting.png";
+        return "symbol-settings";
     }
 
     @SuppressWarnings("unused") //Stapler

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthGlobalConfiguration.java
@@ -82,7 +82,7 @@ public class OAuthGlobalConfiguration extends ManagementLink implements Describa
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return "secure.png";
+        return "symbol-lock-closed";
     }
 
     @CheckForNull

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/token/OAuthTokenConfiguration.java
@@ -60,7 +60,7 @@ public class OAuthTokenConfiguration implements Action, Describable<OAuthGlobalC
     @CheckForNull
     @Override
     public String getIconFileName() {
-        return "secure.png";
+        return "symbol-lock-closed";
     }
 
     @SuppressWarnings("unused") // Stapler


### PR DESCRIPTION
Update the icon of the "Manage Bitbucket Server consumers" menu under "Manage Jenkins".
The idea is to harmonize the look and feel of the page since most other plugins and especially the core functions there also use these kind of icons.

I opted with built-in icons from [Jenkins core](https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols) to not introduce any new dependencies.

### Testing done
Manual starting local instance, comparing results.

**Before**
![before](https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/49242855/96eee61c-f1a0-46c7-a018-7cfbcbc352e7)
**After**
![after](https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/49242855/523bda05-8abd-4c86-938f-a9a782bb32b4)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
