### PR TITLE
JENKINS-73267 make SCMSource retrieve latest head from bitbucket instead of cached value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,10 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 ---
 
 ## Changelog
+
+### 4.x
+- Fix [JENKINS-73267](https://issues.jenkins.io/browse/JENKINS-73267): Building branch on multibranch job without scanning will build stale commit
+
 ### 4.1.0
 - [JENKINS-72120](https://issues.jenkins.io/browse/JENKINS-72120) Implemented discovery of tags. This introduces a tag discovery trait enabling Multibranch pipelines to
   detect tags. The trait will not initialise builds.

--- a/readme.md
+++ b/readme.md
@@ -222,9 +222,6 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
-### 4.x
-- Fix [JENKINS-73267](https://issues.jenkins.io/browse/JENKINS-73267): Building branch on multibranch job without scanning will build stale commit
-
 ### 4.1.0
 - [JENKINS-72120](https://issues.jenkins.io/browse/JENKINS-72120) Implemented discovery of tags. This introduces a tag discovery trait enabling Multibranch pipelines to
   detect tags. The trait will not initialise builds.
@@ -234,6 +231,7 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
     system properties (total count can be calculated using maxPages * pageSize).
     - `bitbucket.remote.tags.retrieval.max.pages` - (defaults to 5)
     - `bitbucket.remote.tags.retrieval.page.size` - (defaults to 1000)
+- Fix [JENKINS-73267](https://issues.jenkins.io/browse/JENKINS-73267): Building branch/pull-request on multibranch job without scanning will build stale commit
 
 ### 4.0.1
 - JENKINS-72280 Secret text credentials can no longer be selected as part of a Bitbucket SCM configuration

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClient.java
@@ -1,0 +1,18 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCommit;
+
+/**
+ * @since JENKINS-73267
+ */
+public interface BitbucketCommitClient {
+
+    /**
+     * Gets the commit details for the given identifier
+     *
+     * @param identifier the commit hash or the name of the branch to get the commit from
+     *
+     * @return commit details corresponding to the given identifier
+     */
+    BitbucketCommit getCommit(String identifier);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClient.java
@@ -3,7 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCommit;
 
 /**
- * @since JENKINS-73267
+ * @since 4.1.0
  */
 public interface BitbucketCommitClient {
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImpl.java
@@ -1,0 +1,33 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCommit;
+import okhttp3.HttpUrl;
+
+public class BitbucketCommitClientImpl implements BitbucketCommitClient {
+
+    private final BitbucketRequestExecutor bitbucketRequestExecutor;
+    private final String projectKey;
+    private final String repositorySlug;
+
+    public BitbucketCommitClientImpl(BitbucketRequestExecutor bitbucketRequestExecutor,
+                                     String projectKey,
+                                     String repositorySlug) {
+        this.bitbucketRequestExecutor = bitbucketRequestExecutor;
+        this.projectKey = projectKey;
+        this.repositorySlug = repositorySlug;
+    }
+
+    @Override
+    public BitbucketCommit getCommit(String identifier) {
+        HttpUrl url = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
+                .addPathSegment("projects")
+                .addPathSegment(projectKey)
+                .addPathSegment("repos")
+                .addPathSegment(repositorySlug)
+                .addPathSegment("commits")
+                .addPathSegment(identifier)
+                .build();
+
+        return bitbucketRequestExecutor.makeGetRequest(url, BitbucketCommit.class).getBody();
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
@@ -79,6 +79,15 @@ public interface BitbucketRepositoryClient {
     BitbucketDeploymentClient getDeploymentClient(String revisionSha);
 
     /**
+     * Gets the pull request corresponding to the given ID.
+     *
+     * @param id the pull request's id
+     * @return the pull request with the given ID
+     * @since JENKINS-73267
+     */
+    BitbucketPullRequest getPullRequest(long id);
+
+    /**
      * Gets all pull requests of the given state for the repository. The returned stream will make paged calls to
      * Bitbucket to ensure that all pull requests are returned. Consumers are advised that this can return large amounts
      * of data and are <strong>strongly</strong> encouraged to not collect to a list or similar before processing items,

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
@@ -23,6 +23,15 @@ public interface BitbucketRepositoryClient {
     BitbucketBranchClient getBranchClient(TaskListener taskListener);
 
     /**
+     * Returns a client for getting commit information from a repository.
+     *
+     * @return a git client that is ready to use
+     *
+     * @since JENKINS-73267
+     */
+    BitbucketCommitClient getCommitClient();
+
+    /**
      * Returns a client for getting file content and directory information on paths in a repository.
      *
      * @return A client that is ready to use

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClient.java
@@ -27,7 +27,7 @@ public interface BitbucketRepositoryClient {
      *
      * @return a git client that is ready to use
      *
-     * @since JENKINS-73267
+     * @since 4.1.0
      */
     BitbucketCommitClient getCommitClient();
 
@@ -83,7 +83,7 @@ public interface BitbucketRepositoryClient {
      *
      * @param id the pull request's id
      * @return the pull request with the given ID
-     * @since JENKINS-73267
+     * @since 4.1.0
      */
     BitbucketPullRequest getPullRequest(long id);
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
@@ -77,6 +77,16 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
     }
 
     @Override
+    public BitbucketPullRequest getPullRequest(long id) {
+        HttpUrl url = getRepositoryUrl()
+                .addPathSegment("pull-requests")
+                .addPathSegment(String.valueOf(id))
+                .build();
+
+        return bitbucketRequestExecutor.makeGetRequest(url, BitbucketPullRequest.class).getBody();
+    }
+
+    @Override
     public Stream<BitbucketPullRequest> getPullRequests(BitbucketPullRequestState state) {
         return getPullRequestsWithState(state.toString());
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImpl.java
@@ -62,6 +62,11 @@ public class BitbucketRepositoryClientImpl implements BitbucketRepositoryClient 
     }
 
     @Override
+    public BitbucketCommitClient getCommitClient() {
+        return new BitbucketCommitClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug);
+    }
+
+    @Override
     public BitbucketDeploymentClient getDeploymentClient(String revisionSha) {
         return new BitbucketDeploymentClientImpl(bitbucketRequestExecutor, projectKey, repositorySlug, revisionSha);
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCommit.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCommit.java
@@ -1,0 +1,47 @@
+package com.atlassian.bitbucket.jenkins.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since JENKINS-73267
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCommit {
+
+    private final long committerTimestamp;
+    private final String displayId;
+    private final String id;
+    private final String message;
+
+    @JsonCreator
+    public BitbucketCommit(
+            @JsonProperty("id") String id,
+            @JsonProperty("displayId") String displayId,
+            @JsonProperty("committerTimestamp") long committerTimestamp,
+            @JsonProperty("message") String message) {
+        this.id = requireNonNull(id, "id");
+        this.displayId = requireNonNull(displayId, "displayId");
+        this.message = message;
+        this.committerTimestamp = committerTimestamp;
+    }
+
+    public long getCommitterTimestamp() {
+        return committerTimestamp;
+    }
+
+    public String getDisplayId() {
+        return displayId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCommit.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/model/BitbucketCommit.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import static java.util.Objects.requireNonNull;
 
 /**
- * @since JENKINS-73267
+ * @since 4.1.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketCommit {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketBranchSCMHead.java
@@ -33,6 +33,10 @@ public class BitbucketBranchSCMHead extends BitbucketSCMHead {
         super(refChange.getRef().getDisplayId(), refChange.getToHash(), UNKNOWN_TIMESTAMP);
     }
 
+    public BitbucketBranchSCMHead(String name, BitbucketCommit commit) {
+        super(name, commit.getId(), commit.getCommitterTimestamp());
+    }
+
     @Override
     public String getFullRef() {
         return REFS_HEADS_PREFIX + getName();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -323,6 +323,8 @@ public class BitbucketSCMSource extends SCMSource {
                 return new BitbucketSCMRevision((BitbucketTagSCMHead) head, fetchedTag.map(BitbucketTag::getLatestCommit).orElse(null));
             }
         } catch (NotFoundException e) {
+            // this exception can be thrown if the head no longer exists (e.g. multi-branch pipeline created without
+            // webhook configured, pull request build is run, pull request is deleted, then build is re-run)
             listener.error(e.getMessage());
             return null;
         }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -483,33 +483,25 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     private Optional<BitbucketCommit> fetchBitbucketCommit(BitbucketBranchSCMHead head) {
-        BitbucketSCMSource.DescriptorImpl descriptor = (BitbucketSCMSource.DescriptorImpl) getDescriptor();
-
-        return descriptor.getConfiguration(getServerId()).map(serverConfiguration -> {
-            BitbucketScmHelper scmHelper = descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(), getCredentials().orElse(null));
-            return scmHelper.getCommitClient(getProjectKey(), getRepositorySlug())
-                    .getCommit(head.getName());
-        });
+        return getScmHelper().map(scmHelper -> scmHelper.getCommitClient(getProjectKey(), getRepositorySlug())
+                .getCommit(head.getName()));
     }
 
     private Optional<BitbucketPullRequest> fetchBitbucketPullRequest(BitbucketPullRequestSCMHead head) {
-        BitbucketSCMSource.DescriptorImpl descriptor = (BitbucketSCMSource.DescriptorImpl) getDescriptor();
-
-        return descriptor.getConfiguration(getServerId()).map(serverConfiguration -> {
-            BitbucketScmHelper scmHelper = descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(), getCredentials().orElse(null));
-            return scmHelper.getRepositoryClient(getProjectKey(), getRepositorySlug())
-                    .getPullRequest(head.getPullRequest().getPullRequestId());
-        });
+        return getScmHelper().map(scmHelper -> scmHelper.getRepositoryClient(getProjectKey(), getRepositorySlug())
+                .getPullRequest(head.getPullRequest().getPullRequestId()));
     }
 
     private Optional<BitbucketTag> fetchBitbucketTag(BitbucketTagSCMHead head, TaskListener listener) {
+        return getScmHelper().map(scmHelper -> scmHelper.getTagClient(getProjectKey(), getRepositorySlug(), listener)
+                .getRemoteTag(head.getName()));
+    }
+
+    private Optional<BitbucketScmHelper> getScmHelper() {
         BitbucketSCMSource.DescriptorImpl descriptor = (BitbucketSCMSource.DescriptorImpl) getDescriptor();
 
-        return descriptor.getConfiguration(getServerId()).map(serverConfiguration -> {
-            BitbucketScmHelper scmHelper = descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(), getCredentials().orElse(null));
-            return scmHelper.getTagClient(getProjectKey(), getRepositorySlug(), listener)
-                    .getRemoteTag(head.getName());
-        });
+        return descriptor.getConfiguration(getServerId()).map(serverConfiguration ->
+                descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(), getCredentials().orElse(null)));
     }
 
     @Symbol("BbS")

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
@@ -114,4 +114,9 @@ public class BitbucketScmHelper {
                 .getRepositoryClient(repositorySlug)
                 .getBitbucketTagClient(listener);
     }
+
+    public BitbucketRepositoryClient getRepositoryClient(String projectKey, String repositorySlug) {
+        return clientFactory.getProjectClient(projectKey)
+                .getRepositoryClient(repositorySlug);
+    }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
@@ -1,9 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactory;
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketFilePathClient;
-import com.atlassian.bitbucket.jenkins.internal.client.BitbucketTagClient;
+import com.atlassian.bitbucket.jenkins.internal.client.*;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClientException;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
@@ -98,6 +95,12 @@ public class BitbucketScmHelper {
                     e.getMessage());
             return Optional.empty();
         }
+    }
+
+    public BitbucketCommitClient getCommitClient(String projectKey, String repositorySlug) {
+        return clientFactory.getProjectClient(projectKey)
+                .getRepositoryClient(repositorySlug)
+                .getCommitClient();
     }
 
     public BitbucketFilePathClient getFilePathClient(String projectKey, String repositorySlug) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
@@ -70,9 +70,7 @@ public class BitbucketScmHelper {
             BitbucketProject project = getProjectByNameOrKey(projectName, clientFactory);
             try {
                 BitbucketRepository repository = getRepositoryByNameOrSlug(project.getName(), repositoryName, clientFactory);
-                return Optional.of(clientFactory
-                            .getProjectClient(project.getKey())
-                            .getRepositoryClient(repository.getSlug())
+                return Optional.of(getRepositoryClient(project.getKey(), repository.getSlug())
                             .getDefaultBranch());
             } catch (NotFoundException e) {
                 LOGGER.info("Error creating the Bitbucket SCM: Cannot find the default branch for " + projectName + "/"
@@ -98,20 +96,17 @@ public class BitbucketScmHelper {
     }
 
     public BitbucketCommitClient getCommitClient(String projectKey, String repositorySlug) {
-        return clientFactory.getProjectClient(projectKey)
-                .getRepositoryClient(repositorySlug)
+        return getRepositoryClient(projectKey, repositorySlug)
                 .getCommitClient();
     }
 
     public BitbucketFilePathClient getFilePathClient(String projectKey, String repositorySlug) {
-        return clientFactory.getProjectClient(projectKey)
-                .getRepositoryClient(repositorySlug)
+        return getRepositoryClient(projectKey, repositorySlug)
                 .getFilePathClient();
     }
 
     public BitbucketTagClient getTagClient(String projectKey, String repositorySlug, TaskListener listener) {
-        return clientFactory.getProjectClient(projectKey)
-                .getRepositoryClient(repositorySlug)
+        return getRepositoryClient(projectKey, repositorySlug)
                 .getBitbucketTagClient(listener);
     }
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImplTest.java
@@ -1,0 +1,52 @@
+package com.atlassian.bitbucket.jenkins.internal.client;
+
+import com.atlassian.bitbucket.jenkins.internal.fixture.FakeRemoteHttpServer;
+import com.atlassian.bitbucket.jenkins.internal.http.HttpRequestExecutorImpl;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCommit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials.ANONYMOUS_CREDENTIALS;
+import static com.atlassian.bitbucket.jenkins.internal.util.TestUtils.*;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketCommitClientImplTest {
+
+    private static final String PROJECT_KEY = "PROJECT_1";
+    private static final String REPO_SLUG = "rep_1";
+    private static final String COMMITS_URL = "%s/rest/api/1.0/projects/%s/repos/%s/commits/%s";
+    private final FakeRemoteHttpServer fakeRemoteHttpServer = new FakeRemoteHttpServer();
+    private final HttpRequestExecutor requestExecutor = new HttpRequestExecutorImpl(fakeRemoteHttpServer);
+    private final BitbucketRequestExecutor bitbucketRequestExecutor = new BitbucketRequestExecutor(BITBUCKET_BASE_URL,
+            requestExecutor, OBJECT_MAPPER, ANONYMOUS_CREDENTIALS);
+    @Mock
+    private BitbucketCapabilitiesClient capabilitiesClient;
+    private BitbucketRepositoryClientImpl client;
+
+    @Before
+    public void setup() {
+        client = new BitbucketRepositoryClientImpl(bitbucketRequestExecutor,
+                capabilitiesClient, PROJECT_KEY, REPO_SLUG);
+    }
+
+    @Test
+    public void testGetCommit() {
+        String commitId = "559aa7ba386";
+        String response = readFileToString("/commit.json");
+        String url = format(COMMITS_URL, BITBUCKET_BASE_URL, PROJECT_KEY, REPO_SLUG, commitId);
+        fakeRemoteHttpServer.mapUrlToResult(url, response);
+
+        BitbucketCommitClient commitClient = client.getCommitClient();
+        BitbucketCommit commit = commitClient.getCommit(commitId);
+
+        assertEquals("559aa7ba386219254f9448ed24cdaa6e914e5fde", commit.getId());
+        assertEquals("559aa7ba386", commit.getDisplayId());
+        assertEquals("Commit message", commit.getMessage());
+        assertEquals(1421908805000L, commit.getCommitterTimestamp());
+    }
+}

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketRepositoryClientImplTest.java
@@ -47,6 +47,7 @@ public class BitbucketRepositoryClientImplTest {
 
     private static final String DEFAULT_BRANCH_URL = "%s/rest/api/1.0/projects/%s/repos/%s/default-branch";
     private static final String PROJECT_KEY = "PROJECT_1";
+    private static final String PULL_REQUEST_URL = "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s";
     private static final String REPO_SLUG = "rep_1";
     private static final String REVISION = "bc891c29e289e373fbf8daff411480e8da6d5252";
     private static final String WEBHOOK_URL = "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests?withAttributes=false&withProperties=false&state=OPEN";
@@ -74,6 +75,19 @@ public class BitbucketRepositoryClientImplTest {
         
         client = new BitbucketRepositoryClientImpl(bitbucketRequestExecutor,
                 capabilitiesClient, PROJECT_KEY, REPO_SLUG);
+    }
+
+    @Test
+    public void testFetchingPullRequest() {
+        String response = readFileToString("/open-pull-request.json");
+        String url = format(PULL_REQUEST_URL, BITBUCKET_BASE_URL, PROJECT_KEY, REPO_SLUG, 97);
+        fakeRemoteHttpServer.mapUrlToResult(url, response);
+
+        BitbucketPullRequest pullRequest = client.getPullRequest(97);
+
+        assertEquals(97, pullRequest.getId());
+        assertEquals(BitbucketPullRequestState.OPEN, pullRequest.getState());
+        assertEquals("e48655db012cd6da02b2b2dbfea569335c7f3495", pullRequest.getFromRef().getLatestCommit());
     }
 
     @Test

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -1,5 +1,9 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketCommitClient;
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketRepositoryClient;
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketTagClient;
+import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.credentials.GlobalCredentialsProvider;
 import com.atlassian.bitbucket.jenkins.internal.link.BitbucketExternalLink;
@@ -15,6 +19,7 @@ import com.atlassian.bitbucket.jenkins.internal.trigger.events.RefsChangedWebhoo
 import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.Action;
 import hudson.model.Actionable;
+import hudson.model.TaskListener;
 import jenkins.branch.MultiBranchProject;
 import jenkins.scm.api.*;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
@@ -35,6 +40,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -380,6 +387,175 @@ public class BitbucketSCMSourceTest {
         assertThat(bitbucketSCMsource.isEventApplicable(null), equalTo(false));
     }
 
+    @Test
+    public void testRetrieveNonExistentPullRequestHeadReturnsNull() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        TaskListener taskListener = mock(TaskListener.class);
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        MinimalPullRequest pullRequest = mock(MinimalPullRequest.class);
+        when(pullRequest.getPullRequestId()).thenReturn(1L);
+        BitbucketPullRequestSCMHead head = mock(BitbucketPullRequestSCMHead.class);
+        when(head.getPullRequest()).thenReturn(pullRequest);
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketRepositoryClient repositoryClient = mock(BitbucketRepositoryClient.class);
+        when(helper.getRepositoryClient(PROJECT_NAME, REPOSITORY_NAME)).thenReturn(repositoryClient);
+        when(repositoryClient.getPullRequest(1)).thenThrow(new NotFoundException("The requested resource does not exist", null));
+
+        assertNull(bitbucketSCMsource.retrieve(head, taskListener));
+        verify(taskListener).error("The requested resource does not exist");
+    }
+
+    @Test
+    public void testRetrievePullRequestHeadFetchesLatestHead() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        MinimalPullRequest pullRequest = mock(MinimalPullRequest.class);
+        when(pullRequest.getPullRequestId()).thenReturn(1L);
+        BitbucketPullRequestSCMHead head = mock(BitbucketPullRequestSCMHead.class);
+        when(head.getPullRequest()).thenReturn(pullRequest);
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketRepositoryClient repositoryClient = mock(BitbucketRepositoryClient.class);
+        when(helper.getRepositoryClient(PROJECT_NAME, REPOSITORY_NAME)).thenReturn(repositoryClient);
+        BitbucketPullRequest latestPullRequest = mock(BitbucketPullRequest.class, RETURNS_DEEP_STUBS);
+        when(latestPullRequest.getFromRef().getLatestCommit()).thenReturn("a1b2c3");
+        when(latestPullRequest.getToRef().getDisplayId()).thenReturn("PR");
+        when(repositoryClient.getPullRequest(1)).thenReturn(latestPullRequest);
+
+        BitbucketSCMRevision revision = (BitbucketSCMRevision) bitbucketSCMsource.retrieve(head, null);
+
+        assertEquals("a1b2c3", revision.getHash());
+    }
+
+    @Test
+    public void testRetrieveNonExistentBranchHeadReturnsNull() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        TaskListener taskListener = mock(TaskListener.class);
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        BitbucketBranchSCMHead head = mock(BitbucketBranchSCMHead.class);
+        when(head.getName()).thenReturn("branch1");
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketCommitClient commitClient = mock(BitbucketCommitClient.class);
+        when(helper.getCommitClient(PROJECT_NAME, REPOSITORY_NAME)).thenReturn(commitClient);
+        when(commitClient.getCommit("branch1")).thenThrow(new NotFoundException("The requested resource does not exist", null));
+
+        assertNull(bitbucketSCMsource.retrieve(head, taskListener));
+        verify(taskListener).error("The requested resource does not exist");
+    }
+
+    @Test
+    public void testRetrieveBranchHeadFetchesLatestHead() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        BitbucketBranchSCMHead head = mock(BitbucketBranchSCMHead.class);
+        when(head.getName()).thenReturn("branch1");
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketCommitClient commitClient = mock(BitbucketCommitClient.class);
+        when(helper.getCommitClient(PROJECT_NAME, REPOSITORY_NAME)).thenReturn(commitClient);
+        when(commitClient.getCommit("branch1")).thenReturn(new BitbucketCommit("a1b2c3d4e5f6", "a1b2c3", 1L, "updated docs"));
+
+        BitbucketSCMRevision revision = (BitbucketSCMRevision) bitbucketSCMsource.retrieve(head, null);
+
+        assertEquals("a1b2c3d4e5f6", revision.getHash());
+    }
+
+    @Test
+    public void testRetrieveNonExistentTagReturnsNull() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        TaskListener taskListener = mock(TaskListener.class);
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        BitbucketTagSCMHead head = mock(BitbucketTagSCMHead.class);
+        when(head.getName()).thenReturn("tag1");
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketTagClient tagClient = mock(BitbucketTagClient.class);
+        when(helper.getTagClient(PROJECT_NAME, REPOSITORY_NAME, taskListener)).thenReturn(tagClient);
+        when(tagClient.getRemoteTag("tag1")).thenThrow(new NotFoundException("The requested resource does not exist", null));
+
+        assertNull(bitbucketSCMsource.retrieve(head, taskListener));
+        verify(taskListener).error("The requested resource does not exist");
+    }
+
+    @Test
+    public void testRetrieveTagHeadFetchesLatestHead() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        TaskListener taskListener = mock(TaskListener.class);
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        BitbucketTagSCMHead head = mock(BitbucketTagSCMHead.class);
+        when(head.getName()).thenReturn("tag1");
+
+        BitbucketSCMSource.DescriptorImpl descriptor = setupDescriptor(bitbucketSCMsource, SERVER_ID, BASE_URL, owner);
+        BitbucketScmHelper helper = descriptor.getBitbucketScmHelper(BASE_URL, null);
+        BitbucketTagClient tagClient = mock(BitbucketTagClient.class);
+        when(helper.getTagClient(PROJECT_NAME, REPOSITORY_NAME, taskListener)).thenReturn(tagClient);
+        when(tagClient.getRemoteTag("tag1")).thenReturn(new BitbucketTag("refs/heads/tag1", "tag1", "jklmno"));
+
+        BitbucketSCMRevision revision = (BitbucketSCMRevision) bitbucketSCMsource.retrieve(head, taskListener);
+
+        assertEquals("jklmno", revision.getHash());
+    }
+
+    @Test
+    public void testRetrieveUnknownHeadType() throws IOException, InterruptedException {
+        BitbucketSCMSource bitbucketSCMsource = new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build();
+
+        TaskListener taskListener = mock(TaskListener.class);
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        bitbucketSCMsource.setOwner(owner);
+        UnknownHead unknownHead = new UnknownHead("unknown");
+
+        assertNull(bitbucketSCMsource.retrieve(unknownHead, taskListener));
+        verify(taskListener).error("Error resolving revision, unsupported SCMHead type class " + UnknownHead.class.getName());
+    }
+
     private BitbucketSCMSource.DescriptorImpl setupDescriptor(BitbucketSCMSource bitbucketSCMSource,
                                                               String serverId, String baseUrl,
                                                               MultiBranchProject<?, ?> owner) {
@@ -474,6 +650,7 @@ public class BitbucketSCMSourceTest {
                         when(project.getName()).thenReturn(PROJECT_NAME);
                         when(project.getKey()).thenReturn(PROJECT_NAME);
                         when(repository.getProject()).thenReturn(project);
+                        when(repository.getSlug()).thenReturn(REPOSITORY_NAME);
                         when(repository.getCloneUrls()).thenReturn(Arrays.asList(httpLink, sshLink));
                         when(repository.getSelfLink()).thenReturn("");
                         doReturn(mock(GlobalCredentialsProvider.class))
@@ -516,6 +693,11 @@ public class BitbucketSCMSourceTest {
             return this;
         }
 
+        public SCMSourceBuilder repositorySlug(String repositorySlug) {
+            this.repositoryName = requireNonNull(repositorySlug, "repositorySlug");
+            return this;
+        }
+
         public SCMSourceBuilder serverId(String serverId) {
             this.serverId = requireNonNull(serverId, "serverId");
             return this;
@@ -524,6 +706,13 @@ public class BitbucketSCMSourceTest {
         public SCMSourceBuilder sshCredentialId(String sshCredentialId) {
             this.sshCredentialId = requireNonNull(sshCredentialId, "sshCredentialId");
             return this;
+        }
+    }
+
+    private static class UnknownHead extends SCMHead {
+
+        public UnknownHead(String name) {
+            super(name);
         }
     }
 }

--- a/src/test/resources/commit.json
+++ b/src/test/resources/commit.json
@@ -1,0 +1,6 @@
+{
+  "id": "559aa7ba386219254f9448ed24cdaa6e914e5fde",
+  "displayId": "559aa7ba386",
+  "committerTimestamp": "1421908805000",
+  "message": "Commit message"
+}

--- a/src/test/resources/open-pull-request.json
+++ b/src/test/resources/open-pull-request.json
@@ -1,0 +1,146 @@
+{
+  "id": 97,
+  "version": 1,
+  "title": "Branchtest",
+  "description": "* test.txt edited online with Bitbucket\r\n* test.txt edited online with Bitbucket",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1610942418166,
+  "updatedDate": 1610942418166,
+  "fromRef": {
+    "id": "refs/heads/branchtest",
+    "displayId": "branchtest",
+    "latestCommit": "e48655db012cd6da02b2b2dbfea569335c7f3495",
+    "repository": {
+      "slug": "rep_1",
+      "id": 1,
+      "name": "rep_1",
+      "hierarchyId": "634a12bd02410f7d954d",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "PROJECT_1",
+        "id": 1,
+        "name": "PROJECT_1",
+        "description": "PROJECT_1",
+        "public": false,
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "http://localhost:7990/bitbucket/projects/PROJECT_1"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [
+          {
+            "href": "http://localhost:7990/bitbucket/scm/project_1/rep_1.git",
+            "name": "http"
+          },
+          {
+            "href": "ssh://git@localhost:7999/project_1/rep_1.git",
+            "name": "ssh"
+          }
+        ],
+        "self": [
+          {
+            "href": "http://localhost:7990/bitbucket/projects/PROJECT_1/repos/rep_1/browse"
+          }
+        ]
+      }
+    }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "1c4c3f92b4f8078e04b7f5a64ce7476a2d4276e0",
+    "repository": {
+      "slug": "rep_1",
+      "id": 1,
+      "name": "rep_1",
+      "hierarchyId": "634a12bd02410f7d954d",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "PROJECT_1",
+        "id": 1,
+        "name": "PROJECT_1",
+        "description": "PROJECT_1",
+        "public": false,
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "http://localhost:7990/bitbucket/projects/PROJECT_1"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [
+          {
+            "href": "http://localhost:7990/bitbucket/scm/project_1/rep_1.git",
+            "name": "http"
+          },
+          {
+            "href": "ssh://git@localhost:7999/project_1/rep_1.git",
+            "name": "ssh"
+          }
+        ],
+        "self": [
+          {
+            "href": "http://localhost:7990/bitbucket/projects/PROJECT_1/repos/rep_1/browse"
+          }
+        ]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "admin",
+      "emailAddress": "admin@example.com",
+      "id": 2,
+      "displayName": "Administrator",
+      "active": true,
+      "slug": "admin",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "http://localhost:7990/bitbucket/users/admin"
+          }
+        ]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "properties": {
+    "mergeResult": {
+      "outcome": "CONFLICTED",
+      "current": false
+    },
+    "resolvedTaskCount": 0,
+    "openTaskCount": 0
+  },
+  "links": {
+    "self": [
+      {
+        "href": "http://localhost:7990/bitbucket/projects/PROJECT_1/repos/rep_1/pull-requests/97"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Addresses [JENKINS-73267](https://issues.jenkins.io/browse/JENKINS-73267) by fetching the latest head in `SCMSource#retrieve(SCMHead head, TaskListener listener)`, for pull request / branch SCMHeads (with corresponding new client methods to get the data from Bitbucket).

### Testing done
- unit tests
- manual tests
  - using reproduction steps in JENKINS-73267 for multibranch pipelines (one to discover branches, one to discover pull requests)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
