### PR TITLE
Fix builds failing with latest Jenkins due to unbundling of a library…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
     <version>4.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+        <!-- This property can most likely be removed when our minimum Jenkins version is greater than 2.456 -->
+        <asm.version>9.7</asm.version>
         <bitbucket.version>6.10.15</bitbucket.version>
         <cloverVersion>4.3.1</cloverVersion>
         <disableTestInjection>true</disableTestInjection>
@@ -348,6 +350,13 @@
             <artifactId>reflections</artifactId>
             <version>0.9.12</version>
             <scope>test</scope>
+        </dependency>
+        <!-- This dependency can most likely be removed when our minimum Jenkins version is greater than 2.456 -->
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <scope>test</scope>
+            <version>${asm.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update amps, which allows use of different JVMs for Bitbucket and Jenkins. If the property is not passed the JVM that maven was started with is used (so same as for Jenkins)