### PR TITLE
JENKINS-72280 remove secret text as selectable option in forms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,9 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ---
 
 ## Changelog
+### 4.0.1
+- JENKINS-72280 Secret text credentials can no longer be selected as part of a Bitbucket SCM configuration
+
 ### 4.0.0
 - JENKINS-66581 Implement ChangeRequestSCMHead2 for pull requests and introduced a pull request discovery trait enabling
   Multibranch Pipelines to detect open pull requests (includes forked pull requests) and initiate builds.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -24,7 +24,6 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.HttpResponse;
 
 import javax.annotation.Nullable;
@@ -79,12 +78,6 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
 
         return new StandardListBoxModel()
                 .includeEmptyValue()
-                .includeMatchingAs(
-                        ACL.SYSTEM,
-                        context,
-                        StringCredentials.class,
-                        URIRequirementBuilder.fromUri(baseUrl).build(),
-                        CredentialsMatchers.always())
                 .includeMatchingAs(
                         ACL.SYSTEM,
                         context,

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -15,6 +15,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.Item;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -58,11 +59,14 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         checkPermission(context);
         if (isBlank(credentialsId)) {
             return FormValidation.warning(
-                    "Without credentials, Jenkins can’t check out source code from non-public repositories. ");
+                    "Without credentials, Jenkins can’t check out source code from non-public repositories.");
         }
         Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
-            return FormValidation.error("No credentials exist for the provided credentialsId");
+            return FormValidation.error("No credentials exist for the provided credentialsId.");
+        }
+        if (providedCredentials.get() instanceof StringCredentials) {
+            return FormValidation.error("Secret text cannot be used for build credentials. Change to a different credentials type.");
         }
         return FormValidation.ok();
     }


### PR DESCRIPTION
In our current version of the git plugin (org.jenkins-ci.plugins:git:5.0.2), secret text credentials are not a supported credential type. They can't be resolved by the plugin, and so an unauthenticated request is sent and inevitably fails. To resolve this, I've changed our plugin to:
- No longer include secret text credentials as an option in the SCM form fill delegate
- Provide a form validation error if those credentials are selected (in the reasonably unlikely event a user already has job configuration with a secret text credential configured).

I've run a manual test of this, there is no automated testing for the credential validation at all unfortunately. Were I to guess, it's because our credentials are resolved using the static method `CredentialsUtils#getCredentials` which can't be easily mocked. We could manually have the test add those credentials, but I'd prefer if possible that class be converted to a singleton or, if that's completely impossible, wrap it with a provider as with the `JenkinsProvider`, which might be better addressed in a separate PR (done before this one merges if considered a merge blocker).

<img width="941" alt="Screenshot 2023-12-20 at 11 50 59 am" src="https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/assets/53157896/0dccf2ef-d637-41b5-99a0-14367dfb6163">
