### PR TITLE
BBSDEV-34436 - Fix Upgrade Test

### DIFF
--- a/src/test/java/upgrade/com/atlassian/bitbucket/jenkins/internal/UpgradeTest.java
+++ b/src/test/java/upgrade/com/atlassian/bitbucket/jenkins/internal/UpgradeTest.java
@@ -53,6 +53,8 @@ public class UpgradeTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
+    private static final String HPI_URL="https://updates.jenkins.io/latest/atlassian-bitbucket-server-integration.hpi";
+
     /**
      * This is a rather complicated test with lots of supporting methods. The gist of it is
      * 1. Download the already released version of the plugin
@@ -196,15 +198,7 @@ public class UpgradeTest {
         File releasedHPIFile = getDestinationFile(tempDir);
         //when working locally no need to go and get the file every time
         if (!releasedHPIFile.exists()) {
-            System.out.println("Updating the update center");
-            //update the update center, so we know of latest versions
-            jenkins.jenkins.getUpdateCenter().updateAllSites();
-            //get our plugin, this is the latest released version (compatible withe the version of Jenkins we run in the test
-            UpdateSite.Plugin plugin = jenkins.jenkins.getUpdateCenter().getPlugin("atlassian-bitbucket-server-integration");
-            System.out.println("Will download: " + plugin.url);
-            System.out.println("Downloading hpi file");
-            //use Commons.io to download the HPI file, wait 10s for connection and 10s for data transfer to start
-            FileUtils.copyURLToFile(new URL(plugin.url), releasedHPIFile, 10_000, 10_1000);
+            FileUtils.copyURLToFile(new URL(HPI_URL), releasedHPIFile, 10_000, 10_1000);
             //the HPI is just a war file, so we need to unzip it.
             //this unzip code is stolen from the internet, and is unsafe, it is good enough for a proof of concept
             System.out.println("Unzip hpi file");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The `updateCenter` test is failing and is causing our build to [fail](https://server-syd-bamboo.internal.atlassian.com/browse/BSERVTOOLS-BBSJEN-1098). The update center in the jenkins rule doesn't appear to work anymore, it just returns a 308 error, which is causing the test to fail with the below error. 

`java.util.concurrent.ExecutionException: java.io.IOException: Could not find JSON in http://localhost:33013/update-center.json?id=default&version=2.426.3
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)`

Instead of relying on the update center to get the latest version of the plugin, we can just go directly to the source and download it from the download site. 

### Testing done

Test passes locally. 

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
