### PR TITLE
replace direct eddsa library with api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.15.3</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -43,7 +43,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
+                <artifactId>bom-2.426.x</artifactId>
                 <version>2661.vb_b_60650f6d97</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -85,9 +85,9 @@
             </scope> <!-- Should really be test scope but that scope does not work due to transitive dependencies -->
         </dependency>
         <dependency>
-            <groupId>net.i2p.crypto</groupId>
-            <artifactId>eddsa</artifactId>
-            <version>0.3.0</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>eddsa-api</artifactId>
+            <version>0.3.0-4.v84c6f0f4969e</version>
         </dependency>
         <dependency>
             <groupId>net.oauth.core</groupId>


### PR DESCRIPTION
replaces the direct dependency on eddsa with the eddsa-api library plugin.
Bumps minimum Jenkins version and bom to accomodate

<!-- Please describe your pull request here. -->

### Testing done

none

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
