### PR TITLE
Fix minor issues in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.18.3</jackson.version>
         <!-- When updating the Jenkins version, also update io.jenkins.tools.bom dependency management and the README -->
-        <jenkins.version>2.492.3</jenkins.version>
+        <jenkins.baseline>2.492</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <net.oauth.version>20100527</net.oauth.version>
         <!-- exclude the upgrade tests by default, as they interact with external resources and should not be run frequently -->
@@ -43,7 +44,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.492.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>5388.v3ea_2e00a_719a_</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -516,6 +517,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
+                <version>2.21.0</version>
                 <configuration>
                     <rulesUri>file://${project.basedir}/version-ruleset.xml</rulesUri>
                 </configuration>
@@ -659,10 +661,10 @@
     </profiles>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/atlassian-bitbucket-server-integration-plugin.git
         </developerConnection>
-        <url>http://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin</url>
+        <url>https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
## Fix minor issues in pom file

Use jenkins.baseline to avoid duplication of data in the declaration of the plugin BOM.  Common practice in over 225 of the 250 most popular and active plugin repositories.

Declare the version of the versions-maven-plugin to silence a Maven warning.

Use https:// in the git repository URL instead of git:// because GitHub no longer supports the unauthenticated git:// protocol.  Refer to https://github.blog/security/application-security/improving-git-protocol-security-github/ from Nov 2021 for more details.  Silences a Maven warning.

Use https:// in the scm repository URL instead of http:// to silence a Maven warning.

### Testing done

Confirmed that plugin compiles with fewer warnings when using these changes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
