### PR TITLE
JENKINS-74736 fix class cast exception

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,10 @@ Integration tests are run under the `it` profile with the Failsafe plugin using 
 
 ## Changelog
 
+### 4.1.3 (still unreleased)
+- [JENKINS-74736](https://issues.jenkins.io/browse/JENKINS-74736): Fixed an issue that could occur with tag discovery if
+  other discovery behaviours were enabled
+
 ### 4.1.2
 - [JENKINS-74782](https://issues.jenkins.io/browse/JENKINS-74782): Previously the pull request name was sent to the build
   status. This has been remedied to now send the source branch ref name.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTrait.java
@@ -39,7 +39,7 @@ public class BitbucketTagDiscoveryTrait extends SCMSourceTrait {
             GitSCMBuilder<?> gitSCMBuilder = (GitSCMBuilder<?>) builder;
             SCMRevision revision = gitSCMBuilder.revision();
 
-            if (revision instanceof BitbucketSCMRevision) {
+            if (revision instanceof BitbucketSCMRevision && revision.getHead() instanceof BitbucketTagSCMHead) {
                 BitbucketSCMRevision tagRevision = (BitbucketSCMRevision) revision;
                 BitbucketTagSCMHead tagHead = (BitbucketTagSCMHead) tagRevision.getHead();
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTraitTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTraitTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -103,7 +104,6 @@ public class BitbucketTagDiscoveryTraitTest {
 
     @Test
     public void testDecorateBuilder() {
-        BitbucketProject project = new BitbucketProject(TEST_PROJECT_KEY, null, TEST_PROJECT_KEY);
         BitbucketTag bitbucketTag = new BitbucketTag("1", "tag", "1");
         BitbucketTagSCMHead head = new BitbucketTagSCMHead(bitbucketTag);
         BitbucketSCMRevision revision = new BitbucketSCMRevision(head, null);
@@ -112,7 +112,6 @@ public class BitbucketTagDiscoveryTraitTest {
         underTest.decorateBuilder(scmBuilder);
 
         assertThat(scmBuilder.extensions().get(0), instanceOf(BitbucketTagSourceBranch.class));
-
     }
 
     @Test
@@ -163,6 +162,18 @@ public class BitbucketTagDiscoveryTraitTest {
         // Verify that the client fetches branches and converts them into heads
         verify(bitbucketTagClient).getRemoteTags();
         assertThat(heads, Matchers.contains(new BitbucketTagSCMHead(tag)));
+    }
+
+    @Test
+    public void testHandlingDifferentHeads() {
+        //if you enable more than one discovery isenabled our tag discovery may be called with a different HEAD type
+        BitbucketPullRequestSCMHead head = mock(BitbucketPullRequestSCMHead.class);
+        BitbucketSCMRevision revision = new BitbucketSCMRevision(head, null);
+        GitSCMBuilder scmBuilder = new GitSCMBuilder(head, revision, "remote", null);
+
+        underTest.decorateBuilder(scmBuilder);
+
+        assertTrue(scmBuilder.extensions().isEmpty());
     }
 
     private void initContext(Set<SCMHead> eventHeads) {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTraitTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketTagDiscoveryTraitTest.java
@@ -166,7 +166,7 @@ public class BitbucketTagDiscoveryTraitTest {
 
     @Test
     public void testHandlingDifferentHeads() {
-        //if you enable more than one discovery isenabled our tag discovery may be called with a different HEAD type
+        //if you enable more than one discovery is enabled our tag discovery may be called with a different HEAD type
         BitbucketPullRequestSCMHead head = mock(BitbucketPullRequestSCMHead.class);
         BitbucketSCMRevision revision = new BitbucketSCMRevision(head, null);
         GitSCMBuilder scmBuilder = new GitSCMBuilder(head, revision, "remote", null);


### PR DESCRIPTION
When multiple discovery behaviours are enabled the decorateBuilder may be called multiple times with different heads.
 This ensures that calling the method with a different head type does no throw any exception, instead the head is
 just ignored.
