### PR TITLE
JENKINS-74782 fix build status ref

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPRBranchNameDecorator.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPRBranchNameDecorator.java
@@ -1,0 +1,37 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BitbucketPRBranchNameDecorator extends GitSCMExtension {
+
+    private final BitbucketPullRequestSCMHead pullRequestSCMHead;
+
+    public BitbucketPRBranchNameDecorator(BitbucketPullRequestSCMHead pullRequestSCMHead) {
+        this.pullRequestSCMHead = pullRequestSCMHead;
+    }
+
+    @Override
+    public void populateEnvironmentVariables(GitSCM scm, Map<String, String> env) {
+        env.put(GitSCM.GIT_BRANCH, pullRequestSCMHead.getOriginName());
+    }
+
+    @Override
+    public Revision decorateRevisionToBuild(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, Revision marked, Revision rev) throws GitException {
+        List<Branch> branches = rev.getBranches().stream()
+                .map(branch -> new Branch(pullRequestSCMHead.getOriginName(), branch.getSHA1()))
+                .collect(Collectors.toList());
+        rev.setBranches(branches);
+        return rev;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPREnvironmentContributor.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPREnvironmentContributor.java
@@ -1,0 +1,34 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.*;
+import jenkins.branch.Branch;
+import jenkins.branch.BranchProjectFactory;
+import jenkins.branch.MultiBranchProject;
+import jenkins.scm.api.SCMHead;
+
+@Extension
+public class BitbucketPREnvironmentContributor extends EnvironmentContributor {
+
+    @Override
+    public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) {
+        buildEnvironmentFor(r.getParent(), envs, listener);
+    }
+
+    public void buildEnvironmentFor(@NonNull Job job, @NonNull EnvVars envs, @NonNull TaskListener listener) {
+        ItemGroup parent = job.getParent();
+        if (parent instanceof MultiBranchProject) {
+            BranchProjectFactory projectFactory = ((MultiBranchProject) parent).getProjectFactory();
+            if (projectFactory.isProject(job)) {
+                Branch branch = projectFactory.getBranch(job);
+                SCMHead head = branch.getHead();
+                if (head instanceof BitbucketPullRequestSCMHead) {
+                    BitbucketPullRequestSCMHead prHead = (BitbucketPullRequestSCMHead) head;
+                    envs.put("BRANCH_NAME", prHead.getOriginName());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -165,6 +165,9 @@ public class BitbucketSCMSource extends SCMSource {
         }
 
         builder.withTraits(traits);
+        if (head instanceof BitbucketPullRequestSCMHead) {
+            builder.withExtension(new BitbucketPRBranchNameDecorator((BitbucketPullRequestSCMHead) head));
+        }
         return builder.build();
     }
 


### PR DESCRIPTION
When we introduced the`BitbucketPullRequestSCMHead` we accidentally changed the value of a number of variables. This puts those variables back to what they should be. This included the `GIT_BRANCH` variable which was used by the `BuildStatusPoster` to post the build status.

Unfortunately  the `WorkflowRun` and `WorkFlowJob` are `final` which makes writing unit tests very hard, so I opted for not doing any tests :( Most of the new code is pretty basic so while a unit test would be beneficial I don't think it is disastrous without it.