### PR TITLE
Support timeout configuration for Http connection to bitbucket server (bitbucket.http.connect.timeout & bitbucket.http.request.timeout)

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
@@ -33,12 +33,19 @@ public class HttpRequestExecutorImpl implements HttpRequestExecutor {
     private static final Logger log = Logger.getLogger(HttpRequestExecutorImpl.class.getName());
     private final Call.Factory httpCallFactory;
 
+    public static OkHttpClient buildDefaultOkHttpClient() {
+        long connectionTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, 10000);
+        long readTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, 10000);
+        log.info("buildDefaultHttpCallFactory with: "+ SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT + ": "+ connectionTimeout + ", "+SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT + ": "+readTimeout);
+        return new OkHttpClient.Builder()
+                .connectTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
+                .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
+                .addInterceptor(new UserAgentInterceptor()).build();
+    }
+
     @Inject
     public HttpRequestExecutorImpl() {
-        this(new OkHttpClient.Builder()
-                .connectTimeout(SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, 10000), TimeUnit.MILLISECONDS)
-                .readTimeout(SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, 10000), TimeUnit.MILLISECONDS)
-                .addInterceptor(new UserAgentInterceptor()).build());
+        this(buildDefaultOkHttpClient());
     }
 
     public HttpRequestExecutorImpl(Call.Factory httpCallFactory) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
@@ -3,6 +3,8 @@ package com.atlassian.bitbucket.jenkins.internal.http;
 import com.atlassian.bitbucket.jenkins.internal.client.HttpRequestExecutor;
 import com.atlassian.bitbucket.jenkins.internal.client.RequestConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
+import com.atlassian.bitbucket.jenkins.internal.util.SystemPropertiesConstants;
+import com.atlassian.bitbucket.jenkins.internal.util.SystemPropertyUtils;
 import hudson.Plugin;
 import jenkins.model.Jenkins;
 import okhttp3.*;
@@ -15,6 +17,7 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,7 +35,10 @@ public class HttpRequestExecutorImpl implements HttpRequestExecutor {
 
     @Inject
     public HttpRequestExecutorImpl() {
-        this(new OkHttpClient.Builder().addInterceptor(new UserAgentInterceptor()).build());
+        this(new OkHttpClient.Builder()
+                .connectTimeout(SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, 10000), TimeUnit.MILLISECONDS)
+                .readTimeout(SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, 10000), TimeUnit.MILLISECONDS)
+                .addInterceptor(new UserAgentInterceptor()).build());
     }
 
     public HttpRequestExecutorImpl(Call.Factory httpCallFactory) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/util/SystemPropertiesConstants.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/util/SystemPropertiesConstants.java
@@ -46,4 +46,16 @@ public class SystemPropertiesConstants {
      * Defaults 3. Care should be taken when adjusting this as to not overload a server that is already under load.
      */
     public static final String REQUEST_RETRY_MAX_ATTEMPTS = "bitbucket.build.post.retry.request.attempts";
+
+    /**
+     * Http client connection timeout for rest calls.
+     * Defaults to 10,000 milliseconds (10 seconds)
+     */
+    public static final String DEFAULT_HTTP_CONNECTION_TIMEOUT = "bitbucket.http.connect.timeout";
+
+    /**
+     * Http client read timeout for rest calls.
+     * Defaults to 10,000 milliseconds (10 seconds)
+     */
+    public static final String DEFAULT_HTTP_READ_TIMEOUT = "bitbucket.http.request.timeout";
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImplTest.java
@@ -4,10 +4,8 @@ import com.atlassian.bitbucket.jenkins.internal.client.HttpRequestExecutor;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
-import okhttp3.Call;
-import okhttp3.HttpUrl;
-import okhttp3.Request;
-import okhttp3.Response;
+import com.atlassian.bitbucket.jenkins.internal.util.SystemPropertiesConstants;
+import okhttp3.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -51,6 +49,26 @@ public class HttpRequestExecutorImplTest {
     @After
     public void teardown() {
         factory.ensureResponseBodyClosed();
+    }
+
+    @Test
+    public void testBuildDefaultOkHttpClientDefaults() {
+        System.clearProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT);
+        System.clearProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT);
+        OkHttpClient client = HttpRequestExecutorImpl.buildDefaultOkHttpClient();
+        assertThat(client.connectTimeoutMillis(), is(equalTo(10000)));
+        assertThat(client.readTimeoutMillis(), is(equalTo(10000)));
+    }
+
+    @Test
+    public void testBuildDefaultOkHttpClientOverrides() {
+        int aConnectionTimeout = 2000;
+        int aReadTimeout = 3000;
+        System.setProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, String.valueOf(aConnectionTimeout));
+        System.setProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, String.valueOf(aReadTimeout));
+        OkHttpClient client = HttpRequestExecutorImpl.buildDefaultOkHttpClient();
+        assertThat(client.connectTimeoutMillis(), is(equalTo(aConnectionTimeout)));
+        assertThat(client.readTimeoutMillis(), is(equalTo(aReadTimeout)));
     }
 
     @Test


### PR DESCRIPTION
[Http timeout for bitbucket server is not configurable](https://issues.jenkins.io/browse/JENKINS-71610?filter=-2)
Added two system porperties:
bitbucket.http.connect.timeout=10000 (ms)
bitbucket.http.request.timeout=10000 (ms)
Which are propagated to the okhttp client

### Testing done

Added unit test

```[tasklist]
### Submitter checklist
- [? ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [? ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
