### PR TITLE
JENKINS-75494 Fix pr builds not getting correct refs

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -306,7 +306,7 @@ public class BitbucketSCMSource extends SCMSource {
             if (head instanceof BitbucketPullRequestSCMHead) {
                 return fetchBitbucketPullRequest((BitbucketPullRequestSCMHead) head).map(fetchedPullRequest -> {
                     BitbucketPullRequestSCMHead latestHead = new BitbucketPullRequestSCMHead(fetchedPullRequest);
-                    return new BitbucketSCMRevision(latestHead, latestHead.getLatestCommit());
+                    return new BitbucketPullRequestSCMRevision(latestHead);
                 }).orElse(null);
             }
 

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -36,8 +36,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -433,9 +432,11 @@ public class BitbucketSCMSourceTest {
         when(latestPullRequest.getToRef().getDisplayId()).thenReturn("PR");
         when(repositoryClient.getPullRequest(1)).thenReturn(latestPullRequest);
 
-        BitbucketSCMRevision revision = (BitbucketSCMRevision) bitbucketSCMsource.retrieve(head, null);
+        SCMRevision revision = bitbucketSCMsource.retrieve(head, null);
 
-        assertEquals("a1b2c3", revision.getHash());
+        BitbucketPullRequestSCMRevision prRevision = (BitbucketPullRequestSCMRevision) revision;
+        assertNotNull(prRevision);
+        assertEquals("a1b2c3", prRevision.getCommitHash());
     }
 
     @Test


### PR DESCRIPTION
### Whats changed?
* Fixed JENKINS-75494 - PR builds not correctly having refs populated when a fork is used in a PR.
* This occurs due to the Jenkins user making the checkout not having appropriate access to the forked repository