### PR TITLE
JENKINS-72071 update SCM Revision to extend from git plugin

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
@@ -2,56 +2,16 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.scm.api.SCMRevision;
-
-import java.util.Objects;
+import jenkins.plugins.git.AbstractGitSCMSource;
 
 /**
  * @since 4.0.0
  */
-public class BitbucketSCMRevision extends SCMRevision {
+public class BitbucketSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
 
     private static final long serialVersionUID = 1L;
-    private final String commitHash;
 
     public BitbucketSCMRevision(@NonNull BitbucketSCMHead head, @CheckForNull String commitHash) {
-        super(head);
-        this.commitHash = commitHash;
-    }
-
-    @CheckForNull
-    public String getCommitHash() {
-        return commitHash;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        BitbucketSCMRevision that = (BitbucketSCMRevision) o;
-        return Objects.equals(getHead(), that.getHead()) && Objects.equals(commitHash, that.commitHash);
-    }
-
-    @Override
-    public int hashCode() {
-        if (commitHash == null) {
-            return getHead().hashCode();
-        }
-
-        return Objects.hash(getHead(), commitHash);
-    }
-
-    @Override
-    public String toString() {
-        if (commitHash == null) {
-            return getHead().toString();
-        }
-
-        return commitHash;
+        super(head, commitHash);
     }
 }


### PR DESCRIPTION
There is no integration testing for this (as we don't and probably shouldn't rely on the ignore committer plugin), but a local test demonstrates the ignored commiters plugin can now create a GitSCMFileSystem without error, and the plugin is working as expected.

<img width="1663" alt="Screenshot 2023-10-05 at 3 45 00 pm" src="https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/53157896/ad994030-0b34-40cd-a83a-2a6c556d08a7">
Only the commit with an allowlisted committer has a build status

<img width="766" alt="Screenshot 2023-10-05 at 3 45 11 pm" src="https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/53157896/87849761-581b-44b2-bc8d-997b7c60c807">
And Jenkins does not have a build for the ignored commiter

<img width="619" alt="Screenshot 2023-10-05 at 3 45 16 pm" src="https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/53157896/75a56d47-2a91-4797-b67a-2dd8dec7db10">