### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 buildPlugin(
 useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
+    [platform: 'linux', jdk: 25],
     [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  Jenkins core (weekly) has supported Java 25 since Jenkins 2.534, Oct 28, 2025.  Jenkins core (LTS) has supported Java 25 since 2.541.1, Jan 21, 2026.  Over 95% of the 300 most popular plugins now compile and test with Java 25.

Java 21 and Java 25 compilers continue to generate Java 17 byte code because the parent pom assures that Java 17 byte code is generated.

### Testing done

* Confirmed that tests pass locally with Java 25.0.2 on Linux
* Used my "replay" permissions on ci.jenkins.io to run the modified Jenkinsfile in [build 2](https://ci.jenkins.io/job/Plugins/job/atlassian-bitbucket-server-integration-plugin/job/PR-483/2/)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
