### PR TITLE
JENKINS-76450 Add support for a combination of string and SSH credentials

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/CredentialUtils.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/credentials/CredentialUtils.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.credentials;
 
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
@@ -17,8 +18,8 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 public final class CredentialUtils {
 
-    private static final List<Class> CREDENTIAL_TYPES = Arrays.asList(StringCredentials.class,
-            UsernamePasswordCredentials.class, BasicSSHUserPrivateKey.class);
+    private static final List<Class> CREDENTIAL_TYPES = Arrays.asList(BitbucketTokenCredentials.class,
+            StringCredentials.class, UsernamePasswordCredentials.class, BasicSSHUserPrivateKey.class);
 
     private CredentialUtils() {
         throw new UnsupportedOperationException(

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -388,8 +388,9 @@ public class BitbucketSCM extends SCM {
         @Override
         @POST
         public FormValidation doCheckSshCredentialsId(@AncestorInPath Item context,
+                                                      @QueryParameter String credentialsId,
                                                       @QueryParameter String sshCredentialsId) {
-            return formValidation.doCheckCredentialsId(context, sshCredentialsId);
+            return formValidation.doCheckSshCredentialsId(context, credentialsId, sshCredentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM.java
@@ -440,11 +440,12 @@ public class BitbucketSCM extends SCM {
         public FormValidation doTestConnection(@AncestorInPath Item context,
                                                @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
+                                               @QueryParameter String sshCredentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName,
-                    mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, sshCredentialsId, projectName,
+                    repositoryName, mirrorName);
         }
 
         @POST

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -659,11 +659,12 @@ public class BitbucketSCMSource extends SCMSource {
         public FormValidation doTestConnection(@AncestorInPath Item context,
                                                @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
+                                               @QueryParameter String sshCredentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName,
-                    mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, sshCredentialsId, projectName,
+                    repositoryName, mirrorName);
         }
 
         public BitbucketClientFactoryProvider getBitbucketClientFactoryProvider() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -579,8 +579,9 @@ public class BitbucketSCMSource extends SCMSource {
 
         @Override
         public FormValidation doCheckSshCredentialsId(@AncestorInPath Item context,
+                                                      @QueryParameter String credentialsId,
                                                       @QueryParameter String sshCredentialsId) {
-            return formValidation.doCheckSshCredentialsId(context, sshCredentialsId);
+            return formValidation.doCheckSshCredentialsId(context, credentialsId, sshCredentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -175,8 +175,9 @@ public class BitbucketSCMStep extends SCMStep {
 
         @Override
         public FormValidation doCheckSshCredentialsId(@AncestorInPath Item context,
+                                                      @QueryParameter String credentialsId,
                                                       @QueryParameter String sshCredentialsId) {
-            return formValidation.doCheckSshCredentialsId(context, sshCredentialsId);
+            return formValidation.doCheckSshCredentialsId(context, credentialsId, sshCredentialsId);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStep.java
@@ -210,10 +210,12 @@ public class BitbucketSCMStep extends SCMStep {
         public FormValidation doTestConnection(@AncestorInPath Item context,
                                                @QueryParameter String serverId,
                                                @QueryParameter String credentialsId,
+                                               @QueryParameter String sshCredentialsId,
                                                @QueryParameter String projectName,
                                                @QueryParameter String repositoryName,
                                                @QueryParameter String mirrorName) {
-            return formValidation.doTestConnection(context, serverId, credentialsId, projectName, repositoryName, mirrorName);
+            return formValidation.doTestConnection(context, serverId, credentialsId, sshCredentialsId, projectName,
+                    repositoryName, mirrorName);
         }
 
         @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormFillDelegate.java
@@ -26,6 +26,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.HttpResponse;
 
 import javax.annotation.Nullable;
@@ -79,6 +80,12 @@ public class BitbucketScmFormFillDelegate implements BitbucketScmFormFill {
 
         return new StandardListBoxModel()
                 .includeEmptyValue()
+                .includeMatchingAs(
+                        ACL.SYSTEM,
+                        context,
+                        StringCredentials.class,
+                        URIRequirementBuilder.fromUri(baseUrl).build(),
+                        CredentialsMatchers.always())
                 .includeMatchingAs(
                         ACL.SYSTEM,
                         context,

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
@@ -18,5 +18,6 @@ public interface BitbucketScmFormValidation {
     FormValidation doCheckServerId(@Nullable Item context, String serverId);
 
     FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId,
-                                    String projectName, String repositoryName, String mirrorName);
+                                    String sshCredentialsId, String projectName, String repositoryName,
+                                    String mirrorName);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidation.java
@@ -9,7 +9,7 @@ public interface BitbucketScmFormValidation {
 
     FormValidation doCheckCredentialsId(@Nullable Item context, String credentialsId);
 
-    FormValidation doCheckSshCredentialsId(@Nullable Item context, String sshCredentialsId);
+    FormValidation doCheckSshCredentialsId(@Nullable Item context, String credentialsId, String sshCredentialsId);
 
     FormValidation doCheckProjectName(@Nullable Item context, String serverId, String credentialsId, String projectName);
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -185,7 +185,8 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
-    public FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId, String projectName,
+    public FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId,
+                                           String sshCredentialsId, String projectName,
                                            String repositoryName, String mirrorName) {
         checkPermission(context);
         FormValidation serverIdValidation = doCheckServerId(context, serverId);
@@ -196,6 +197,11 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         FormValidation credentialsIdValidation = doCheckCredentialsId(context, credentialsId);
         if (credentialsIdValidation.kind == ERROR) {
             return credentialsIdValidation;
+        }
+
+        FormValidation sshCredentialsIdValidation = doCheckSshCredentialsId(context, credentialsId, sshCredentialsId);
+        if (sshCredentialsIdValidation.kind == ERROR) {
+            return sshCredentialsIdValidation;
         }
 
         FormValidation projectNameValidation = doCheckProjectName(context, serverId, credentialsId, projectName);

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -59,7 +59,7 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         checkPermission(context);
         if (isBlank(credentialsId)) {
             return FormValidation.warning(
-                    "Without credentials, Jenkins can’t check out source code from non-public repositories. ");
+                    "Without credentials, Jenkins can’t check out source code from non-public repositories.");
         }
         Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
@@ -173,12 +173,9 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         // operations when a token is used. Username/password credentials can be used directly by git, without SSH.
         if (!isBlank(credentialsId)) {
             Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
-            if (providedSshCredentials.isEmpty() &&
-                providedCredentials.isPresent() &&
-                isBearerTokenCredential(providedCredentials.get())
-            ) {
-                return FormValidation.warning(
-                        "SSH credentials are required when using a token and Bitbucket has Basic Auth access disabled.");
+            if (providedSshCredentials.isEmpty() && providedCredentials.isPresent() &&
+                isBearerTokenCredential(providedCredentials.get())) {
+                return FormValidation.warning("SSH credentials are required when using a token and Bitbucket has Basic Auth access disabled.");
             }
         }
         return FormValidation.ok();

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -6,6 +6,7 @@ import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClient
 import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentials;
 import com.atlassian.bitbucket.jenkins.internal.credentials.CredentialUtils;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
@@ -15,11 +16,11 @@ import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.Item;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import java.util.Optional;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getProjectByNameOrKey;
@@ -63,16 +64,6 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
             return FormValidation.error("No credentials exist for the provided credentialsId");
-        }
-        return FormValidation.ok();
-    }
-
-    @Override
-    public FormValidation doCheckSshCredentialsId(@Nullable Item context, String sshCredentialsId) {
-        checkPermission(context);
-        Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(sshCredentialsId, context);
-        if (!isBlank(sshCredentialsId) && !providedCredentials.isPresent()) {
-            return FormValidation.error("No credentials exist for the provided sshCredentialsId");
         }
         return FormValidation.ok();
     }
@@ -169,6 +160,31 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
     }
 
     @Override
+    public FormValidation doCheckSshCredentialsId(@Nullable Item context, String credentialsId,
+                                                  String sshCredentialsId) {
+        checkPermission(context);
+        Optional<Credentials> providedSshCredentials = CredentialUtils.getCredentials(sshCredentialsId, context);
+        if (!isBlank(sshCredentialsId) && providedSshCredentials.isEmpty()) {
+            return FormValidation.error("No credentials exist for the provided sshCredentialsId");
+        }
+
+        // If the HTTP credential is a bearer token (StringCredentials or BitbucketTokenCredentials), SSH credentials
+        // are mandatory because git has no built-in concept of bearer tokens and Bitbucket may restrict basic auth
+        // operations when a token is used. Username/password credentials can be used directly by git, without SSH.
+        if (!isBlank(credentialsId)) {
+            Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
+            if (providedSshCredentials.isEmpty() &&
+                providedCredentials.isPresent() &&
+                isBearerTokenCredential(providedCredentials.get())
+            ) {
+                return FormValidation.warning(
+                        "SSH credentials are required when using a token and Bitbucket has Basic Auth access disabled.");
+            }
+        }
+        return FormValidation.ok();
+    }
+
+    @Override
     public FormValidation doTestConnection(@Nullable Item context, String serverId, String credentialsId, String projectName,
                                            String repositoryName, String mirrorName) {
         checkPermission(context);
@@ -204,6 +220,10 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
                 .orElse("Bitbucket Server");
         return FormValidation.ok(format("Jenkins successfully connected to %s's %s / %s on %s", serverName, projectName,
                 repositoryName, isBlank(mirrorName) ? "Primary Server" : mirrorName));
+    }
+
+    private static boolean isBearerTokenCredential(@Nullable Credentials credentials) {
+        return credentials instanceof StringCredentials || credentials instanceof BitbucketTokenCredentials;
     }
 
     private void checkPermission(@Nullable Item context) {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegate.java
@@ -15,7 +15,6 @@ import com.cloudbees.plugins.credentials.Credentials;
 import hudson.model.Item;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -59,14 +58,11 @@ public class BitbucketScmFormValidationDelegate implements BitbucketScmFormValid
         checkPermission(context);
         if (isBlank(credentialsId)) {
             return FormValidation.warning(
-                    "Without credentials, Jenkins can’t check out source code from non-public repositories.");
+                    "Without credentials, Jenkins can’t check out source code from non-public repositories. ");
         }
         Optional<Credentials> providedCredentials = CredentialUtils.getCredentials(credentialsId, context);
         if (!providedCredentials.isPresent()) {
-            return FormValidation.error("No credentials exist for the provided credentialsId.");
-        }
-        if (providedCredentials.get() instanceof StringCredentials) {
-            return FormValidation.error("Secret text cannot be used for build credentials. Change to a different credentials type.");
+            return FormValidation.error("No credentials exist for the provided credentialsId");
         }
         return FormValidation.ok();
     }

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/config.groovy
@@ -56,7 +56,7 @@ f.section() {
                 title: _("bitbucket.scm.test.connection"),
                 progress: _("bitbucket.scm.test.connection"),
                 method: "testConnection",
-                with: "credentialsId,serverId,projectName,repositoryName,mirrorName"
+                with: "credentialsId,sshCredentialsId,serverId,projectName,repositoryName,mirrorName"
         )
     }
 

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/help-sshCredentialsId.html
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCM/help-sshCredentialsId.html
@@ -1,6 +1,7 @@
 <div>
     <p>If specified, Jenkins will use these credentials to check out the source code for builds. If no SSH credentials
         are specified, Jenkins will use the basic credentials instead.</p>
+    <p>SSH credentials are required in combination with token credentials when basic auth is disabled in Bitbucket.</p>
 
     <p>To provide Jenkins with SSH credentials, you can:</p>
     <ul>

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/config.groovy
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/config.groovy
@@ -47,7 +47,7 @@ f.section() {
                 title: _("bitbucket.scm.test.connection"),
                 progress: _("bitbucket.scm.test.connection"),
                 method: "testConnection",
-                with: "credentialsId,serverId,projectName,repositoryName,mirrorName"
+                with: "credentialsId,sshCredentialsId,serverId,projectName,repositoryName,mirrorName"
         )
     }
 

--- a/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/help-sshCredentialsId.html
+++ b/src/main/resources/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource/help-sshCredentialsId.html
@@ -1,6 +1,7 @@
 <div>
     <p>If specified, Jenkins will use these credentials to check out the source code for builds. If no SSH credentials
         are specified, Jenkins will use the basic credentials instead.</p>
+    <p>SSH credentials are required in combination with token credentials when basic auth is disabled in Bitbucket.</p>
 
     <p>To provide Jenkins with SSH credentials, you can:</p>
     <ul>

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.fixture;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketTokenCredentialsImpl;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -30,6 +31,8 @@ import static java.lang.String.format;
 public class BitbucketMockJenkinsRule extends JenkinsRule {
 
     private final String bitbucketUserToken;
+    private String secondSshCredentialsId;
+    private String sshCredentialsId;
     private String stringCredentialsId;
     private String tokenCredentialsId;
     private String usernamePasswordCredentialsId;
@@ -62,6 +65,10 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
         setupStringCredentials(stringCredentialsId, bitbucketUserToken);
         usernamePasswordCredentialsId = UUID.randomUUID().toString();
         setupUsernamePasswordCredentials(usernamePasswordCredentialsId);
+        sshCredentialsId = UUID.randomUUID().toString();
+        setupSshCredentials(sshCredentialsId);
+        secondSshCredentialsId = UUID.randomUUID().toString();
+        setupSshCredentials(secondSshCredentialsId);
         serverId = UUID.randomUUID().toString();
         BitbucketServerConfiguration server =
                 new BitbucketServerConfiguration(tokenCredentialsId, service.baseUrl(), serverId);
@@ -70,6 +77,14 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
         BitbucketPluginConfiguration configuration = new BitbucketPluginConfiguration();
         configuration.setServerList(servers);
         configuration.save();
+    }
+
+    public String getSecondSshCredentialsId() {
+        return secondSshCredentialsId;
+    }
+
+    public String getSshCredentialsId() {
+        return sshCredentialsId;
     }
 
     public String getTokenCredentialsId() {
@@ -134,6 +149,11 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
     private void setupStringCredentials(String credentialsId, String secret) throws Exception {
         setupCredentials(new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsId,
                 "Bitbucket Server token string credentials", SecretFactory.getSecret(secret)));
+    }
+
+    private void setupSshCredentials(String credentialsId) throws Exception {
+        setupCredentials(new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, credentialsId, "git",
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("private-key"), "", "SSH credentials"));
     }
 
     private void setupUsernamePasswordCredentials(String credentialsId) throws Exception {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/fixture/BitbucketMockJenkinsRule.java
@@ -14,6 +14,7 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.util.SecretFactory;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import static java.lang.String.format;
 public class BitbucketMockJenkinsRule extends JenkinsRule {
 
     private final String bitbucketUserToken;
+    private String stringCredentialsId;
     private String tokenCredentialsId;
     private String usernamePasswordCredentialsId;
     private String serverId;
@@ -56,6 +58,8 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
 
         tokenCredentialsId = UUID.randomUUID().toString();
         setupTokenCredentials(tokenCredentialsId, bitbucketUserToken);
+        stringCredentialsId = UUID.randomUUID().toString();
+        setupStringCredentials(stringCredentialsId, bitbucketUserToken);
         usernamePasswordCredentialsId = UUID.randomUUID().toString();
         setupUsernamePasswordCredentials(usernamePasswordCredentialsId);
         serverId = UUID.randomUUID().toString();
@@ -70,6 +74,10 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
 
     public String getTokenCredentialsId() {
         return tokenCredentialsId;
+    }
+
+    public String getStringCredentialsId() {
+        return stringCredentialsId;
     }
 
     public String getUsernamePasswordCredentialsId() {
@@ -121,6 +129,11 @@ public class BitbucketMockJenkinsRule extends JenkinsRule {
 
     private void setupTokenCredentials(String credentialsId, String secret) throws Exception {
         setupCredentials(new BitbucketTokenCredentialsImpl(credentialsId, "", SecretFactory.getSecret(secret)));
+    }
+
+    private void setupStringCredentials(String credentialsId, String secret) throws Exception {
+        setupCredentials(new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsId,
+                "Bitbucket Server token string credentials", SecretFactory.getSecret(secret)));
     }
 
     private void setupUsernamePasswordCredentials(String credentialsId) throws Exception {

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMDescriptorTest.java
@@ -57,6 +57,12 @@ public class BitbucketSCMDescriptorTest {
     }
 
     @Test
+    public void testDoCheckSshCredentialsId() {
+        descriptor.doCheckSshCredentialsId(parent, "myCredentialsId", "mySshCredentialsId");
+        verify(formValidation).doCheckSshCredentialsId(parent, "myCredentialsId", "mySshCredentialsId");
+    }
+
+    @Test
     public void testDoCheckServerId() {
         descriptor.doCheckServerId(parent, "myServerId");
         verify(formValidation).doCheckServerId(parent, "myServerId");

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMStepDescriptorTest.java
@@ -41,6 +41,12 @@ public class BitbucketSCMStepDescriptorTest {
     }
 
     @Test
+    public void testDoCheckSshCredentialsId() {
+        descriptor.doCheckSshCredentialsId(parent, "myCredentialsId", "mySshCredentialsId");
+        verify(formValidation).doCheckSshCredentialsId(parent, "myCredentialsId", "mySshCredentialsId");
+    }
+
+    @Test
     public void testDoCheckServerId() {
         descriptor.doCheckServerId(parent, "myServerId");
         verify(formValidation).doCheckServerId(parent, "myServerId");

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegateTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegateTest.java
@@ -31,6 +31,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -248,14 +249,18 @@ public class BitbucketScmFormValidationDelegateTest {
 
     @Test
     public void testSshCredentialsIdEmptyWithTokenCredentials() {
-        assertEquals(FormValidation.Kind.WARNING, delegate.doCheckSshCredentialsId(null,
-                bbJenkins.getTokenCredentialsId(), "").kind);
+        FormValidation result = delegate.doCheckSshCredentialsId(null, bbJenkins.getTokenCredentialsId(), "");
+        assertEquals(FormValidation.Kind.WARNING, result.kind);
+        assertEquals("SSH credentials are required when using a token and Bitbucket has Basic Auth access disabled.",
+                result.getMessage());
     }
 
     @Test
     public void testSshCredentialsIdEmptyWithStringCredentials() {
-        assertEquals(FormValidation.Kind.WARNING, delegate.doCheckSshCredentialsId(parent,
-                bbJenkins.getStringCredentialsId(), "").kind);
+        FormValidation result = delegate.doCheckSshCredentialsId(parent, bbJenkins.getStringCredentialsId(), "");
+        assertEquals(FormValidation.Kind.WARNING, result.kind);
+        assertEquals("SSH credentials are required when using a token and Bitbucket has Basic Auth access disabled.",
+                result.getMessage());
     }
 
     @Test
@@ -277,20 +282,26 @@ public class BitbucketScmFormValidationDelegateTest {
 
     @Test
     public void testSshCredentialsIdValidWithStringCredentials() {
-        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
-                bbJenkins.getStringCredentialsId(), bbJenkins.getSshCredentialsId()).kind);
+        FormValidation result = delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getStringCredentialsId(), bbJenkins.getSshCredentialsId());
+        assertEquals(FormValidation.Kind.OK, result.kind);
+        assertNull(result.getMessage());
     }
 
     @Test
     public void testSecondSshCredentialsIdValidWithStringCredentials() {
-        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
-                bbJenkins.getStringCredentialsId(), bbJenkins.getSecondSshCredentialsId()).kind);
+        FormValidation result = delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getStringCredentialsId(), bbJenkins.getSecondSshCredentialsId());
+        assertEquals(FormValidation.Kind.OK, result.kind);
+        assertNull(result.getMessage());
     }
 
     @Test
     public void testSshCredentialsIdInvalid() {
-        assertEquals(FormValidation.Kind.ERROR, delegate.doCheckSshCredentialsId(parent,
-                bbJenkins.getTokenCredentialsId(), "missing-ssh-credentials").kind);
+        FormValidation result = delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getTokenCredentialsId(), "missing-ssh-credentials");
+        assertEquals(FormValidation.Kind.ERROR, result.kind);
+        assertEquals("No credentials exist for the provided sshCredentialsId", result.getMessage());
     }
 
     @Test(expected = AccessDeniedException.class)
@@ -304,15 +315,20 @@ public class BitbucketScmFormValidationDelegateTest {
         BitbucketMirrorClient mirrorClient = mock(BitbucketMirrorClient.class);
         when(bitbucketClientFactory.getMirroredRepositoriesClient(0)).thenReturn(mirrorClient);
         when(mirrorClient.getMirroredRepositoryDescriptors()).thenReturn(new BitbucketPage<>());
-        assertEquals(FormValidation.Kind.OK, delegate.doTestConnection(parent, serverConfigurationValid.getId(),
+        FormValidation result = delegate.doTestConnection(parent, serverConfigurationValid.getId(),
                 bbJenkins.getUsernamePasswordCredentialsId(), bbJenkins.getSecondSshCredentialsId(), "PROJECT_1", "repo",
-                "").kind);
+                "");
+        assertEquals(FormValidation.Kind.OK, result.kind);
+        assertEquals("Jenkins successfully connected to ServerName_Valid&#039;s PROJECT_1 / repo on Primary Server",
+                result.getMessage());
     }
 
     @Test
     public void testTestConnectionInvalidSshCredentialsId() {
-        assertEquals(FormValidation.Kind.ERROR, delegate.doTestConnection(parent, serverConfigurationValid.getId(),
-                bbJenkins.getUsernamePasswordCredentialsId(), "missing-ssh-credentials", "PROJECT_1", "repo", "").kind);
+        FormValidation result = delegate.doTestConnection(parent, serverConfigurationValid.getId(),
+                bbJenkins.getUsernamePasswordCredentialsId(), "missing-ssh-credentials", "PROJECT_1", "repo", "");
+        assertEquals(FormValidation.Kind.ERROR, result.kind);
+        assertEquals("No credentials exist for the provided sshCredentialsId", result.getMessage());
     }
 
     @Test(expected = AccessDeniedException.class)

--- a/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegateTest.java
+++ b/src/test/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmFormValidationDelegateTest.java
@@ -247,18 +247,78 @@ public class BitbucketScmFormValidationDelegateTest {
     }
 
     @Test
+    public void testSshCredentialsIdEmptyWithTokenCredentials() {
+        assertEquals(FormValidation.Kind.WARNING, delegate.doCheckSshCredentialsId(null,
+                bbJenkins.getTokenCredentialsId(), "").kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdEmptyWithStringCredentials() {
+        assertEquals(FormValidation.Kind.WARNING, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getStringCredentialsId(), "").kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdEmptyWithUsernamePasswordCredentials() {
+        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getUsernamePasswordCredentialsId(), "").kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdEmptyWithNoCredentials() {
+        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent, "", "").kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdValidWithTokenCredentials() {
+        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getTokenCredentialsId(), bbJenkins.getSshCredentialsId()).kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdValidWithStringCredentials() {
+        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getStringCredentialsId(), bbJenkins.getSshCredentialsId()).kind);
+    }
+
+    @Test
+    public void testSecondSshCredentialsIdValidWithStringCredentials() {
+        assertEquals(FormValidation.Kind.OK, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getStringCredentialsId(), bbJenkins.getSecondSshCredentialsId()).kind);
+    }
+
+    @Test
+    public void testSshCredentialsIdInvalid() {
+        assertEquals(FormValidation.Kind.ERROR, delegate.doCheckSshCredentialsId(parent,
+                bbJenkins.getTokenCredentialsId(), "missing-ssh-credentials").kind);
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    public void testSshCredentialsIdNoPermissions() {
+        doThrow(AccessDeniedException.class).when(parent).checkPermission(Item.EXTENDED_READ);
+        delegate.doCheckSshCredentialsId(parent, bbJenkins.getTokenCredentialsId(), bbJenkins.getSshCredentialsId());
+    }
+
+    @Test
     public void testTestConnection() {
         BitbucketMirrorClient mirrorClient = mock(BitbucketMirrorClient.class);
         when(bitbucketClientFactory.getMirroredRepositoriesClient(0)).thenReturn(mirrorClient);
         when(mirrorClient.getMirroredRepositoryDescriptors()).thenReturn(new BitbucketPage<>());
         assertEquals(FormValidation.Kind.OK, delegate.doTestConnection(parent, serverConfigurationValid.getId(),
-                bbJenkins.getUsernamePasswordCredentialsId(), "PROJECT_1", "repo", "").kind);
+                bbJenkins.getUsernamePasswordCredentialsId(), bbJenkins.getSecondSshCredentialsId(), "PROJECT_1", "repo",
+                "").kind);
+    }
+
+    @Test
+    public void testTestConnectionInvalidSshCredentialsId() {
+        assertEquals(FormValidation.Kind.ERROR, delegate.doTestConnection(parent, serverConfigurationValid.getId(),
+                bbJenkins.getUsernamePasswordCredentialsId(), "missing-ssh-credentials", "PROJECT_1", "repo", "").kind);
     }
 
     @Test(expected = AccessDeniedException.class)
     public void testTestConnectionNoPermissions() {
         doThrow(AccessDeniedException.class).when(parent).checkPermission(Item.EXTENDED_READ);
-        delegate.doTestConnection(parent, serverConfigurationValid.getId(), "", "PROEJECT_1", "repo", "");
+        delegate.doTestConnection(parent, serverConfigurationValid.getId(), "", "", "PROEJECT_1", "repo", "");
     }
 
     private static Map<String, List<BitbucketNamedLink>> getSelfLink(String projectKey) {


### PR DESCRIPTION
This is to fix [JENKINS-76450](https://issues.jenkins.io/browse/JENKINS-76450)

Support for personal access tokens (PAT, as a Secret text credentials) was removed in [JENKINS-72280](https://issues.jenkins.io/browse/JENKINS-72280) because git harness doesn't allow PATs that come as a Bearer tokens easily. Which resulted in repository only accessible via REST APIs, but not via git.

Which is a problem when Basic Auth is disabled in Bitbucket DC instance - REST APIs is still accessible with Bearer token, but not the git. However, if SSH credentials are used for git access, this combination makes everything to work well.

This PR brings support for Secret text credentials back (which are passed as Bearer token to Bitbucket), and shows a warning that SSH credentials are also must be set in this case for git access.

<img width="691" height="134" alt="image" src="https://github.com/user-attachments/assets/f5f36f84-d79f-4787-9a28-71404bc56843" />

### Testing done

On top of added automated testing, was manual end-to-end for local Bitbucket and Jenkins:
1. Jenkins uses username + password combination when Basic Auth enabled - everything works.
2. Jenkins uses Secret text credentials when Basic Auth enabled - everything works, but breaks when Basic Auth disabled
3. Jenkins uses Secret text and SSH credentials when Basic Auth is disabled - everything works.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
