### PR TITLE
Rewrite tests to not serialize mocks

### DIFF
--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfigurationTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/config/BitbucketPluginConfigurationTest.java
@@ -1,6 +1,7 @@
 package com.atlassian.bitbucket.jenkins.internal.config;
 
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
+import com.atlassian.bitbucket.jenkins.internal.util.SerializationFriendlySCM;
 import hudson.model.FreeStyleProject;
 import hudson.scm.SCM;
 import hudson.util.FormValidation;
@@ -76,8 +77,8 @@ public class BitbucketPluginConfigurationTest {
         FreeStyleProject freeStyleProject = jenkins.createFreeStyleProject();
         BitbucketSCM bitbucketSCMInitial = mock(BitbucketSCM.class);
         when(bitbucketSCMInitial.getServerId()).thenReturn("0");
-        freeStyleProject.setScm(bitbucketSCMInitial);
-        assertThat(jenkins.getInstance().getAllItems(FreeStyleProject.class).get(0).getScm(),
+        freeStyleProject.setScm(new SerializationFriendlySCM(bitbucketSCMInitial));
+        assertThat(((SerializationFriendlySCM) jenkins.getInstance().getAllItems(FreeStyleProject.class).get(0).getScm()).getUnderlyingSCM(),
                 equalTo(bitbucketSCMInitial));
 
         WorkflowJob workflowJob = jenkins.createProject(WorkflowJob.class);

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/status/LocalSCMListenerTest.java
@@ -4,6 +4,7 @@ import com.atlassian.bitbucket.jenkins.internal.provider.GlobalLibrariesProvider
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
 import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepositoryHelper;
+import com.atlassian.bitbucket.jenkins.internal.util.SerializationFriendlySCM;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleBuild;
@@ -105,10 +106,8 @@ public class LocalSCMListenerTest extends HudsonTestCase {
                 jenkinsRule.getInstance().createProject(WorkflowMultiBranchProject.class, "MultiBranchProject");
         WorkflowJob workflowJob = new WorkflowJob(workflowMultiBranchProject, "Job1");
         WorkflowRun workflowRun = new WorkflowRun(workflowJob);
-        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
-        SCMRetriever scmRetriever = mock(SCMRetriever.class);
-        when(libConfig.getRetriever()).thenReturn(scmRetriever);
-        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        SCMRetriever scmRetriever = new SCMRetriever(new SerializationFriendlySCM(bitbucketSCM));
+        LibraryConfiguration libConfig = new LibraryConfiguration("multibranch folder", scmRetriever);
         FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
         workflowMultiBranchProject.addProperty(folderLibraries);
 
@@ -189,10 +188,8 @@ public class LocalSCMListenerTest extends HudsonTestCase {
         when(bitbucketSCM.getId()).thenReturn("SomeID");
         Folder folder = new Folder(jenkinsRule.getInstance().getItemGroup(), "Folder");
         WorkflowJob workflowJob = new WorkflowJob(folder, "Job1");
-        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
-        SCMRetriever scmRetriever = mock(SCMRetriever.class);
-        when(libConfig.getRetriever()).thenReturn(scmRetriever);
-        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        SCMRetriever scmRetriever = new SCMRetriever(new SerializationFriendlySCM(bitbucketSCM));
+        LibraryConfiguration libConfig = new LibraryConfiguration("folder on checkout", scmRetriever);
         FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
         folder.addProperty(folderLibraries);
         WorkflowRun workflowRun = new WorkflowRun(workflowJob);
@@ -275,10 +272,8 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     public void testOnCheckoutWithNestedFolderLibraryDoesNotPostBuildStatus() throws IOException {
         when(bitbucketSCM.getId()).thenReturn("SomeID");
         Folder parentFolder = new Folder(jenkinsRule.getInstance().getItemGroup(), "ParentFolder");
-        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
-        SCMRetriever scmRetriever = mock(SCMRetriever.class);
-        when(libConfig.getRetriever()).thenReturn(scmRetriever);
-        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        SCMRetriever scmRetriever = new SCMRetriever(new SerializationFriendlySCM(bitbucketSCM));
+        LibraryConfiguration libConfig = new LibraryConfiguration("folder lib test", scmRetriever);
         FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
         parentFolder.addProperty(folderLibraries);
         Folder folder = new Folder(parentFolder, "Folder");
@@ -296,10 +291,8 @@ public class LocalSCMListenerTest extends HudsonTestCase {
     public void testOnCheckoutWithNestedFolderLibraryUnderMultiBranchDoesNotPostBuildStatus() throws IOException {
         when(bitbucketSCM.getId()).thenReturn("SomeID");
         Folder parentFolder = new Folder(jenkinsRule.getInstance().getItemGroup(), "ParentFolder");
-        LibraryConfiguration libConfig = mock(LibraryConfiguration.class);
-        SCMRetriever scmRetriever = mock(SCMRetriever.class);
-        when(libConfig.getRetriever()).thenReturn(scmRetriever);
-        when(scmRetriever.getScm()).thenReturn(bitbucketSCM);
+        SCMRetriever scmRetriever = new SCMRetriever(new SerializationFriendlySCM(bitbucketSCM));
+        LibraryConfiguration libConfig = new LibraryConfiguration("library under multibranch", scmRetriever);
         FolderLibraries folderLibraries = new FolderLibraries(singletonList(libConfig));
         parentFolder.addProperty(folderLibraries);
         WorkflowMultiBranchProject workflowMultiBranchProject = new WorkflowMultiBranchProject(parentFolder, "name");

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/SerializationFriendlySCM.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/SerializationFriendlySCM.java
@@ -1,0 +1,42 @@
+package com.atlassian.bitbucket.jenkins.internal.util;
+
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
+import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
+
+import javax.annotation.CheckForNull;
+import java.util.List;
+
+/**
+ * Xstream under Java 17 struggles to serialize Mockito mocks.
+ * For testing, we very rarely want to actually serialize the mock, and so this class was born.
+ * If it needs to actually get a mocked value, delegate to the SCM we hold.
+ */
+public class SerializationFriendlySCM extends BitbucketSCM {
+
+    private final transient BitbucketSCM delegate;
+
+    public SerializationFriendlySCM(BitbucketSCM mockedSCM) {
+        super(mockedSCM);
+        delegate = mockedSCM;
+    }
+
+    @Override
+    public String getMirrorName() {
+        return delegate.getMirrorName();
+    }
+
+    @Override
+    public List<BitbucketSCMRepository> getRepositories() {
+        return delegate.getRepositories();
+    }
+
+    @CheckForNull
+    @Override
+    public String getServerId() {
+        return delegate.getServerId();
+    }
+
+    public BitbucketSCM getUnderlyingSCM() {
+        return delegate;
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/SerializationFriendlyTrigger.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/util/SerializationFriendlyTrigger.java
@@ -1,0 +1,39 @@
+package com.atlassian.bitbucket.jenkins.internal.util;
+
+import com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookTriggerImpl;
+import com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookTriggerRequest;
+import com.atlassian.bitbucket.jenkins.internal.trigger.events.AbstractWebhookEvent;
+import hudson.Extension;
+import hudson.model.Job;
+import org.jenkinsci.Symbol;
+
+public class SerializationFriendlyTrigger extends BitbucketWebhookTriggerImpl {
+
+    private final transient BitbucketWebhookTriggerImpl delegate;
+
+    public SerializationFriendlyTrigger(BitbucketWebhookTriggerImpl mockTrigger) {
+        super(mockTrigger.isPullRequestTrigger(), mockTrigger.isRefTrigger());
+        delegate = mockTrigger;
+    }
+
+    @Override
+    public boolean isApplicableForEvent(AbstractWebhookEvent event) {
+        return delegate.isApplicableForEvent(event);
+    }
+
+    @Override
+    public void start(Job<?, ?> project, boolean newInstance) {
+        delegate.start(project, newInstance);
+    }
+
+    @Override
+    public void trigger(BitbucketWebhookTriggerRequest triggerRequest) {
+        delegate.trigger(triggerRequest);
+    }
+
+    @Symbol("BitbucketWebhookTriggerImpl")
+    @Extension
+    public static class SerializationFriendlyTriggerDescriptor extends BitbucketWebhookTriggerImpl.BitbucketWebhookTriggerDescriptor {
+
+    }
+}


### PR DESCRIPTION
Under Java 17 it is not possible to serialize mocks without add-opens. This rewrites a handful of tests to avoid serializing mocks by introducing a class that simply skips over the mock when serializing, and so it works under Java 17 without adding add-opens.

This is not super elegant, but it has the benefit of working.