### PR TITLE
JENKINS-73871 Fix tag and branch names not building with slash in it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,9 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 4.1.1
+- [JEKINS-73871](https://issues.jenkins.io/browse/JENKINS-73871): Fix branch and tag names with slashes, not being built.
+
 ### 4.1.0
 - [JENKINS-72120](https://issues.jenkins.io/browse/JENKINS-72120) Implemented discovery of tags. This introduces a tag discovery trait enabling Multibranch pipelines to
   detect tags. The trait will not initialise builds.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImpl.java
@@ -3,6 +3,9 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketCommit;
 import okhttp3.HttpUrl;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 public class BitbucketCommitClientImpl implements BitbucketCommitClient {
 
     private final BitbucketRequestExecutor bitbucketRequestExecutor;
@@ -19,14 +22,19 @@ public class BitbucketCommitClientImpl implements BitbucketCommitClient {
 
     @Override
     public BitbucketCommit getCommit(String identifier) {
-        HttpUrl url = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
-                .addPathSegment("projects")
-                .addPathSegment(projectKey)
-                .addPathSegment("repos")
-                .addPathSegment(repositorySlug)
-                .addPathSegment("commits")
-                .addPathSegment(identifier)
-                .build();
+        HttpUrl url = null;
+        try {
+            url = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
+                    .addPathSegment("projects")
+                    .addPathSegment(projectKey)
+                    .addPathSegment("repos")
+                    .addPathSegment(repositorySlug)
+                    .addPathSegment("commits")
+                    .addPathSegment(URLEncoder.encode(identifier, "UTF-8"))
+                    .build();
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
 
         return bitbucketRequestExecutor.makeGetRequest(url, BitbucketCommit.class).getBody();
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketTagClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketTagClientImpl.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import hudson.model.TaskListener;
 import okhttp3.HttpUrl;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,13 +62,18 @@ public class BitbucketTagClientImpl implements BitbucketTagClient {
     }
 
     public BitbucketTag getRemoteTag(String tagName) {
-        HttpUrl.Builder urlBuilder = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
-                .addPathSegment("projects")
-                .addPathSegment(projectKey)
-                .addPathSegment("repos")
-                .addPathSegment(repositorySlug)
-                .addPathSegment("tags")
-                .addPathSegment(tagName);
+        HttpUrl.Builder urlBuilder = null;
+        try {
+            urlBuilder = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
+                    .addPathSegment("projects")
+                    .addPathSegment(projectKey)
+                    .addPathSegment("repos")
+                    .addPathSegment(repositorySlug)
+                    .addPathSegment("tags")
+                    .addPathSegment(URLEncoder.encode(tagName, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
 
         HttpUrl url = urlBuilder.build();
         BitbucketTag tag = bitbucketRequestExecutor.makeGetRequest(url, BitbucketTag.class).getBody();

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketCommitClientImplTest.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.UnsupportedEncodingException;
+
 import static com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials.ANONYMOUS_CREDENTIALS;
 import static com.atlassian.bitbucket.jenkins.internal.util.TestUtils.*;
 import static java.lang.String.format;
@@ -35,17 +37,18 @@ public class BitbucketCommitClientImplTest {
     }
 
     @Test
-    public void testGetCommit() {
-        String commitId = "559aa7ba386";
+    public void testGetCommit() throws UnsupportedEncodingException {
+        String commitId = "feature/myfeature";
+        String encodedCommitId = "feature%252Fmyfeature"; // for some reason apache double encodes the url
         String response = readFileToString("/commit.json");
-        String url = format(COMMITS_URL, BITBUCKET_BASE_URL, PROJECT_KEY, REPO_SLUG, commitId);
+        String url = format(COMMITS_URL, BITBUCKET_BASE_URL, PROJECT_KEY, REPO_SLUG, encodedCommitId);
         fakeRemoteHttpServer.mapUrlToResult(url, response);
 
         BitbucketCommitClient commitClient = client.getCommitClient();
         BitbucketCommit commit = commitClient.getCommit(commitId);
 
         assertEquals("559aa7ba386219254f9448ed24cdaa6e914e5fde", commit.getId());
-        assertEquals("559aa7ba386", commit.getDisplayId());
+        assertEquals("feature/myfeature", commit.getDisplayId());
         assertEquals("Commit message", commit.getMessage());
         assertEquals(1421908805000L, commit.getCommitterTimestamp());
     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketTagClientImplTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketTagClientImplTest.java
@@ -57,8 +57,8 @@ public class BitbucketTagClientImplTest {
         BitbucketTagClient tagClient = client.getBitbucketTagClient(taskListener);
         List<BitbucketTag> tagList = tagClient.getRemoteTags().collect(Collectors.toList());
 
-        assertEquals(tagList.size(), 1);
-        assertEquals(tagList.get(0).getDisplayId(), "tag_1");
+        assertEquals(1, tagList.size());
+        assertEquals("release/tag_1", tagList.get(0).getDisplayId());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/resources/commit.json
+++ b/src/test/resources/commit.json
@@ -1,6 +1,6 @@
 {
   "id": "559aa7ba386219254f9448ed24cdaa6e914e5fde",
-  "displayId": "559aa7ba386",
+  "displayId": "feature/myfeature",
   "committerTimestamp": "1421908805000",
   "message": "Commit message"
 }

--- a/src/test/resources/tags.json
+++ b/src/test/resources/tags.json
@@ -5,7 +5,7 @@
   "values": [
     {
       "id":"refs/tags/tag_1",
-      "displayId":"tag_1",
+      "displayId":"release/tag_1",
       "latestCommit":"a69daea0ed930057bac6d5fc2f7ca21acad66491"
     }
   ]


### PR DESCRIPTION
Branch and tag names with slashes could not be built due to not encoding the slashes for the query parameter. Adds url encoding to the branch / tag name. 

The exception shouldn't be thrown unless your JVM doesn't support "UTF-8" encoding. 

### Testing done
* Manual testing was carried out against both tags & branches. 
* Integration and unit testing has also been performed.