### PR TITLE
Bump bom version to resolve internal build failures

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -19,9 +19,9 @@
         <httpclient.version>4.5.13</httpclient.version>
         <jenkins.version>2.401.3</jenkins.version>
         <scribejava.version>6.8.1</scribejava.version>
-        <jackson.version>2.15.1</jackson.version>
+        <jackson.version>2.15.3</jackson.version>
         <groovy.version>3.0.7</groovy.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-lang3.version>3.13.0</commons-lang3.version>
         <jgit.version>4.5.7.201904151645-r</jgit.version>
         <junit.version>5.9.2</junit.version>
         <log4j.version>1.7.25</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,13 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.11.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- commons-text comes in via the jenkins:checks-api at a more modern version, exclude this one -->
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
         <hamcrest.version>2.2</hamcrest.version>
-        <jackson.version>2.15.1</jackson.version>
+        <jackson.version>2.15.3</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
         <jenkins.version>2.401.3</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -100,7 +100,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.401.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <version>2661.vb_b_60650f6d97</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Bumping bom version to `2661.vb_b_60650f6d97` to resolve `BitbucketProjectConfigurationIT` test failures.

Bumping the following other dependencies to resolve maven upper bound enforcer issues:
- jackson 
- commons-lang3

### Testing done

Confirmed that the build now passes.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
