### PR TITLE
NONE checkstyle fixes, increased default timeouts to 30s to minimise surprises

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.1</version>
+            <version>3.14.9</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImpl.java
@@ -33,16 +33,6 @@ public class HttpRequestExecutorImpl implements HttpRequestExecutor {
     private static final Logger log = Logger.getLogger(HttpRequestExecutorImpl.class.getName());
     private final Call.Factory httpCallFactory;
 
-    public static OkHttpClient buildDefaultOkHttpClient() {
-        long connectionTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, 10000);
-        long readTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, 10000);
-        log.info("buildDefaultHttpCallFactory with: "+ SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT + ": "+ connectionTimeout + ", "+SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT + ": "+readTimeout);
-        return new OkHttpClient.Builder()
-                .connectTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
-                .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
-                .addInterceptor(new UserAgentInterceptor()).build();
-    }
-
     @Inject
     public HttpRequestExecutorImpl() {
         this(buildDefaultOkHttpClient());
@@ -50,6 +40,16 @@ public class HttpRequestExecutorImpl implements HttpRequestExecutor {
 
     public HttpRequestExecutorImpl(Call.Factory httpCallFactory) {
         this.httpCallFactory = httpCallFactory;
+    }
+
+    public static OkHttpClient buildDefaultOkHttpClient() {
+        long connectionTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT, 30000);
+        long readTimeout = SystemPropertyUtils.parsePositiveLongFromSystemProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT, 30000);
+        log.info("buildDefaultHttpCallFactory with: " + SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT + ": " + connectionTimeout + ", " + SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT + ": " + readTimeout);
+        return new OkHttpClient.Builder()
+                .connectTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
+                .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
+                .addInterceptor(new UserAgentInterceptor()).build();
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/util/SystemPropertiesConstants.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/util/SystemPropertiesConstants.java
@@ -21,6 +21,20 @@ public class SystemPropertiesConstants {
      */
     public static final String CAPABILITIES_CACHE_DURATION_KEY = "bitbucket.client.capabilities.cache.duration";
     /**
+     * Http client connection timeout for rest calls.
+     * Defaults to 30,000 milliseconds (30 seconds)
+     *
+     * @since 4.0.1
+     */
+    public static final String DEFAULT_HTTP_CONNECTION_TIMEOUT = "bitbucket.http.connect.timeout";
+    /**
+     * Http client read timeout for rest calls.
+     * Defaults to 30,000 milliseconds (30 seconds)
+     *
+     * @since 4.0.1
+     */
+    public static final String DEFAULT_HTTP_READ_TIMEOUT = "bitbucket.http.request.timeout";
+    /**
      * Specifies the time to live (TTL) of an OAuth access token, used when making API requests in Jenkins on
      * behalf of the Bitbucket user, such as starting jobs. When the token expires, the user will have to acquire
      * another before being able to make further API requests.
@@ -46,6 +60,7 @@ public class SystemPropertiesConstants {
      * Specifies the maximum number of pages to fetch when
      * {@link BitbucketBranchClient#getRemoteBranches() fetching remote branches}.
      * Defaults to 5.
+     *
      * @since 4.0.0
      */
     public static final String REMOTE_BRANCHES_RETRIEVAL_MAX_PAGES = "bitbucket.remote.branches.retrieval.max.pages";
@@ -53,6 +68,7 @@ public class SystemPropertiesConstants {
      * Specifies the size of a page to fetch when
      * {@link BitbucketBranchClient#getRemoteBranches() fetching remote branches}.
      * Defaults to 1000.
+     *
      * @since 4.0.0
      */
     public static final String REMOTE_BRANCHES_RETRIEVAL_PAGE_SIZE = "bitbucket.remote.branches.retrieval.page.size";
@@ -61,16 +77,4 @@ public class SystemPropertiesConstants {
      * Defaults 3. Care should be taken when adjusting this as to not overload a server that is already under load.
      */
     public static final String REQUEST_RETRY_MAX_ATTEMPTS = "bitbucket.build.post.retry.request.attempts";
-
-    /**
-     * Http client connection timeout for rest calls.
-     * Defaults to 10,000 milliseconds (10 seconds)
-     */
-    public static final String DEFAULT_HTTP_CONNECTION_TIMEOUT = "bitbucket.http.connect.timeout";
-
-    /**
-     * Http client read timeout for rest calls.
-     * Defaults to 10,000 milliseconds (10 seconds)
-     */
-    public static final String DEFAULT_HTTP_READ_TIMEOUT = "bitbucket.http.request.timeout";
 }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/http/HttpRequestExecutorImplTest.java
@@ -56,8 +56,8 @@ public class HttpRequestExecutorImplTest {
         System.clearProperty(SystemPropertiesConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT);
         System.clearProperty(SystemPropertiesConstants.DEFAULT_HTTP_READ_TIMEOUT);
         OkHttpClient client = HttpRequestExecutorImpl.buildDefaultOkHttpClient();
-        assertThat(client.connectTimeoutMillis(), is(equalTo(10000)));
-        assertThat(client.readTimeoutMillis(), is(equalTo(10000)));
+        assertThat(client.connectTimeoutMillis(), is(equalTo(30000)));
+        assertThat(client.readTimeoutMillis(), is(equalTo(30000)));
     }
 
     @Test


### PR DESCRIPTION
Increased the timeouts slightly to allow slower environments to function. 
Formatted the code to adhere to our code style