### PR TITLE
Fix orphan detection broken by anyMatch short-circuiting head discovery

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -408,13 +408,11 @@ public class BitbucketSCMSource extends SCMSource {
                             TaskListener listener) throws IOException {
         Collection<SCMHead> eventHeads = event == null ? Collections.emptySet() : event.heads(this).keySet();
 
-        BitbucketSCMSourceContext context =
-                new BitbucketSCMSourceContext(criteria, observer, getCredentials().orElse(null), eventHeads,
-                        repository, listener).withTraits(traits);
+        BitbucketSCMSourceContext context = createSourceContext(criteria, observer, eventHeads, listener);
 
         try (BitbucketSCMSourceRequest request = context.newRequest(this, listener)) {
             for (BitbucketSCMHeadDiscoveryHandler discoveryHandler : request.getDiscoveryHandlers()) {
-                for (SCMHead scmHead : (Iterable<? extends SCMHead>) discoveryHandler.discoverHeads()::iterator) {
+                for (SCMHead scmHead : (Iterable<SCMHead>) () -> (java.util.Iterator<SCMHead>) (java.util.Iterator<?>) discoveryHandler.discoverHeads().iterator()) {
                     if (request.isComplete()) {
                         break;
                     }
@@ -434,6 +432,15 @@ public class BitbucketSCMSource extends SCMSource {
                 }
             }
         }
+    }
+
+    @VisibleForTesting
+    protected BitbucketSCMSourceContext createSourceContext(@CheckForNull SCMSourceCriteria criteria,
+                                                            SCMHeadObserver observer,
+                                                            Collection<SCMHead> eventHeads,
+                                                            TaskListener listener) {
+        return new BitbucketSCMSourceContext(criteria, observer, getCredentials().orElse(null), eventHeads,
+                repository, listener).withTraits(traits);
     }
 
     private List<BitbucketWebhookMultibranchTrigger> getTriggers(ComputedFolder<?> owner) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -414,12 +414,13 @@ public class BitbucketSCMSource extends SCMSource {
 
         try (BitbucketSCMSourceRequest request = context.newRequest(this, listener)) {
             for (BitbucketSCMHeadDiscoveryHandler discoveryHandler : request.getDiscoveryHandlers()) {
-                // Process the stream of heads as they come in and terminate the
-                // stream if the request has finished observing (returns true)
-                discoveryHandler.discoverHeads().anyMatch(scmHead -> {
+                for (SCMHead scmHead : (Iterable<? extends SCMHead>) discoveryHandler.discoverHeads()::iterator) {
+                    if (request.isComplete()) {
+                        break;
+                    }
                     SCMRevision scmRevision = discoveryHandler.toRevision(scmHead);
                     try {
-                        return request.process(
+                        request.process(
                                 scmHead,
                                 scmRevision,
                                 this::newProbe,
@@ -429,10 +430,8 @@ public class BitbucketSCMSource extends SCMSource {
                     } catch (IOException | InterruptedException e) {
                         listener.error("Error processing request for head: " + scmHead + ", revision: " +
                                 scmRevision + ", error: " + e.getMessage());
-
-                        return true;
                     }
-                });
+                }
             }
         }
     }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -405,7 +405,7 @@ public class BitbucketSCMSource extends SCMSource {
     private void doRetrieve(@CheckForNull SCMSourceCriteria criteria,
                             SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event,
-                            TaskListener listener) throws IOException {
+                            TaskListener listener) throws IOException, InterruptedException {
         Collection<SCMHead> eventHeads = event == null ? Collections.emptySet() : event.heads(this).keySet();
 
         BitbucketSCMSourceContext context = createSourceContext(criteria, observer, eventHeads, listener);
@@ -424,9 +424,6 @@ public class BitbucketSCMSource extends SCMSource {
                                 (head, revision, isMatch) ->
                                         listener.getLogger().printf("head: %s, revision: %s, isMatch: %s%n",
                                                 head, revision, isMatch));
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new IOException("Interrupted while processing head: " + scmHead, e);
                     } catch (IOException e) {
                         listener.error("Error processing request for head: " + scmHead + ", revision: " +
                                 scmRevision + ", error: " + e.getMessage());

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -412,10 +412,9 @@ public class BitbucketSCMSource extends SCMSource {
 
         try (BitbucketSCMSourceRequest request = context.newRequest(this, listener)) {
             for (BitbucketSCMHeadDiscoveryHandler discoveryHandler : request.getDiscoveryHandlers()) {
-                for (SCMHead scmHead : (Iterable<SCMHead>) () -> (java.util.Iterator<SCMHead>) (java.util.Iterator<?>) discoveryHandler.discoverHeads().iterator()) {
-                    if (request.isComplete()) {
-                        break;
-                    }
+                Iterator<? extends SCMHead> it = discoveryHandler.discoverHeads().iterator();
+                while (it.hasNext() && !request.isComplete()) {
+                    SCMHead scmHead = it.next();
                     SCMRevision scmRevision = discoveryHandler.toRevision(scmHead);
                     try {
                         request.process(
@@ -425,7 +424,10 @@ public class BitbucketSCMSource extends SCMSource {
                                 (head, revision, isMatch) ->
                                         listener.getLogger().printf("head: %s, revision: %s, isMatch: %s%n",
                                                 head, revision, isMatch));
-                    } catch (IOException | InterruptedException e) {
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted while processing head: " + scmHead, e);
+                    } catch (IOException e) {
                         listener.error("Error processing request for head: " + scmHead + ", revision: " +
                                 scmRevision + ", error: " + e.getMessage());
                     }

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceTest.java
@@ -542,6 +542,81 @@ public class BitbucketSCMSourceTest {
     }
 
     @Test
+    public void testRetrieveProcessesAllHeadsWhenObserverNeverSignalsDone() throws IOException, InterruptedException {
+        List<String> processedHeads = new ArrayList<>();
+        BitbucketSCMSourceRequest request = mockRequestWithHeads(
+                Arrays.asList(new SCMHead("PR-1"), new SCMHead("PR-2"), new SCMHead("PR-3")),
+                processedHeads,
+                false);
+
+        BitbucketSCMSource source = sourceWithMockedContext(request);
+        source.retrieve(null, SCMHeadObserver.collect(), null, mockListener());
+
+        assertThat(processedHeads, equalTo(Arrays.asList("PR-1", "PR-2", "PR-3")));
+    }
+
+    @Test
+    public void testRetrieveStopsEarlyWhenObserverSignalsDone() throws IOException, InterruptedException {
+        List<String> processedHeads = new ArrayList<>();
+        BitbucketSCMSourceRequest request = mockRequestWithHeads(
+                Arrays.asList(new SCMHead("PR-1"), new SCMHead("PR-2")),
+                processedHeads,
+                true);
+
+        BitbucketSCMSource source = sourceWithMockedContext(request);
+        source.retrieve(null, SCMHeadObserver.collect(), null, mockListener());
+
+        assertThat(processedHeads, equalTo(singletonList("PR-1")));
+    }
+
+    private BitbucketSCMSourceRequest mockRequestWithHeads(
+            List<SCMHead> heads, List<String> processedHeads, boolean stopAfterFirst) throws IOException {
+        BitbucketSCMSourceRequest request = mock(BitbucketSCMSourceRequest.class);
+        when(request.getDiscoveryHandlers()).thenReturn(singletonList(
+                new BitbucketSCMHeadDiscoveryHandler() {
+                    @Override
+                    public java.util.stream.Stream<? extends SCMHead> discoverHeads() {
+                        return heads.stream();
+                    }
+
+                    @Override
+                    public SCMRevision toRevision(SCMHead head) {
+                        processedHeads.add(head.getName());
+                        return mock(SCMRevision.class);
+                    }
+                }));
+        if (stopAfterFirst) {
+            when(request.isComplete()).thenReturn(false, true);
+        } else {
+            when(request.isComplete()).thenReturn(false);
+        }
+        return request;
+    }
+
+    private BitbucketSCMSource sourceWithMockedContext(BitbucketSCMSourceRequest request) throws IOException {
+        BitbucketSCMSourceContext context = mock(BitbucketSCMSourceContext.class);
+        when(context.newRequest(any(), any())).thenReturn(request);
+
+        BitbucketSCMSource source = spy(new SCMSourceBuilder(CREDENTIAL_ID)
+                .serverId(SERVER_ID)
+                .projectName(PROJECT_NAME)
+                .repositorySlug(REPOSITORY_NAME)
+                .build());
+        doReturn(context).when(source).createSourceContext(any(), any(), any(), any());
+        MultiBranchProject<?, ?> owner = mock(MultiBranchProject.class);
+        source.setOwner(owner);
+        doReturn(true).when(source).isValid();
+        doNothing().when(source).afterSave();
+        return source;
+    }
+
+    private TaskListener mockListener() {
+        TaskListener listener = mock(TaskListener.class);
+        when(listener.getLogger()).thenReturn(new java.io.PrintStream(java.io.OutputStream.nullOutputStream()));
+        return listener;
+    }
+
+    @Test
     public void testDescriptorDelegatesAutoCompleteProjectName() throws Exception {
         BitbucketSCMSource.DescriptorImpl descriptor = new BitbucketSCMSource.DescriptorImpl();
         BitbucketScmFormFillDelegate formFill = mock(BitbucketScmFormFillDelegate.class);
@@ -740,6 +815,7 @@ public class BitbucketSCMSourceTest {
             this.sshCredentialId = requireNonNull(sshCredentialId, "sshCredentialId");
             return this;
         }
+
     }
 
     private static class UnknownHead extends SCMHead {


### PR DESCRIPTION
## Problem

When a Multibranch Pipeline performs a full scan to detect orphaned branches, `WorkflowMultiBranchProject` passes a `SCMHeadObserver.Collector` to `retrieve()` that needs to see **all** currently open heads in order to diff against its previously-indexed jobs. Any head that was indexed but not reported back is treated as an orphan and handed to the orphan item strategy for cleanup.

The previous implementation used `anyMatch` to process the stream of discovered heads:

```java
discoveryHandler.discoverHeads().anyMatch(scmHead -> {
    ...
    return request.process(...); // returns true when observer says "done"
});
```
`anyMatch` short-circuits — it stops consuming the stream as soon as `request.process()` returns `true.` For a `Collector`-based observer this can happen before all open PRs are reported, leaving Jenkins with an incomplete picture. The result: declined or merged PR jobs are never identified as orphans, and are never cleaned up regardless of the configured `daysToKeep` / `numToKeep` strategy.

## Fix
Replace `anyMatch` with explicit iteration that checks `request.isComplete()` at the top of each step. This preserves early-termination for targeted single-branch fetches (where the observer genuinely signals it has everything it needs after one head), while ensuring full scans always process all discovered heads:

```java
for (SCMHead scmHead : (Iterable<? extends SCMHead>) discoveryHandler.discoverHeads()::iterator) {
    if (request.isComplete()) {
        break;
    }
    request.process(...);
}
```

As a side effect, errors on individual heads no longer abort the rest of the stream (previously return true inside the catch block would stop all further processing).

## Testing
Verified with a Multibranch Pipeline pointing at a Bitbucket Server instance. Triggered a Multibranch Pipeline scan -> job now correctly identified orphans and removed them as per the configured strategy.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
