### PR TITLE
Update AMPS and allow setting the JVM to use for Bitbucket, to allow …

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -192,7 +192,7 @@
                 <plugin>
                     <groupId>com.atlassian.maven.plugins</groupId>
                     <artifactId>bitbucket-maven-plugin</artifactId>
-                    <version>8.0.4</version>
+                    <version>9.0.1</version>
                     <configuration>
                         <skipAllPrompts>true</skipAllPrompts>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
                     <plugin>
                         <groupId>com.atlassian.maven.plugins</groupId>
                         <artifactId>bitbucket-maven-plugin</artifactId>
-                        <version>8.0.0</version>
+                        <version>9.0.1</version>
                         <extensions>true</extensions>
                         <configuration>
                             <products>
@@ -572,6 +572,7 @@
                                     <instanceId>bitbucket</instanceId>
                                     <version>${bitbucket.version}</version>
                                     <productDataVersion>${bitbucket.version}</productDataVersion>
+                                    <jvm>${bitbucket.jvm}</jvm>
                                 </product>
                             </products>
                         </configuration>


### PR DESCRIPTION
Allow us to use different versions for Bitbucket.
If no property is passed the same JVM that was used to run maven is used to start Bitbucket