### PR TITLE
Remove usages of wiremocks shaded apache http classes to ease upgrades

### DIFF
--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/FreestyleDeploymentStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/FreestyleDeploymentStatusPosterIT.java
@@ -4,8 +4,8 @@ import com.atlassian.bitbucket.jenkins.internal.deployments.DeploymentNotifier;
 import com.atlassian.bitbucket.jenkins.internal.model.deployment.BitbucketDeploymentEnvironmentType;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import org.apache.http.HttpStatus;
 import org.junit.Test;
-import wiremock.org.apache.http.HttpStatus;
 
 import static com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState.IN_PROGRESS;
 import static com.atlassian.bitbucket.jenkins.internal.model.deployment.DeploymentState.SUCCESSFUL;

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/PipelineDeploymentStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/deployments/PipelineDeploymentStatusPosterIT.java
@@ -1,10 +1,10 @@
 package it.com.atlassian.bitbucket.jenkins.internal.deployments;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Test;
-import wiremock.org.apache.http.HttpStatus;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
+++ b/src/test/java/it/com/atlassian/bitbucket/jenkins/internal/status/BuildStatusPosterIT.java
@@ -10,6 +10,7 @@ import it.com.atlassian.bitbucket.jenkins.internal.fixture.BitbucketProxyRule;
 import it.com.atlassian.bitbucket.jenkins.internal.fixture.GitHelper;
 import it.com.atlassian.bitbucket.jenkins.internal.fixture.JenkinsProjectHandler;
 import jenkins.branch.MultiBranchProject;
+import org.apache.http.HttpStatus;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
@@ -20,7 +21,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
-import wiremock.org.apache.http.HttpStatus;
 
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
We have been naughty and used wiremock provided apache http classes. We should not, it make upgrades etc hard. This changes the usages to their proper dependencies which was already present in our pom.xml